### PR TITLE
Update the targeted Facebook API version to v2.1.

### DIFF
--- a/samples/CookieSample/CookieSample.kproj
+++ b/samples/CookieSample/CookieSample.kproj
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <DevelopmentServerPort>54539</DevelopmentServerPort>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">

--- a/samples/CookieSessionSample/CookieSessionSample.kproj
+++ b/samples/CookieSessionSample/CookieSessionSample.kproj
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <DevelopmentServerPort>54541</DevelopmentServerPort>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">

--- a/samples/SocialSample/SocialSample.kproj
+++ b/samples/SocialSample/SocialSample.kproj
@@ -1,8 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <DevelopmentServerPort>54540</DevelopmentServerPort>
+    <CommandLineArguments />
+    <DebugTarget />
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">

--- a/samples/SocialSample/Startup.cs
+++ b/samples/SocialSample/Startup.cs
@@ -37,6 +37,7 @@ namespace CookieSample
                     options.LoginPath = new PathString("/login");
                 });
 
+            // https://developers.facebook.com/apps/
             app.UseFacebookAuthentication(options =>
             {
                 options.AppId = "569522623154478";
@@ -55,23 +56,25 @@ namespace CookieSample
                 options.Scope.Add("email");
             });
 
+            // https://console.developers.google.com/project
             app.UseGoogleAuthentication(options =>
             {
                 options.ClientId = "560027070069-37ldt4kfuohhu3m495hk2j4pjp92d382.apps.googleusercontent.com";
                 options.ClientSecret = "n2Q-GEw9RQjzcRbU3qhfTj8f";
             });
 
+            // https://apps.twitter.com/
             app.UseTwitterAuthentication(options =>
             {
                 options.ConsumerKey = "6XaCTaLbMqfj6ww3zvZ5g";
                 options.ConsumerSecret = "Il2eFzGIrYhz6BWjYhVXBPQSfZuS4xoHpSSyD9PI";
             });
 
-            /*
-            The MicrosoftAccount service has restrictions that prevent the use of http://localhost:12345/ for test applications.
-            As such, here is how to change this sample to uses http://mssecsample.localhost.this:12345/ instead.
+            /* https://account.live.com/developers/applications
+            The MicrosoftAccount service has restrictions that prevent the use of http://localhost:54540/ for test applications.
+            As such, here is how to change this sample to uses http://mssecsample.localhost.this:54540/ instead.
 
-            Edit the Project.json file and replace http://localhost:12345/ with http://mssecsample.localhost.this:12345/.
+            Edit the Project.json file and replace http://localhost:54540/ with http://mssecsample.localhost.this:54540/.
 
             From an admin command console first enter:
              notepad C:\Windows\System32\drivers\etc\hosts
@@ -79,7 +82,7 @@ namespace CookieSample
              127.0.0.1 MsSecSample.localhost.this
 
             Then you can choose to run the app as admin (see below) or add the following ACL as admin:
-             netsh http add urlacl url=http://mssecsample.localhost.this:12345/ user=[domain\user]
+             netsh http add urlacl url=http://mssecsample.localhost.this:54540/ user=[domain\user]
 
             The sample app can then be run via:
              k web
@@ -102,6 +105,7 @@ namespace CookieSample
                 options.ClientSecret = "bLw2JIvf8Y1TaToipPEqxTVlOeJwCUsr";
             });
 
+            // https://github.com/settings/applications/
             app.UseOAuthAuthentication("GitHub-AccessToken", options =>
             {
                 options.ClientId = "8c0c5a572abe8fe89588";

--- a/samples/SocialSample/project.json
+++ b/samples/SocialSample/project.json
@@ -11,8 +11,9 @@
         "Kestrel": "1.0.0-*"
     },
     "commands": {
-        "web": "Microsoft.AspNet.Hosting server=Microsoft.AspNet.Server.WebListener server.urls=http://localhost:12345",
-        "kestrel": "Microsoft.AspNet.Hosting --server Kestrel --server.urls http://localhost:5004"
+        /* Note all servers must use the same address and port because these are pre-registered with the various providers. */
+        "web": "Microsoft.AspNet.Hosting server=Microsoft.AspNet.Server.WebListener server.urls=http://localhost:54540",
+        "kestrel": "Microsoft.AspNet.Hosting --server Kestrel --server.urls http://localhost:54540"
     },
     "frameworks": {
         "aspnet50": {

--- a/src/Microsoft.AspNet.Security.Facebook/FacebookAuthenticationDefaults.cs
+++ b/src/Microsoft.AspNet.Security.Facebook/FacebookAuthenticationDefaults.cs
@@ -7,10 +7,10 @@ namespace Microsoft.AspNet.Security.Facebook
     {
         public const string AuthenticationType = "Facebook";
 
-        public const string AuthorizationEndpoint = "https://www.facebook.com/dialog/oauth";
+        public const string AuthorizationEndpoint = "https://www.facebook.com/v2.2/dialog/oauth";
 
-        public const string TokenEndpoint = "https://graph.facebook.com/oauth/access_token";
+        public const string TokenEndpoint = "https://graph.facebook.com/v2.2/oauth/access_token";
 
-        public const string UserInformationEndpoint = "https://graph.facebook.com/me";
+        public const string UserInformationEndpoint = "https://graph.facebook.com/v2.2/me";
     }
 }

--- a/test/Microsoft.AspNet.Security.Test/Facebook/FacebookMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Security.Test/Facebook/FacebookMiddlewareTests.cs
@@ -97,7 +97,7 @@ namespace Microsoft.AspNet.Security.Facebook
             var transaction = await SendAsync(server, "http://example.com/challenge");
             transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
             var location = transaction.Response.Headers.Location.AbsoluteUri;
-            location.ShouldContain("https://www.facebook.com/dialog/oauth");
+            location.ShouldContain("https://www.facebook.com/v2.2/dialog/oauth");
             location.ShouldContain("response_type=code");
             location.ShouldContain("client_id=");
             location.ShouldContain("redirect_uri=");


### PR DESCRIPTION
#85 - Facebook is deprecating v1.0 of their API in April so we are moving to v2.1. I didn't see any behavioral changes in the APIs we use.
