### PR TITLE
Make middleware report when auth fails.

### DIFF
--- a/src/Microsoft.AspNet.Security/Infrastructure/AuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Security/Infrastructure/AuthenticationHandler.cs
@@ -141,6 +141,10 @@ namespace Microsoft.AspNet.Security.Infrastructure
                 {
                     context.Authenticated(ticket.Identity, ticket.Properties.Dictionary, BaseOptions.Description.Dictionary);
                 }
+                else
+                {
+                    context.NotAuthenticated(BaseOptions.AuthenticationType, properties: null, description: BaseOptions.Description.Dictionary);
+                }
             }
 
             if (PriorHandler != null)


### PR DESCRIPTION
Without this, HttpContext.Authenticate will throw an InvalidOperationException because it thinks the given auth type was not present in the pipeline.
