### PR TITLE
Adding necessary dependencies to OpenIdConnect directly

### DIFF
--- a/src/Microsoft.AspNet.Security.OpenIdConnect/project.json
+++ b/src/Microsoft.AspNet.Security.OpenIdConnect/project.json
@@ -2,16 +2,18 @@
     "version": "1.0.0-*",
     "dependencies": {
         "Microsoft.AspNet.Security": "1.0.0-*",
-        "Microsoft.IdentityModel.Protocol.Extensions": "2.0.0.0-beta1-*"
+        "Microsoft.IdentityModel.Protocol.Extensions": "2.0.0-beta1-*"
     },
     "frameworks": {
         "aspnet50": {
             "frameworkAssemblies": {
+                "System.Net.Http": "",
                 "System.Net.Http.WebRequest": ""
             }
         },
         "aspnetcore50": {
             "dependencies": {
+                "System.Collections.Specialized": "4.0.0-beta-*",
                 "System.Net.Http.WinHttpHandler": "4.0.0-beta-*"
             }
         }


### PR DESCRIPTION
OpenIdconnect project is betting on the dependencies included by Microsoft.IdentityModel.Protocol.Extensions for the types that are referenced directly in this library but not used in Protocol.Extensions library.

This change is to enable Wilson clean up its unused dependencies.

@brentschmaltz @Tratcher @muratg 