### PR TITLE
Push ClaimsIssuer to base options and respect it, also refactor tests

### DIFF
--- a/src/Microsoft.AspNet.Authentication.Cookies/CookieAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.Cookies/CookieAuthenticationHandler.cs
@@ -193,8 +193,8 @@ namespace Microsoft.AspNet.Authentication.Cookies
                         _sessionKey = await Options.SessionStore.StoreAsync(model);
                         var principal = new ClaimsPrincipal(
                             new ClaimsIdentity(
-                                new[] { new Claim(SessionIdClaim, _sessionKey) },
-                                Options.AuthenticationScheme));
+                                new[] { new Claim(SessionIdClaim, _sessionKey, ClaimValueTypes.String, Options.ClaimsIssuer) },
+                                Options.ClaimsIssuer));
                         model = new AuthenticationTicket(principal, null, Options.AuthenticationScheme);
                     }
                     var cookieValue = Options.TicketDataFormat.Protect(model);
@@ -243,7 +243,7 @@ namespace Microsoft.AspNet.Authentication.Cookies
                         await Options.SessionStore.RenewAsync(_sessionKey, model);
                         var principal = new ClaimsPrincipal(
                             new ClaimsIdentity(
-                                new[] { new Claim(SessionIdClaim, _sessionKey) },
+                                new[] { new Claim(SessionIdClaim, _sessionKey, ClaimValueTypes.String, Options.ClaimsIssuer) },
                                 Options.AuthenticationScheme));
                         model = new AuthenticationTicket(principal, null, Options.AuthenticationScheme);
                     }

--- a/src/Microsoft.AspNet.Authentication.Facebook/FacebookAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.Facebook/FacebookAuthenticationHandler.cs
@@ -13,7 +13,6 @@ using Microsoft.AspNet.Http.Authentication;
 using Microsoft.AspNet.Http.Collections;
 using Microsoft.AspNet.Http.Extensions;
 using Microsoft.AspNet.WebUtilities;
-using Microsoft.Framework.WebEncoders;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNet.Authentication.Facebook
@@ -65,34 +64,34 @@ namespace Microsoft.AspNet.Authentication.Facebook
 
             var context = new FacebookAuthenticatedContext(Context, Options, user, tokens);
             var identity = new ClaimsIdentity(
-                Options.AuthenticationScheme,
+                Options.ClaimsIssuer,
                 ClaimsIdentity.DefaultNameClaimType,
                 ClaimsIdentity.DefaultRoleClaimType);
             if (!string.IsNullOrEmpty(context.Id))
             {
-                identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, context.Id, ClaimValueTypes.String, Options.AuthenticationScheme));
+                identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, context.Id, ClaimValueTypes.String, Options.ClaimsIssuer));
             }
             if (!string.IsNullOrEmpty(context.UserName))
             {
-                identity.AddClaim(new Claim(ClaimsIdentity.DefaultNameClaimType, context.UserName, ClaimValueTypes.String, Options.AuthenticationScheme));
+                identity.AddClaim(new Claim(ClaimsIdentity.DefaultNameClaimType, context.UserName, ClaimValueTypes.String, Options.ClaimsIssuer));
             }
             if (!string.IsNullOrEmpty(context.Email))
             {
-                identity.AddClaim(new Claim(ClaimTypes.Email, context.Email, ClaimValueTypes.String, Options.AuthenticationScheme));
+                identity.AddClaim(new Claim(ClaimTypes.Email, context.Email, ClaimValueTypes.String, Options.ClaimsIssuer));
             }
             if (!string.IsNullOrEmpty(context.Name))
             {
-                identity.AddClaim(new Claim("urn:facebook:name", context.Name, ClaimValueTypes.String, Options.AuthenticationScheme));
+                identity.AddClaim(new Claim("urn:facebook:name", context.Name, ClaimValueTypes.String, Options.ClaimsIssuer));
 
                 // Many Facebook accounts do not set the UserName field.  Fall back to the Name field instead.
                 if (string.IsNullOrEmpty(context.UserName))
                 {
-                    identity.AddClaim(new Claim(ClaimsIdentity.DefaultNameClaimType, context.Name, ClaimValueTypes.String, Options.AuthenticationScheme));
+                    identity.AddClaim(new Claim(ClaimsIdentity.DefaultNameClaimType, context.Name, ClaimValueTypes.String, Options.ClaimsIssuer));
                 }
             }
             if (!string.IsNullOrEmpty(context.Link))
             {
-                identity.AddClaim(new Claim("urn:facebook:link", context.Link, ClaimValueTypes.String, Options.AuthenticationScheme));
+                identity.AddClaim(new Claim("urn:facebook:link", context.Link, ClaimValueTypes.String, Options.ClaimsIssuer));
             }
             context.Properties = properties;
             context.Principal = new ClaimsPrincipal(identity);
@@ -104,7 +103,7 @@ namespace Microsoft.AspNet.Authentication.Facebook
 
         private string GenerateAppSecretProof(string accessToken)
         {
-            using (HMACSHA256 algorithm = new HMACSHA256(Encoding.ASCII.GetBytes(Options.AppSecret)))
+            using (var algorithm = new HMACSHA256(Encoding.ASCII.GetBytes(Options.AppSecret)))
             {
                 var hash = algorithm.ComputeHash(Encoding.ASCII.GetBytes(accessToken));
                 var builder = new StringBuilder();

--- a/src/Microsoft.AspNet.Authentication.Google/GoogleAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.Google/GoogleAuthenticationHandler.cs
@@ -33,39 +33,39 @@ namespace Microsoft.AspNet.Authentication.Google
 
             var context = new GoogleAuthenticatedContext(Context, Options, user, tokens);
             var identity = new ClaimsIdentity(
-                Options.AuthenticationScheme,
+                Options.ClaimsIssuer,
                 ClaimsIdentity.DefaultNameClaimType,
                 ClaimsIdentity.DefaultRoleClaimType);
 
             if (!string.IsNullOrEmpty(context.Id))
             {
                 identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, context.Id,
-                    ClaimValueTypes.String, Options.AuthenticationScheme));
+                    ClaimValueTypes.String, Options.ClaimsIssuer));
             }
             if (!string.IsNullOrEmpty(context.GivenName))
             {
                 identity.AddClaim(new Claim(ClaimTypes.GivenName, context.GivenName,
-                    ClaimValueTypes.String, Options.AuthenticationScheme));
+                    ClaimValueTypes.String, Options.ClaimsIssuer));
             }
             if (!string.IsNullOrEmpty(context.FamilyName))
             {
                 identity.AddClaim(new Claim(ClaimTypes.Surname, context.FamilyName,
-                    ClaimValueTypes.String, Options.AuthenticationScheme));
+                    ClaimValueTypes.String, Options.ClaimsIssuer));
             }
             if (!string.IsNullOrEmpty(context.Name))
             {
                 identity.AddClaim(new Claim(ClaimTypes.Name, context.Name, ClaimValueTypes.String,
-                    Options.AuthenticationScheme));
+                    Options.ClaimsIssuer));
             }
             if (!string.IsNullOrEmpty(context.Email))
             {
                 identity.AddClaim(new Claim(ClaimTypes.Email, context.Email, ClaimValueTypes.String,
-                    Options.AuthenticationScheme));
+                    Options.ClaimsIssuer));
             }
             if (!string.IsNullOrEmpty(context.Profile))
             {
                 identity.AddClaim(new Claim("urn:google:profile", context.Profile, ClaimValueTypes.String,
-                    Options.AuthenticationScheme));
+                    Options.ClaimsIssuer));
             }
             context.Properties = properties;
             context.Principal = new ClaimsPrincipal(identity);

--- a/src/Microsoft.AspNet.Authentication.MicrosoftAccount/MicrosoftAccountAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.MicrosoftAccount/MicrosoftAccountAuthenticationHandler.cs
@@ -32,18 +32,18 @@ namespace Microsoft.AspNet.Authentication.MicrosoftAccount
             var identity = new ClaimsIdentity(
                 new[]
                     {
-                        new Claim(ClaimTypes.NameIdentifier, context.Id, ClaimValueTypes.String, Options.AuthenticationScheme),
-                        new Claim(ClaimTypes.Name, context.Name, ClaimValueTypes.String, Options.AuthenticationScheme),
-                        new Claim("urn:microsoftaccount:id", context.Id, ClaimValueTypes.String, Options.AuthenticationScheme),
-                        new Claim("urn:microsoftaccount:name", context.Name, ClaimValueTypes.String, Options.AuthenticationScheme)
+                        new Claim(ClaimTypes.NameIdentifier, context.Id, ClaimValueTypes.String, Options.ClaimsIssuer),
+                        new Claim(ClaimTypes.Name, context.Name, ClaimValueTypes.String, Options.ClaimsIssuer),
+                        new Claim("urn:microsoftaccount:id", context.Id, ClaimValueTypes.String, Options.ClaimsIssuer),
+                        new Claim("urn:microsoftaccount:name", context.Name, ClaimValueTypes.String, Options.ClaimsIssuer)
                     },
-                Options.AuthenticationScheme,
+                Options.ClaimsIssuer,
                 ClaimsIdentity.DefaultNameClaimType,
                 ClaimsIdentity.DefaultRoleClaimType);
 
             if (!string.IsNullOrWhiteSpace(context.Email))
             {
-                identity.AddClaim(new Claim(ClaimTypes.Email, context.Email, ClaimValueTypes.String, Options.AuthenticationScheme));
+                identity.AddClaim(new Claim(ClaimTypes.Email, context.Email, ClaimValueTypes.String, Options.ClaimsIssuer));
             }
             context.Principal = new ClaimsPrincipal(identity);
 

--- a/src/Microsoft.AspNet.Authentication.OAuth/OAuthAuthenticationMiddleware.cs
+++ b/src/Microsoft.AspNet.Authentication.OAuth/OAuthAuthenticationMiddleware.cs
@@ -69,7 +69,7 @@ namespace Microsoft.AspNet.Authentication.OAuth
             if (Options.StateDataFormat == null)
             {
                 var dataProtector = dataProtectionProvider.CreateProtector(
-                    this.GetType().FullName, Options.AuthenticationScheme, "v1");
+                    GetType().FullName, Options.AuthenticationScheme, "v1");
                 Options.StateDataFormat = new PropertiesDataFormat(dataProtector);
             }
 

--- a/src/Microsoft.AspNet.Authentication.OAuth/OAuthAuthenticationOptions.cs
+++ b/src/Microsoft.AspNet.Authentication.OAuth/OAuthAuthenticationOptions.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Authentication;
 
@@ -105,11 +104,6 @@ namespace Microsoft.AspNet.Authentication.OAuth
         /// When omitted, <see cref="ExternalAuthenticationOptions.SignInScheme"/> is used as a fallback value.
         /// </summary>
         public string SignInScheme { get; set; }
-
-        /// <summary>
-        /// Gets or sets the issuer that should be used for any claims that are created
-        /// </summary>
-        public string ClaimsIssuer { get; set; }
 
         /// <summary>
         /// Gets or sets the type used to secure data handled by the middleware.

--- a/src/Microsoft.AspNet.Authentication.Twitter/TwitterAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.Twitter/TwitterAuthenticationHandler.cs
@@ -93,12 +93,12 @@ namespace Microsoft.AspNet.Authentication.Twitter
                     new ClaimsIdentity(
                         new[]
                         {
-                            new Claim(ClaimTypes.NameIdentifier, accessToken.UserId, "http://www.w3.org/2001/XMLSchema#string", Options.AuthenticationScheme),
-                            new Claim(ClaimTypes.Name, accessToken.ScreenName, "http://www.w3.org/2001/XMLSchema#string", Options.AuthenticationScheme),
-                            new Claim("urn:twitter:userid", accessToken.UserId, "http://www.w3.org/2001/XMLSchema#string", Options.AuthenticationScheme),
-                            new Claim("urn:twitter:screenname", accessToken.ScreenName, "http://www.w3.org/2001/XMLSchema#string", Options.AuthenticationScheme)
+                            new Claim(ClaimTypes.NameIdentifier, accessToken.UserId, "http://www.w3.org/2001/XMLSchema#string", Options.ClaimsIssuer),
+                            new Claim(ClaimTypes.Name, accessToken.ScreenName, "http://www.w3.org/2001/XMLSchema#string", Options.ClaimsIssuer),
+                            new Claim("urn:twitter:userid", accessToken.UserId, "http://www.w3.org/2001/XMLSchema#string", Options.ClaimsIssuer),
+                            new Claim("urn:twitter:screenname", accessToken.ScreenName, "http://www.w3.org/2001/XMLSchema#string", Options.ClaimsIssuer)
                         },
-                        Options.AuthenticationScheme,
+                        Options.ClaimsIssuer,
                         ClaimsIdentity.DefaultNameClaimType,
                         ClaimsIdentity.DefaultRoleClaimType));
                 context.Properties = requestToken.Properties;

--- a/src/Microsoft.AspNet.Authentication/AuthenticationMiddleware.cs
+++ b/src/Microsoft.AspNet.Authentication/AuthenticationMiddleware.cs
@@ -35,6 +35,12 @@ namespace Microsoft.AspNet.Authentication
             Logger = loggerFactory.CreateLogger(this.GetType().FullName);
             UrlEncoder = encoder;
 
+            if (string.IsNullOrEmpty(Options.ClaimsIssuer))
+            {
+                // Default to something reasonable
+                Options.ClaimsIssuer = Options.AuthenticationScheme;
+            }
+
             _next = next;
         }
 

--- a/src/Microsoft.AspNet.Authentication/AuthenticationOptions.cs
+++ b/src/Microsoft.AspNet.Authentication/AuthenticationOptions.cs
@@ -34,6 +34,11 @@ namespace Microsoft.AspNet.Authentication
         public bool AutomaticAuthentication { get; set; }
 
         /// <summary>
+        /// Gets or sets the issuer that should be used for any claims that are created
+        /// </summary>
+        public string ClaimsIssuer { get; set; }
+
+        /// <summary>
         /// Additional information about the authentication type which is made available to the application.
         /// </summary>
         public AuthenticationDescription Description { get; set; } = new AuthenticationDescription();

--- a/src/Microsoft.AspNet.Authentication/DataHandler/Encoder/Base64UrlTextEncoder.cs
+++ b/src/Microsoft.AspNet.Authentication/DataHandler/Encoder/Base64UrlTextEncoder.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-
 using System;
 using Microsoft.Framework.Internal;
 

--- a/test/Microsoft.AspNet.Authentication.Test/AuthMiddlewareTestHelpers.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/AuthMiddlewareTestHelpers.cs
@@ -1,0 +1,129 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+using Microsoft.AspNet.Http;
+using Microsoft.AspNet.TestHost;
+
+namespace Microsoft.AspNet.Authentication
+{
+    public class Transaction
+    {
+        public HttpRequestMessage Request { get; set; }
+        public HttpResponseMessage Response { get; set; }
+
+        public IList<string> SetCookie { get; set; }
+
+        public string ResponseText { get; set; }
+        public XElement ResponseElement { get; set; }
+
+        public string AuthenticationCookieValue
+        {
+            get
+            {
+                if (SetCookie != null && SetCookie.Count > 0)
+                {
+                    var authCookie = SetCookie.SingleOrDefault(c => c.Contains(".AspNet.Cookie="));
+                    if (authCookie != null)
+                    {
+                        return authCookie.Substring(0, authCookie.IndexOf(';'));
+                    }
+                }
+
+                return null;
+            }
+        }
+
+        public string FindClaimValue(string claimType, string issuer = null)
+        {
+            var claim = ResponseElement.Elements("claim")
+                .SingleOrDefault(elt => elt.Attribute("type").Value == claimType &&
+                    (issuer == null || elt.Attribute("issuer").Value == issuer));
+            if (claim == null)
+            {
+                return null;
+            }
+            return claim.Attribute("value").Value;
+        }
+    }
+
+    public class TestHttpMessageHandler : HttpMessageHandler
+    {
+        public Func<HttpRequestMessage, HttpResponseMessage> Sender { get; set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
+        {
+            if (Sender != null)
+            {
+                return Task.FromResult(Sender(request));
+            }
+
+            return Task.FromResult<HttpResponseMessage>(null);
+        }
+    }
+
+
+    public static class AuthTestExtensions
+    {
+        public static async Task<Transaction> SendAsync(this TestServer server, string uri, string cookieHeader = null)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, uri);
+            if (!string.IsNullOrEmpty(cookieHeader))
+            {
+                request.Headers.Add("Cookie", cookieHeader);
+            }
+            var transaction = new Transaction
+            {
+                Request = request,
+                Response = await server.CreateClient().SendAsync(request),
+            };
+            if (transaction.Response.Headers.Contains("Set-Cookie"))
+            {
+                transaction.SetCookie = transaction.Response.Headers.GetValues("Set-Cookie").ToList();
+            }
+            transaction.ResponseText = await transaction.Response.Content.ReadAsStringAsync();
+
+            if (transaction.Response.Content != null &&
+                transaction.Response.Content.Headers.ContentType != null &&
+                transaction.Response.Content.Headers.ContentType.MediaType == "text/xml")
+            {
+                transaction.ResponseElement = XElement.Parse(transaction.ResponseText);
+            }
+            return transaction;
+        }
+
+        public static void Describe(this HttpResponse res, ClaimsPrincipal principal)
+        {
+            res.StatusCode = 200;
+            res.ContentType = "text/xml";
+            var xml = new XElement("xml");
+            if (principal != null)
+            {
+                foreach (var identity in principal.Identities)
+                {
+                    xml.Add(identity.Claims.Select(claim => 
+                        new XElement("claim", new XAttribute("type", claim.Type), 
+                        new XAttribute("value", claim.Value), 
+                        new XAttribute("issuer", claim.Issuer))));
+                }
+            }
+            using (var memory = new MemoryStream())
+            {
+                using (var writer = new XmlTextWriter(memory, Encoding.UTF8))
+                {
+                    xml.WriteTo(writer);
+                }
+                res.Body.Write(memory.ToArray(), 0, memory.ToArray().Length);
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Authentication.Test/Facebook/FacebookMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Facebook/FacebookMiddlewareTests.cs
@@ -71,8 +71,7 @@ namespace Microsoft.AspNet.Authentication.Facebook
                 },
                 services =>
                 {
-                    services.AddWebEncoders();
-                    services.AddDataProtection();
+                    services.AddAuthentication();
                     services.ConfigureFacebookAuthentication(options =>
                     {
                         options.AppId = "Test App Id";

--- a/test/Microsoft.AspNet.Authentication.Test/Facebook/FacebookMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Facebook/FacebookMiddlewareTests.cs
@@ -2,10 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Http;
@@ -29,8 +26,7 @@ namespace Microsoft.AspNet.Authentication.Facebook
                 },
                 services =>
                 {
-                    services.AddWebEncoders();
-                    services.AddDataProtection();
+                    services.AddAuthentication();
                     services.ConfigureFacebookAuthentication(options =>
                     {
                         options.AppId = "Test App Id";
@@ -58,7 +54,7 @@ namespace Microsoft.AspNet.Authentication.Facebook
                     context.Authentication.Challenge("Facebook");
                     return true;
                 });
-            var transaction = await SendAsync(server, "http://example.com/challenge");
+            var transaction = await server.SendAsync("http://example.com/challenge");
             transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
             var query = transaction.Response.Headers.Location.Query;
             query.ShouldContain("custom=test");
@@ -96,7 +92,7 @@ namespace Microsoft.AspNet.Authentication.Facebook
                     context.Authentication.Challenge("Facebook");
                     return true;
                 });
-            var transaction = await SendAsync(server, "http://example.com/challenge");
+            var transaction = await server.SendAsync("http://example.com/challenge");
             transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
             var location = transaction.Response.Headers.Location.AbsoluteUri;
             location.ShouldContain("https://www.facebook.com/v2.2/dialog/oauth");
@@ -124,35 +120,6 @@ namespace Microsoft.AspNet.Authentication.Facebook
                 });
             },
             configureServices);
-        }
-
-        private static async Task<Transaction> SendAsync(TestServer server, string uri, string cookieHeader = null)
-        {
-            var request = new HttpRequestMessage(HttpMethod.Get, uri);
-            if (!string.IsNullOrEmpty(cookieHeader))
-            {
-                request.Headers.Add("Cookie", cookieHeader);
-            }
-            var transaction = new Transaction
-            {
-                Request = request,
-                Response = await server.CreateClient().SendAsync(request),
-            };
-            if (transaction.Response.Headers.Contains("Set-Cookie"))
-            {
-                transaction.SetCookie = transaction.Response.Headers.GetValues("Set-Cookie").ToList();
-            }
-            transaction.ResponseText = await transaction.Response.Content.ReadAsStringAsync();
-
-            return transaction;
-        }
-
-        private class Transaction
-        {
-            public HttpRequestMessage Request { get; set; }
-            public HttpResponseMessage Response { get; set; }
-            public IList<string> SetCookie { get; set; }
-            public string ResponseText { get; set; }
         }
     }
 }

--- a/test/Microsoft.AspNet.Authentication.Test/MicrosoftAccount/MicrosoftAccountMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/MicrosoftAccount/MicrosoftAccountMiddlewareTests.cs
@@ -1,16 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
-using System.Xml;
-using System.Xml.Linq;
 using Microsoft.AspNet.Authentication.DataHandler;
 using Microsoft.AspNet.Authentication.MicrosoftAccount;
 using Microsoft.AspNet.Builder;
@@ -49,7 +44,7 @@ namespace Microsoft.AspNet.Authentication.Tests.MicrosoftAccount
                     context.Authentication.Challenge("Microsoft");
                     return true;
                 });
-            var transaction = await SendAsync(server, "http://example.com/challenge");
+            var transaction = await server.SendAsync("http://example.com/challenge");
             transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
             var query = transaction.Response.Headers.Location.Query;
             query.ShouldContain("custom=test");
@@ -69,7 +64,7 @@ namespace Microsoft.AspNet.Authentication.Tests.MicrosoftAccount
                     context.Authentication.Challenge("Microsoft");
                     return true;
                 });
-            var transaction = await SendAsync(server, "http://example.com/challenge");
+            var transaction = await server.SendAsync("http://example.com/challenge");
             transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
             var location = transaction.Response.Headers.Location.AbsoluteUri;
             location.ShouldContain("https://login.live.com/oauth20_authorize.srf");
@@ -83,7 +78,7 @@ namespace Microsoft.AspNet.Authentication.Tests.MicrosoftAccount
         [Fact]
         public async Task AuthenticatedEventCanGetRefreshToken()
         {
-            ISecureDataFormat<AuthenticationProperties> stateFormat = new PropertiesDataFormat(new EphemeralDataProtectionProvider().CreateProtector("MsftTest"));
+            var stateFormat = new PropertiesDataFormat(new EphemeralDataProtectionProvider().CreateProtector("MsftTest"));
             var server = CreateServer(
                 options =>
                 {
@@ -134,7 +129,7 @@ namespace Microsoft.AspNet.Authentication.Tests.MicrosoftAccount
                 },
                 context =>
                 {
-                    Describe(context.Response, context.User);
+                    context.Response.Describe(context.User);
                     return true;
                 });
             var properties = new AuthenticationProperties();
@@ -143,7 +138,7 @@ namespace Microsoft.AspNet.Authentication.Tests.MicrosoftAccount
             properties.Items.Add(correlationKey, correlationValue);
             properties.RedirectUri = "/me";
             var state = stateFormat.Protect(properties);
-            var transaction = await SendAsync(server,
+            var transaction = await server.SendAsync(
                 "https://example.com/signin-microsoft?code=TestCode&state=" + UrlEncoder.Default.UrlEncode(state),
                 correlationKey + "=" + correlationValue);
             transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
@@ -153,7 +148,7 @@ namespace Microsoft.AspNet.Authentication.Tests.MicrosoftAccount
             transaction.SetCookie[1].ShouldContain(".AspNet.External");
 
             var authCookie = transaction.AuthenticationCookieValue;
-            transaction = await SendAsync(server, "https://example.com/me", authCookie);
+            transaction = await server.SendAsync("https://example.com/me", authCookie);
             transaction.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
             transaction.FindClaimValue("RefreshToken").ShouldBe("Test Refresh Token");
         }
@@ -186,112 +181,12 @@ namespace Microsoft.AspNet.Authentication.Tests.MicrosoftAccount
             });
         }
 
-        private static async Task<Transaction> SendAsync(TestServer server, string uri, string cookieHeader = null)
-        {
-            var request = new HttpRequestMessage(HttpMethod.Get, uri);
-            if (!string.IsNullOrEmpty(cookieHeader))
-            {
-                request.Headers.Add("Cookie", cookieHeader);
-            }
-            var transaction = new Transaction
-            {
-                Request = request,
-                Response = await server.CreateClient().SendAsync(request),
-            };
-            if (transaction.Response.Headers.Contains("Set-Cookie"))
-            {
-                transaction.SetCookie = transaction.Response.Headers.GetValues("Set-Cookie").ToList();
-            }
-            transaction.ResponseText = await transaction.Response.Content.ReadAsStringAsync();
-
-            if (transaction.Response.Content != null &&
-                transaction.Response.Content.Headers.ContentType != null &&
-                transaction.Response.Content.Headers.ContentType.MediaType == "text/xml")
-            {
-                transaction.ResponseElement = XElement.Parse(transaction.ResponseText);
-            }
-            return transaction;
-        }
-
         private static HttpResponseMessage ReturnJsonResponse(object content)
         {
             var res = new HttpResponseMessage(HttpStatusCode.OK);
             var text = JsonConvert.SerializeObject(content);
             res.Content = new StringContent(text, Encoding.UTF8, "application/json");
             return res;
-        }
-
-        private static void Describe(HttpResponse res, ClaimsPrincipal principal)
-        {
-            res.StatusCode = 200;
-            res.ContentType = "text/xml";
-            var xml = new XElement("xml");
-            if (principal != null)
-            {
-                foreach (var identity in principal.Identities)
-                {
-                    xml.Add(identity.Claims.Select(claim => new XElement("claim", new XAttribute("type", claim.Type), new XAttribute("value", claim.Value))));
-                }
-            }
-            using (var memory = new MemoryStream())
-            {
-                using (var writer = new XmlTextWriter(memory, Encoding.UTF8))
-                {
-                    xml.WriteTo(writer);
-                }
-                res.Body.Write(memory.ToArray(), 0, memory.ToArray().Length);
-            }
-        }
-
-        private class TestHttpMessageHandler : HttpMessageHandler
-        {
-            public Func<HttpRequestMessage, HttpResponseMessage> Sender { get; set; }
-
-            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
-            {
-                if (Sender != null)
-                {
-                    return Task.FromResult(Sender(request));
-                }
-
-                return Task.FromResult<HttpResponseMessage>(null);
-            }
-        }
-
-        private class Transaction
-        {
-            public HttpRequestMessage Request { get; set; }
-            public HttpResponseMessage Response { get; set; }
-            public IList<string> SetCookie { get; set; }
-            public string ResponseText { get; set; }
-            public XElement ResponseElement { get; set; }
-
-            public string AuthenticationCookieValue
-            {
-                get
-                {
-                    if (SetCookie != null && SetCookie.Count > 0)
-                    {
-                        var authCookie = SetCookie.SingleOrDefault(c => c.Contains(".AspNet.External="));
-                        if (authCookie != null)
-                        {
-                            return authCookie.Substring(0, authCookie.IndexOf(';'));
-                        }
-                    }
-
-                    return null;
-                }
-            }
-
-            public string FindClaimValue(string claimType)
-            {
-                XElement claim = ResponseElement.Elements("claim").SingleOrDefault(elt => elt.Attribute("type").Value == claimType);
-                if (claim == null)
-                {
-                    return null;
-                }
-                return claim.Attribute("value").Value;
-            }
         }
     }
 }

--- a/test/Microsoft.AspNet.Authentication.Test/OpenIdConnect/TestUtilities.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/OpenIdConnect/TestUtilities.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.IdentityModel.Protocols;
 using System;
 
 namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect

--- a/test/Microsoft.AspNet.Authentication.Test/TestExtensions.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/TestExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -16,64 +14,10 @@ using Microsoft.AspNet.TestHost;
 
 namespace Microsoft.AspNet.Authentication
 {
-    public class Transaction
+    public static class TestExtensions
     {
-        public HttpRequestMessage Request { get; set; }
-        public HttpResponseMessage Response { get; set; }
+        public const string CookieAuthenticationScheme = "External";
 
-        public IList<string> SetCookie { get; set; }
-
-        public string ResponseText { get; set; }
-        public XElement ResponseElement { get; set; }
-
-        public string AuthenticationCookieValue
-        {
-            get
-            {
-                if (SetCookie != null && SetCookie.Count > 0)
-                {
-                    var authCookie = SetCookie.SingleOrDefault(c => c.Contains(".AspNet.Cookie="));
-                    if (authCookie != null)
-                    {
-                        return authCookie.Substring(0, authCookie.IndexOf(';'));
-                    }
-                }
-
-                return null;
-            }
-        }
-
-        public string FindClaimValue(string claimType, string issuer = null)
-        {
-            var claim = ResponseElement.Elements("claim")
-                .SingleOrDefault(elt => elt.Attribute("type").Value == claimType &&
-                    (issuer == null || elt.Attribute("issuer").Value == issuer));
-            if (claim == null)
-            {
-                return null;
-            }
-            return claim.Attribute("value").Value;
-        }
-    }
-
-    public class TestHttpMessageHandler : HttpMessageHandler
-    {
-        public Func<HttpRequestMessage, HttpResponseMessage> Sender { get; set; }
-
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
-        {
-            if (Sender != null)
-            {
-                return Task.FromResult(Sender(request));
-            }
-
-            return Task.FromResult<HttpResponseMessage>(null);
-        }
-    }
-
-
-    public static class AuthTestExtensions
-    {
         public static async Task<Transaction> SendAsync(this TestServer server, string uri, string cookieHeader = null)
         {
             var request = new HttpRequestMessage(HttpMethod.Get, uri);

--- a/test/Microsoft.AspNet.Authentication.Test/TestHttpMessageHandler.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/TestHttpMessageHandler.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNet.Authentication
+{
+    public class TestHttpMessageHandler : HttpMessageHandler
+    {
+        public Func<HttpRequestMessage, HttpResponseMessage> Sender { get; set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
+        {
+            if (Sender != null)
+            {
+                return Task.FromResult(Sender(request));
+            }
+
+            return Task.FromResult<HttpResponseMessage>(null);
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Authentication.Test/Transaction.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Transaction.cs
@@ -1,0 +1,50 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Xml.Linq;
+
+namespace Microsoft.AspNet.Authentication
+{
+    public class Transaction
+    {
+        public HttpRequestMessage Request { get; set; }
+        public HttpResponseMessage Response { get; set; }
+
+        public IList<string> SetCookie { get; set; }
+
+        public string ResponseText { get; set; }
+        public XElement ResponseElement { get; set; }
+
+        public string AuthenticationCookieValue
+        {
+            get
+            {
+                if (SetCookie != null && SetCookie.Count > 0)
+                {
+                    var authCookie = SetCookie.SingleOrDefault(c => c.Contains(".AspNet." + TestExtensions.CookieAuthenticationScheme + "="));
+                    if (authCookie != null)
+                    {
+                        return authCookie.Substring(0, authCookie.IndexOf(';'));
+                    }
+                }
+
+                return null;
+            }
+        }
+
+        public string FindClaimValue(string claimType, string issuer = null)
+        {
+            var claim = ResponseElement.Elements("claim")
+                .SingleOrDefault(elt => elt.Attribute("type").Value == claimType &&
+                    (issuer == null || elt.Attribute("issuer").Value == issuer));
+            if (claim == null)
+            {
+                return null;
+            }
+            return claim.Attribute("value").Value;
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Authentication.Test/Twitter/TwitterMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Twitter/TwitterMiddlewareTests.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -57,7 +55,7 @@ namespace Microsoft.AspNet.Authentication.Twitter
                     context.Authentication.Challenge("Twitter");
                     return true;
                 });
-            var transaction = await SendAsync(server, "http://example.com/challenge");
+            var transaction = await server.SendAsync("http://example.com/challenge");
             transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
             var query = transaction.Response.Headers.Location.Query;
             query.ShouldContain("custom=test");
@@ -95,7 +93,7 @@ namespace Microsoft.AspNet.Authentication.Twitter
                     context.Authentication.Challenge("Twitter");
                     return true;
                 });
-            var transaction = await SendAsync(server, "http://example.com/challenge");
+            var transaction = await server.SendAsync("http://example.com/challenge");
             transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
             var location = transaction.Response.Headers.Location.AbsoluteUri;
             location.ShouldContain("https://twitter.com/oauth/authenticate?oauth_token=");
@@ -129,50 +127,6 @@ namespace Microsoft.AspNet.Authentication.Twitter
                     options.SignInScheme = "External";
                 });
             });
-        }
-
-        private static async Task<Transaction> SendAsync(TestServer server, string uri, string cookieHeader = null)
-        {
-            var request = new HttpRequestMessage(HttpMethod.Get, uri);
-            if (!string.IsNullOrEmpty(cookieHeader))
-            {
-                request.Headers.Add("Cookie", cookieHeader);
-            }
-            var transaction = new Transaction
-            {
-                Request = request,
-                Response = await server.CreateClient().SendAsync(request),
-            };
-            if (transaction.Response.Headers.Contains("Set-Cookie"))
-            {
-                transaction.SetCookie = transaction.Response.Headers.GetValues("Set-Cookie").ToList();
-            }
-            transaction.ResponseText = await transaction.Response.Content.ReadAsStringAsync();
-
-            return transaction;
-        }
-
-        private class TestHttpMessageHandler : HttpMessageHandler
-        {
-            public Func<HttpRequestMessage, HttpResponseMessage> Sender { get; set; }
-
-            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
-            {
-                if (Sender != null)
-                {
-                    return Task.FromResult(Sender(request));
-                }
-
-                return Task.FromResult<HttpResponseMessage>(null);
-            }
-        }
-
-        private class Transaction
-        {
-            public HttpRequestMessage Request { get; set; }
-            public HttpResponseMessage Response { get; set; }
-            public IList<string> SetCookie { get; set; }
-            public string ResponseText { get; set; }
         }
     }
 }


### PR DESCRIPTION
- Moved ClaimsIssuer to AuthenticationOptions, all auth middleware should respect this when issuing claims (Fixes https://github.com/aspnet/Security/issues/234)
- Started refactoring tests.  Next iteration will consolidate tests into a base test class for OAuth, to reduce all the copy/paste all over

cc @Tratcher 