### PR TITLE
Set a default user-agent for the OAuth backchannel.

### DIFF
--- a/samples/SocialSample/Startup.cs
+++ b/samples/SocialSample/Startup.cs
@@ -119,7 +119,6 @@ namespace CookieSample
                         HttpRequestMessage userRequest = new HttpRequestMessage(HttpMethod.Get, context.Options.UserInformationEndpoint);
                         userRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", context.AccessToken);
                         userRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                        userRequest.Headers.UserAgent.ParseAdd("Microsoft ASP.NET OAuth middleware for GitHub");
                         HttpResponseMessage userResponse = await context.Backchannel.SendAsync(userRequest, context.HttpContext.RequestAborted);
                         userResponse.EnsureSuccessStatusCode();
                         var text = await userResponse.Content.ReadAsStringAsync();

--- a/src/Microsoft.AspNet.Security.OAuth/OAuthAuthenticationMiddleware.cs
+++ b/src/Microsoft.AspNet.Security.OAuth/OAuthAuthenticationMiddleware.cs
@@ -62,6 +62,7 @@ namespace Microsoft.AspNet.Security.OAuth
             }
 
             Backchannel = new HttpClient(ResolveHttpMessageHandler(Options));
+            Backchannel.DefaultRequestHeaders.UserAgent.ParseAdd("Microsoft ASP.NET OAuth middleware");
             Backchannel.Timeout = Options.BackchannelTimeout;
             Backchannel.MaxResponseContentBufferSize = 1024 * 1024 * 10; // 10 MB
         }


### PR DESCRIPTION
#52

Some providers require a User-Agent. Even when not required, it's strongly recommended by the HTTP spec to include one for debugging purposes.
