### PR TITLE
Clean up data protection provider helper.

### DIFF
--- a/samples/CookieSessionSample/MemoryCacheSessionStore.cs
+++ b/samples/CookieSessionSample/MemoryCacheSessionStore.cs
@@ -13,7 +13,7 @@ namespace CookieSessionSample
 
         public MemoryCacheSessionStore()
         {
-            _cache = new MemoryCache();
+            _cache = new MemoryCache(new MemoryCacheOptions());
         }
 
         public async Task<string> StoreAsync(AuthenticationTicket ticket)

--- a/src/Microsoft.AspNet.Security.Cookies/CookieAuthenticationMiddleware.cs
+++ b/src/Microsoft.AspNet.Security.Cookies/CookieAuthenticationMiddleware.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNet.Security.Cookies
             }
             if (Options.TicketDataFormat == null)
             {
-                IDataProtector dataProtector = DataProtectionHelpers.CreateDataProtector(dataProtectionProvider,
+                IDataProtector dataProtector = dataProtectionProvider.CreateDataProtector(
                     typeof(CookieAuthenticationMiddleware).FullName, Options.AuthenticationType, "v1");
                 Options.TicketDataFormat = new TicketDataFormat(dataProtector);
             }

--- a/src/Microsoft.AspNet.Security.OAuth/OAuthAuthenticationMiddleware.cs
+++ b/src/Microsoft.AspNet.Security.OAuth/OAuthAuthenticationMiddleware.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNet.Security.OAuth
 
             if (Options.StateDataFormat == null)
             {
-                IDataProtector dataProtector = DataProtectionHelpers.CreateDataProtector(dataProtectionProvider,
+                IDataProtector dataProtector = dataProtectionProvider.CreateDataProtector(
                     this.GetType().FullName, Options.AuthenticationType, "v1");
                 Options.StateDataFormat = new PropertiesDataFormat(dataProtector);
             }

--- a/src/Microsoft.AspNet.Security.OAuth/OAuthBearerAuthenticationMiddleware.cs
+++ b/src/Microsoft.AspNet.Security.OAuth/OAuthBearerAuthenticationMiddleware.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AspNet.Security.OAuth
 
             if (Options.AccessTokenFormat == null)
             {
-                var dataProtector = DataProtectionHelpers.CreateDataProtector(dataProtectionProvider,
+                IDataProtector dataProtector = dataProtectionProvider.CreateDataProtector(
                     this.GetType().FullName, Options.AuthenticationType, "v1");
                 Options.AccessTokenFormat = new TicketDataFormat(dataProtector);
             }

--- a/src/Microsoft.AspNet.Security.Twitter/TwitterAuthenticationMiddleware.cs
+++ b/src/Microsoft.AspNet.Security.Twitter/TwitterAuthenticationMiddleware.cs
@@ -60,7 +60,7 @@ namespace Microsoft.AspNet.Security.Twitter
             }
             if (Options.StateDataFormat == null)
             {
-                IDataProtector dataProtector = DataProtectionHelpers.CreateDataProtector(dataProtectionProvider,
+                IDataProtector dataProtector = dataProtectionProvider.CreateDataProtector(
                     typeof(TwitterAuthenticationMiddleware).FullName, Options.AuthenticationType, "v1");
                 Options.StateDataFormat = new SecureDataFormat<RequestToken>(
                     Serializers.RequestToken,

--- a/src/Microsoft.AspNet.Security/DataProtection/DataProtectionHelpers.cs
+++ b/src/Microsoft.AspNet.Security/DataProtection/DataProtectionHelpers.cs
@@ -1,22 +1,12 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-
-using System;
-using Microsoft.AspNet.Http;
-
 namespace Microsoft.AspNet.Security.DataProtection
 {
     public static class DataProtectionHelpers
     {
-        public static IDataProtector CreateDataProtector(IDataProtectionProvider dataProtectionProvider, params string[] purposes)
+        public static IDataProtector CreateDataProtector([NotNull] this IDataProtectionProvider dataProtectionProvider, params string[] purposes)
         {
-            if (dataProtectionProvider == null)
-            {
-                // TODO: Get this from the environment.
-                dataProtectionProvider = new EphemeralDataProtectionProvider();
-            }
-
             return dataProtectionProvider.CreateProtector(string.Join(";", purposes));
         }
     }


### PR DESCRIPTION
#74. IDataProtectionProvider is always provided via DI, we don't need a fallback path.

Also changing the helper to be an extension method.
