### PR TITLE
Using [NotNull] and  'nameof' operator

### DIFF
--- a/src/Microsoft.AspNet.Authentication.Cookies/CookieAuthenticationOptions.cs
+++ b/src/Microsoft.AspNet.Authentication.Cookies/CookieAuthenticationOptions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Authentication.Cookies.Infrastructure;
+using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Authentication.Cookies
 {
@@ -38,12 +39,9 @@ namespace Microsoft.AspNet.Authentication.Cookies
         public string CookieName
         {
             get { return _cookieName; }
+            [param: NotNull]
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException("value");
-                }
                 _cookieName = value;
             }
         }

--- a/src/Microsoft.AspNet.Authentication.Facebook/FacebookAuthenticationMiddleware.cs
+++ b/src/Microsoft.AspNet.Authentication.Facebook/FacebookAuthenticationMiddleware.cs
@@ -37,11 +37,11 @@ namespace Microsoft.AspNet.Authentication.Facebook
         {
             if (string.IsNullOrWhiteSpace(Options.AppId))
             {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Exception_OptionMustBeProvided, "AppId"));
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Exception_OptionMustBeProvided, nameof(Options.AppId)));
             }
             if (string.IsNullOrWhiteSpace(Options.AppSecret))
             {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Exception_OptionMustBeProvided, "AppSecret"));
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Exception_OptionMustBeProvided, nameof(Options.AppSecret)));
             }
 
             if (Options.Notifications == null)

--- a/src/Microsoft.AspNet.Authentication.MicrosoftAccount/Notifications/MicrosoftAccountAuthenticatedContext.cs
+++ b/src/Microsoft.AspNet.Authentication.MicrosoftAccount/Notifications/MicrosoftAccountAuthenticatedContext.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNet.Authentication.MicrosoftAccount
             JToken userId = User["id"];
             if (userId == null)
             {
-                throw new ArgumentException(Resources.Exception_MissingId, "user");
+                throw new ArgumentException(Resources.Exception_MissingId, nameof(user));
             }
 
             Id = userId.ToString();

--- a/src/Microsoft.AspNet.Authentication.OAuth/OAuthAuthenticationMiddleware.cs
+++ b/src/Microsoft.AspNet.Authentication.OAuth/OAuthAuthenticationMiddleware.cs
@@ -43,17 +43,17 @@ namespace Microsoft.AspNet.Authentication.OAuth
             // todo: review error handling
             if (string.IsNullOrWhiteSpace(Options.AuthenticationScheme))
             {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Exception_OptionMustBeProvided, "AuthenticationScheme"));
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Exception_OptionMustBeProvided, nameof(Options.AuthenticationScheme)));
             }
 
             if (string.IsNullOrWhiteSpace(Options.ClientId))
             {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Exception_OptionMustBeProvided, "ClientId"));
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Exception_OptionMustBeProvided, nameof(Options.ClientId)));
             }
 
             if (string.IsNullOrWhiteSpace(Options.ClientSecret))
             {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Exception_OptionMustBeProvided, "ClientSecret"));
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Exception_OptionMustBeProvided, nameof(Options.ClientSecret)));
             }
 
             if (string.IsNullOrWhiteSpace(Options.AuthorizationEndpoint))

--- a/src/Microsoft.AspNet.Authentication.OAuthBearer/OAuthBearerAuthenticationOptions.cs
+++ b/src/Microsoft.AspNet.Authentication.OAuthBearer/OAuthBearerAuthenticationOptions.cs
@@ -7,6 +7,7 @@ using System.IdentityModel.Tokens;
 using System.Net.Http;
 using Microsoft.AspNet.Authentication;
 using Microsoft.IdentityModel.Protocols;
+using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Authentication.OAuthBearer
 {
@@ -122,13 +123,9 @@ namespace Microsoft.AspNet.Authentication.OAuthBearer
                 return _securityTokenValidators;
             }
 
+            [param: NotNull]
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException("SecurityTokenValidators");
-                }
-
                 _securityTokenValidators = value;
             }
         }

--- a/src/Microsoft.AspNet.Authentication.OpenIdConnect/OpenIdConnectAuthenticationOptions.cs
+++ b/src/Microsoft.AspNet.Authentication.OpenIdConnect/OpenIdConnectAuthenticationOptions.cs
@@ -9,6 +9,7 @@ using System.Net.Http;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Authentication;
 using Microsoft.IdentityModel.Protocols;
+using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Authentication.OpenIdConnect
 {
@@ -110,7 +111,7 @@ namespace Microsoft.AspNet.Authentication.OpenIdConnect
             {
                 if (value <= TimeSpan.Zero)
                 {
-                    throw new ArgumentOutOfRangeException("BackchannelTimeout", value, Resources.OIDCH_0101_BackChallnelLessThanZero);
+                    throw new ArgumentOutOfRangeException(nameof(BackchannelTimeout), value, Resources.OIDCH_0101_BackChallnelLessThanZero);
                 }
 
                 _backchannelTimeout = value;
@@ -190,13 +191,9 @@ namespace Microsoft.AspNet.Authentication.OpenIdConnect
             {
                 return _protocolValidator;
             }
+            [param: NotNull]
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException("value");
-                }
-
                 _protocolValidator = value;
             }
         }

--- a/src/Microsoft.AspNet.Authentication.Twitter/TwitterAuthenticationMiddleware.cs
+++ b/src/Microsoft.AspNet.Authentication.Twitter/TwitterAuthenticationMiddleware.cs
@@ -45,11 +45,11 @@ namespace Microsoft.AspNet.Authentication.Twitter
         {
             if (string.IsNullOrWhiteSpace(Options.ConsumerSecret))
             {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Exception_OptionMustBeProvided, "ConsumerSecret"));
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Exception_OptionMustBeProvided, nameof(Options.ConsumerSecret)));
             }
             if (string.IsNullOrWhiteSpace(Options.ConsumerKey))
             {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Exception_OptionMustBeProvided, "ConsumerKey"));
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Exception_OptionMustBeProvided, nameof(Options.ConsumerKey)));
             }
 
             if (Options.Notifications == null)

--- a/src/Microsoft.AspNet.Authentication/CertificateSubjectPublicKeyInfoValidator.cs
+++ b/src/Microsoft.AspNet.Authentication/CertificateSubjectPublicKeyInfoValidator.cs
@@ -36,12 +36,12 @@ namespace Microsoft.AspNet.Authentication
 
             if (_validBase64EncodedSubjectPublicKeyInfoHashes.Count == 0)
             {
-                throw new ArgumentOutOfRangeException("validBase64EncodedSubjectPublicKeyInfoHashes");
+                throw new ArgumentOutOfRangeException(nameof(validBase64EncodedSubjectPublicKeyInfoHashes));
             }
 
             if (_algorithm != SubjectPublicKeyInfoAlgorithm.Sha1 && _algorithm != SubjectPublicKeyInfoAlgorithm.Sha256)
             {
-                throw new ArgumentOutOfRangeException("algorithm");
+                throw new ArgumentOutOfRangeException(nameof(algorithm));
             }
 
             _algorithm = algorithm;

--- a/src/Microsoft.AspNet.Authentication/CertificateThumbprintValidator.cs
+++ b/src/Microsoft.AspNet.Authentication/CertificateThumbprintValidator.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNet.Authentication
 
             if (_validCertificateThumbprints.Count == 0)
             {
-                throw new ArgumentOutOfRangeException("validThumbprints");
+                throw new ArgumentOutOfRangeException(nameof(validThumbprints));
             }
         }
 


### PR DESCRIPTION
Using the "nameof" operator instead of magic string will help us if the variable change in the future for whatever the reason