### PR TITLE
Removing the AzureAD feed from security repo

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,6 +3,5 @@
   <packageSources>
     <add key="AspNetVNext" value="https://www.myget.org/F/aspnetrelease/api/v2" />
     <add key="NuGet.org" value="https://nuget.org/api/v2/" />
-    <add key="AzureADNighty" value="http://www.myget.org/F/azureadwebstacknightly"/>
   </packageSources>
 </configuration>


### PR DESCRIPTION
Wilson packages are now part of aspnet myget feeds. Removing azure feed from restore sources.