### PR TITLE
Fix Security :: IServiceManifest

### DIFF
--- a/test/Microsoft.AspNet.Security.Test/Google/GoogleMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Security.Test/Google/GoogleMiddlewareTests.cs
@@ -14,15 +14,15 @@ using System.Xml.Linq;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Security;
-using Microsoft.AspNet.Security.Cookies;
+using Microsoft.AspNet.Security.DataHandler;
+using Microsoft.AspNet.Security.DataProtection;
+using Microsoft.AspNet.Security.Test;
 using Microsoft.AspNet.TestHost;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.Runtime;
 using Newtonsoft.Json;
 using Shouldly;
 using Xunit;
-using Microsoft.Framework.OptionsModel;
-using Microsoft.Framework.DependencyInjection;
-using Microsoft.AspNet.Security.DataProtection;
-using Microsoft.AspNet.Security.DataHandler;
 
 namespace Microsoft.AspNet.Security.Google
 {
@@ -463,15 +463,14 @@ namespace Microsoft.AspNet.Security.Google
 
         private static TestServer CreateServer(Action<GoogleAuthenticationOptions> configureOptions, Func<HttpContext, Task> testpath = null)
         {
-            return TestServer.Create(app =>
+            var services = new ServiceCollection().AddSingleton<IApplicationEnvironment, TestApplicationEnvironment>();
+            services.Configure<ExternalAuthenticationOptions>(options =>
             {
-                app.UseServices(services =>
-                {
-                    services.Configure<ExternalAuthenticationOptions>(options =>
-                    {
-                        options.SignInAsAuthenticationType = CookieAuthenticationType;
-                    });
-                });
+                options.SignInAsAuthenticationType = CookieAuthenticationType;
+            });
+
+            return TestServer.Create(services, app =>
+            {
                 app.UseCookieAuthentication(options => options.AuthenticationType = CookieAuthenticationType);
                 app.UseGoogleAuthentication(configureOptions);
                 app.Use(async (context, next) =>

--- a/test/Microsoft.AspNet.Security.Test/Microsoft.AspNet.Security.Tests.kproj
+++ b/test/Microsoft.AspNet.Security.Test/Microsoft.AspNet.Security.Tests.kproj
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <CommandLineArguments />
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">

--- a/test/Microsoft.AspNet.Security.Test/MicrosoftAccount/MicrosoftAccountMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Security.Test/MicrosoftAccount/MicrosoftAccountMiddlewareTests.cs
@@ -24,6 +24,8 @@ using Microsoft.Framework.OptionsModel;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.AspNet.Security.DataHandler;
 using Microsoft.AspNet.Security.DataProtection;
+using Microsoft.Framework.Runtime;
+using Microsoft.AspNet.Security.Test;
 
 namespace Microsoft.AspNet.Security.Tests.MicrosoftAccount
 {
@@ -161,15 +163,13 @@ namespace Microsoft.AspNet.Security.Tests.MicrosoftAccount
 
         private static TestServer CreateServer(Action<MicrosoftAccountAuthenticationOptions> configureOptions, Func<HttpContext, bool> handler)
         {
-            return TestServer.Create(app =>
+            var services = new ServiceCollection().AddSingleton<IApplicationEnvironment, TestApplicationEnvironment>();
+            services.Configure<ExternalAuthenticationOptions>(options =>
             {
-                app.UseServices(services =>
-                {
-                    services.Configure<ExternalAuthenticationOptions>(options =>
-                    {
-                        options.SignInAsAuthenticationType = "External";
-                    });
-                });
+                options.SignInAsAuthenticationType = "External";
+            });
+            return TestServer.Create(services, app =>
+            {
                 app.UseCookieAuthentication(options => options.AuthenticationType = "External");
                 app.UseMicrosoftAccountAuthentication(configureOptions);
                 app.Use(async (context, next) =>

--- a/test/Microsoft.AspNet.Security.Test/TestApplicationEnvironment.cs
+++ b/test/Microsoft.AspNet.Security.Test/TestApplicationEnvironment.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.Versioning;
+using Microsoft.Framework.Runtime;
+
+namespace Microsoft.AspNet.Security.Test
+{
+    public class TestApplicationEnvironment : IApplicationEnvironment
+    {
+        public string ApplicationName
+        {
+            get { return "Test App environment"; }
+        }
+
+        public string Version
+        {
+            get { return "1.0.0"; }
+        }
+
+        public string ApplicationBasePath
+        {
+            get { return Environment.CurrentDirectory; }
+        }
+
+        public string Configuration
+        {
+            get { return "Test"; }
+        }
+
+        public FrameworkName RuntimeFramework
+        {
+            get { return new FrameworkName(".NETFramework", new Version(4, 5)); }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Security.Test/Twitter/TwitterMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Security.Test/Twitter/TwitterMiddlewareTests.cs
@@ -17,6 +17,8 @@ using Shouldly;
 using Xunit;
 using Microsoft.Framework.OptionsModel;
 using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.Runtime;
+using Microsoft.AspNet.Security.Test;
 
 namespace Microsoft.AspNet.Security.Twitter
 {
@@ -107,15 +109,14 @@ namespace Microsoft.AspNet.Security.Twitter
 
         private static TestServer CreateServer(Action<IApplicationBuilder> configure, Func<HttpContext, bool> handler)
         {
-            return TestServer.Create(app =>
+            var services = new ServiceCollection().AddSingleton<IApplicationEnvironment, TestApplicationEnvironment>();
+            services.Configure<ExternalAuthenticationOptions>(options =>
             {
-                app.UseServices(services =>
-                {
-                    services.Configure<ExternalAuthenticationOptions>(options =>
-                    {
-                        options.SignInAsAuthenticationType = "External";
-                    });
-                });
+                options.SignInAsAuthenticationType = "External";
+            });
+
+            return TestServer.Create(services, app =>
+            {
                 app.UseCookieAuthentication(options =>
                 {
                     options.AuthenticationType = "External";


### PR DESCRIPTION
@davidfowl @lodejard @Tratcher 

These changes were needed to fix Security tests to work with new hosting test server changes...

Of note, UseServices appears busted currently, had to pull out the IServiceCollection which then required defining its own test IApplicationEnvironment (which is what hosting tests do already)
