### PR TITLE
Reading AuthenticationProperties from SignOutContext

### DIFF
--- a/src/Microsoft.AspNet.Authentication.OpenIdConnect/OpenidConnectAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.OpenIdConnect/OpenidConnectAuthenticationHandler.cs
@@ -77,7 +77,7 @@ namespace Microsoft.AspNet.Authentication.OpenIdConnect
                 // 1. properties.Redirect
                 // 2. Options.Wreply
                 var properties = new AuthenticationProperties(signout.Properties);
-                if (properties != null && !string.IsNullOrEmpty(properties.RedirectUri))
+                if (!string.IsNullOrEmpty(properties.RedirectUri))
                 {
                     openIdConnectMessage.PostLogoutRedirectUri = properties.RedirectUri;
                 }

--- a/src/Microsoft.AspNet.Authentication.OpenIdConnect/OpenidConnectAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.OpenIdConnect/OpenidConnectAuthenticationHandler.cs
@@ -8,10 +8,9 @@ using System.IO;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Authentication.Notifications;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Authentication;
-using Microsoft.AspNet.Authentication;
-using Microsoft.AspNet.Authentication.Notifications;
 using Microsoft.Framework.Logging;
 using Microsoft.IdentityModel.Protocols;
 
@@ -77,7 +76,7 @@ namespace Microsoft.AspNet.Authentication.OpenIdConnect
                 // Set End_Session_Endpoint in order:
                 // 1. properties.Redirect
                 // 2. Options.Wreply
-                AuthenticationProperties properties = new AuthenticationProperties();
+                var properties = new AuthenticationProperties(signout.Properties);
                 if (properties != null && !string.IsNullOrEmpty(properties.RedirectUri))
                 {
                     openIdConnectMessage.PostLogoutRedirectUri = properties.RedirectUri;
@@ -220,7 +219,7 @@ namespace Microsoft.AspNet.Authentication.OpenIdConnect
             }
 
             OpenIdConnectMessage openIdConnectMessage = null;
-            
+
             // assumption: if the ContentType is "application/x-www-form-urlencoded" it should be safe to read as it is small.
             if (string.Equals(Request.Method, "POST", StringComparison.OrdinalIgnoreCase)
               && !string.IsNullOrWhiteSpace(Request.ContentType)

--- a/test/Microsoft.AspNet.Authentication.Test/OpenIdConnect/OpenIdConnectMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/OpenIdConnect/OpenIdConnectMiddlewareTests.cs
@@ -125,7 +125,6 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
         [Fact]
         public async Task SignOutWithDefaultRedirectUri()
         {
-            ISecureDataFormat<AuthenticationProperties> stateFormat = new PropertiesDataFormat(new EphemeralDataProtectionProvider().CreateProtector("GoogleTest"));
             var server = CreateServer(options =>
             {
                 options.Authority = "https://login.windows.net/common";
@@ -140,7 +139,6 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
         [Fact]
         public async Task SignOutWithCustomRedirectUri()
         {
-            ISecureDataFormat<AuthenticationProperties> stateFormat = new PropertiesDataFormat(new EphemeralDataProtectionProvider().CreateProtector("GoogleTest"));
             var server = CreateServer(options =>
             {
                 options.Authority = "https://login.windows.net/common";
@@ -154,9 +152,8 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
         }
 
         [Fact]
-        public async Task SignOutWith_Specifi_RedirectUri_From_Authentication_Properites()
+        public async Task SignOutWith_Specific_RedirectUri_From_Authentication_Properites()
         {
-            var stateFormat = new PropertiesDataFormat(new EphemeralDataProtectionProvider().CreateProtector("OpenIdConnectTest"));
             var server = CreateServer(options =>
             {
                 options.Authority = "https://login.windows.net/common";

--- a/test/Microsoft.AspNet.Authentication.Test/OpenIdConnect/OpenIdConnectMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/OpenIdConnect/OpenIdConnectMiddlewareTests.cs
@@ -154,6 +154,22 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
         }
 
         [Fact]
+        public async Task SignOutWith_Specifi_RedirectUri_From_Authentication_Properites()
+        {
+            var stateFormat = new PropertiesDataFormat(new EphemeralDataProtectionProvider().CreateProtector("OpenIdConnectTest"));
+            var server = CreateServer(options =>
+            {
+                options.Authority = "https://login.windows.net/common";
+                options.ClientId = "Test Id";
+                options.PostLogoutRedirectUri = "https://example.com/logout";
+            });
+
+            var transaction = await SendAsync(server, "https://example.com/signout_with_specific_redirect_uri");
+            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            transaction.Response.Headers.Location.AbsoluteUri.ShouldContain(Uri.EscapeDataString("http://www.example.com/specific_redirect_uri"));
+        }
+
+        [Fact]
         // Test Cases for calculating the expiration time of cookie from cookie name
         public void NonceCookieExpirationTime()
         {
@@ -211,6 +227,12 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
                     else if (req.Path == new PathString("/signout"))
                     {
                         res.SignOut(OpenIdConnectAuthenticationDefaults.AuthenticationScheme);
+                    }
+                    else if (req.Path == new PathString("/signout_with_specific_redirect_uri"))
+                    {
+                        res.SignOut(
+                            OpenIdConnectAuthenticationDefaults.AuthenticationScheme, 
+                            new AuthenticationProperties() { RedirectUri = "http://www.example.com/specific_redirect_uri" });
                     }
                     else if (handler != null)
                     {


### PR DESCRIPTION
This will enable users to set a specific redirect uri and call signout.

This will depend on https://github.com/aspnet/HttpAbstractions/pull/218

@brentschmaltz @Tratcher @HaoK 