### PR TITLE
Fix regression with OAuth Notifications.

### DIFF
--- a/samples/SocialSample/project.json
+++ b/samples/SocialSample/project.json
@@ -18,5 +18,6 @@
         },
         "aspnetcore50": {
         }
-    }
+    },
+    "webroot": "wwwroot"
 }

--- a/src/Microsoft.AspNet.Security.OAuth/OAuthAuthenticationExtensions.cs
+++ b/src/Microsoft.AspNet.Security.OAuth/OAuthAuthenticationExtensions.cs
@@ -31,6 +31,10 @@ namespace Microsoft.AspNet.Builder
                     {
                         configureOptions(options);
                     }
+                    if (options.Notifications == null)
+                    {
+                        options.Notifications = new OAuthAuthenticationNotifications();
+                    }
                 }) 
                 {
                     Name = authenticationType,


### PR DESCRIPTION
#84 - Some default initialization was removed when the options were refactored. This can cause null reffs in the handler.

@HaoK 
