### PR TITLE
OpneIdConnectMiddleWare ConfirationManager initialization - issue #128

### DIFF
--- a/samples/CookieSample/CookieSample.kproj
+++ b/samples/CookieSample/CookieSample.kproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
@@ -12,6 +12,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
+    <DevelopmentServerPort>3032</DevelopmentServerPort>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/samples/CookieSessionSample/CookieSessionSample.kproj
+++ b/samples/CookieSessionSample/CookieSessionSample.kproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
@@ -12,6 +12,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
+    <DevelopmentServerPort>3035</DevelopmentServerPort>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/samples/SocialSample/SocialSample.kproj
+++ b/samples/SocialSample/SocialSample.kproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
@@ -12,6 +12,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
+    <DevelopmentServerPort>3033</DevelopmentServerPort>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/Microsoft.AspNet.Security.OpenIdConnect/OpenIdConnectAuthenticationMiddleware.cs
+++ b/src/Microsoft.AspNet.Security.OpenIdConnect/OpenIdConnectAuthenticationMiddleware.cs
@@ -105,16 +105,15 @@ namespace Microsoft.AspNet.Security.OpenIdConnect
                 {
                     Options.ConfigurationManager = new StaticConfigurationManager<OpenIdConnectConfiguration>(Options.Configuration);
                 }
-                else if (!(string.IsNullOrWhiteSpace(Options.MetadataAddress) && string.IsNullOrWhiteSpace(Options.Authority)))
+                else if (!(string.IsNullOrWhiteSpace(Options.MetadataAddress) || !(string.IsNullOrWhiteSpace(Options.Authority))))
                 {
-                    if (string.IsNullOrWhiteSpace(Options.MetadataAddress) && !string.IsNullOrWhiteSpace(Options.Authority))
+                    if (string.IsNullOrWhiteSpace(Options.MetadataAddress))
                     {
                         Options.MetadataAddress = Options.Authority;
                         if (!Options.MetadataAddress.EndsWith("/", StringComparison.Ordinal))
                         {
                             Options.MetadataAddress += "/";
                         }
-
                         Options.MetadataAddress += ".well-known/openid-configuration";
                     }
 


### PR DESCRIPTION
Fixing the Options.ConfigurationManager initialization inside the OpeIdConnectAuthenticationMiddleWare constructor. The condition:

```C#
if (string.IsNullOrWhiteSpace(Options.MetadataAddress) && !string.IsNullOrWhiteSpace(Options.Authority))
```
inside the middle ware constructor will never been satisfied so it must be fixed. 