### PR TITLE
Remove cookie compression.

### DIFF
--- a/src/Microsoft.AspNet.Security.Cookies/CookieAuthenticationMiddleware.cs
+++ b/src/Microsoft.AspNet.Security.Cookies/CookieAuthenticationMiddleware.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNet.Security.Cookies
             if (Options.TicketDataFormat == null)
             {
                 IDataProtector dataProtector = dataProtectionProvider.CreateDataProtector(
-                    typeof(CookieAuthenticationMiddleware).FullName, Options.AuthenticationType, "v1");
+                    typeof(CookieAuthenticationMiddleware).FullName, Options.AuthenticationType, "v2");
                 Options.TicketDataFormat = new TicketDataFormat(dataProtector);
             }
             if (Options.CookieManager == null)

--- a/src/Microsoft.AspNet.Security.OAuth/project.json
+++ b/src/Microsoft.AspNet.Security.OAuth/project.json
@@ -26,7 +26,6 @@
                 "System.Dynamic.Runtime": "4.0.0-beta-*",
                 "System.Globalization": "4.0.10-beta-*",
                 "System.IO": "4.0.10-beta-*",
-                "System.IO.Compression": "4.0.0-beta-*",
                 "System.Linq": "4.0.0-beta-*",
                 "System.Net.Http.WinHttpHandler": "4.0.0-beta-*",
                 "System.ObjectModel": "4.0.10-beta-*",

--- a/src/Microsoft.AspNet.Security/DataHandler/Serializer/TicketSerializer.cs
+++ b/src/Microsoft.AspNet.Security/DataHandler/Serializer/TicketSerializer.cs
@@ -1,11 +1,8 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Security.Claims;
 
@@ -13,46 +10,27 @@ namespace Microsoft.AspNet.Security.DataHandler.Serializer
 {
     public class TicketSerializer : IDataSerializer<AuthenticationTicket>
     {
-        private static readonly bool IsMono = Type.GetType("Mono.Runtime") != null;
         private const int FormatVersion = 2;
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times", Justification = "Dispose is idempotent")]
         public virtual byte[] Serialize(AuthenticationTicket model)
         {
             using (var memory = new MemoryStream())
             {
-                GZipStream compression;
-                if (IsMono)
+                using (var writer = new BinaryWriter(memory))
                 {
-                    // The other constructor is not currently supported on Mono.
-                    compression = new GZipStream(memory, CompressionMode.Compress);
-                }
-                else
-                {
-                    compression = new GZipStream(memory, CompressionLevel.Optimal);
-                }
-                using (compression)
-                {
-                    using (var writer = new BinaryWriter(compression))
-                    {
-                        Write(writer, model);
-                    }
+                    Write(writer, model);
                 }
                 return memory.ToArray();
             }
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times", Justification = "Dispose is idempotent")]
         public virtual AuthenticationTicket Deserialize(byte[] data)
         {
             using (var memory = new MemoryStream(data))
             {
-                using (var compression = new GZipStream(memory, CompressionMode.Decompress))
+                using (var reader = new BinaryReader(memory))
                 {
-                    using (var reader = new BinaryReader(compression))
-                    {
-                        return Read(reader);
-                    }
+                    return Read(reader);
                 }
             }
         }

--- a/src/Microsoft.AspNet.Security/project.json
+++ b/src/Microsoft.AspNet.Security/project.json
@@ -10,10 +10,6 @@
     },
     "frameworks": {
         "aspnet50": { },
-        "aspnetcore50": {
-            "dependencies": {
-                "System.IO.Compression": "4.0.0-beta-*"
-            }
-        }
+        "aspnetcore50": { }
     }
 }


### PR DESCRIPTION
#79

@GrabYourPitchforks @blowdart @lodejard 

Using the social auth sample, here are my before and after sizes:
Before - After:
Facebook: 469 - 618
Google: 511 - 874
Google Access Token: 426 - 511
Twitter: 426 - 554
Github: 447 - 554
Github Access Token: 383 - 426

Certainly lager, but not as bad as I was expecting. Of course WsFed & ODIC are still going to be in trouble.
