### PR TITLE
AuthZ: Replace params overloads with IEnumerable to enable sugar

### DIFF
--- a/src/Microsoft.AspNet.Authorization/AuthorizationPolicy.cs
+++ b/src/Microsoft.AspNet.Authorization/AuthorizationPolicy.cs
@@ -10,8 +10,12 @@ namespace Microsoft.AspNet.Authorization
 {
     public class AuthorizationPolicy
     {
-        public AuthorizationPolicy(IEnumerable<IAuthorizationRequirement> requirements, IEnumerable<string> activeAuthenticationSchemes)
+        public AuthorizationPolicy([NotNull] IEnumerable<IAuthorizationRequirement> requirements, [NotNull] IEnumerable<string> activeAuthenticationSchemes)
         {
+            if (requirements.Count() == 0)
+            {
+                throw new InvalidOperationException(Resources.Exception_AuthorizationPolicyEmpty);
+            }
             Requirements = new List<IAuthorizationRequirement>(requirements).AsReadOnly();
             ActiveAuthenticationSchemes = new List<string>(activeAuthenticationSchemes).AsReadOnly();
         }

--- a/src/Microsoft.AspNet.Authorization/AuthorizationServiceExtensions.cs
+++ b/src/Microsoft.AspNet.Authorization/AuthorizationServiceExtensions.cs
@@ -28,12 +28,60 @@ namespace Microsoft.AspNet.Authorization
         /// </summary>
         /// <param name="service">The authorization service.</param>
         /// <param name="user">The user to check the policy against.</param>
+        /// <param name="policy">The policy to check against a specific context.</param>
+        /// <returns><value>true</value> when the user fulfills the policy, <value>false</value> otherwise.</returns>
+        public static Task<bool> AuthorizeAsync([NotNull] this IAuthorizationService service, ClaimsPrincipal user, [NotNull] AuthorizationPolicy policy)
+        {
+            return service.AuthorizeAsync(user, resource: null, policy: policy);
+        }
+
+        /// <summary>
+        /// Checks if a user meets a specific authorization policy
+        /// </summary>
+        /// <param name="service">The authorization service.</param>
+        /// <param name="user">The user to check the policy against.</param>
+        /// <param name="policyName">The name of the policy to check against a specific context.</param>
+        /// <returns><value>true</value> when the user fulfills the policy, <value>false</value> otherwise.</returns>
+        public static Task<bool> AuthorizeAsync([NotNull] this IAuthorizationService service, ClaimsPrincipal user, [NotNull] string policyName)
+        {
+            return service.AuthorizeAsync(user, resource: null, policyName: policyName);
+        }
+
+        /// <summary>
+        /// Checks if a user meets a specific authorization policy
+        /// </summary>
+        /// <param name="service">The authorization service.</param>
+        /// <param name="user">The user to check the policy against.</param>
         /// <param name="resource">The resource the policy should be checked with.</param>
         /// <param name="policy">The policy to check against a specific context.</param>
         /// <returns><value>true</value> when the user fulfills the policy, <value>false</value> otherwise.</returns>
         public static bool Authorize([NotNull] this IAuthorizationService service, ClaimsPrincipal user, object resource, [NotNull] AuthorizationPolicy policy)
         {
             return service.Authorize(user, resource, policy.Requirements.ToArray());
+        }
+
+        /// <summary>
+        /// Checks if a user meets a specific authorization policy
+        /// </summary>
+        /// <param name="service">The authorization service.</param>
+        /// <param name="user">The user to check the policy against.</param>
+        /// <param name="policy">The policy to check against a specific context.</param>
+        /// <returns><value>true</value> when the user fulfills the policy, <value>false</value> otherwise.</returns>
+        public static bool Authorize([NotNull] this IAuthorizationService service, ClaimsPrincipal user, [NotNull] AuthorizationPolicy policy)
+        {
+            return service.Authorize(user, resource: null, requirements: policy.Requirements.ToArray());
+        }
+
+        /// <summary>
+        /// Checks if a user meets a specific authorization policy
+        /// </summary>
+        /// <param name="service">The authorization service.</param>
+        /// <param name="user">The user to check the policy against.</param>
+        /// <param name="policyName">The name of the policy to check against a specific context.</param>
+        /// <returns><value>true</value> when the user fulfills the policy, <value>false</value> otherwise.</returns>
+        public static bool Authorize([NotNull] this IAuthorizationService service, ClaimsPrincipal user, [NotNull] string policyName)
+        {
+            return service.Authorize(user, resource: null, policyName: policyName);
         }
 
     }

--- a/src/Microsoft.AspNet.Authorization/AuthorizationServiceExtensions.cs
+++ b/src/Microsoft.AspNet.Authorization/AuthorizationServiceExtensions.cs
@@ -11,6 +11,18 @@ namespace Microsoft.AspNet.Authorization
     public static class AuthorizationServiceExtensions
     {
         /// <summary>
+        /// Checks if a user meets a specific requirement for the specified resource
+        /// </summary>
+        /// <param name="user"></param>
+        /// <param name="resource"></param>
+        /// <param name="requirement"></param>
+        /// <returns></returns>
+        public static Task<bool> AuthorizeAsync([NotNull] this IAuthorizationService service, ClaimsPrincipal user, object resource, [NotNull] IAuthorizationRequirement requirement)
+        {
+            return service.AuthorizeAsync(user, resource, new IAuthorizationRequirement[] { requirement });
+        }
+
+        /// <summary>
         /// Checks if a user meets a specific authorization policy
         /// </summary>
         /// <param name="service">The authorization service.</param>
@@ -45,6 +57,18 @@ namespace Microsoft.AspNet.Authorization
         public static Task<bool> AuthorizeAsync([NotNull] this IAuthorizationService service, ClaimsPrincipal user, [NotNull] string policyName)
         {
             return service.AuthorizeAsync(user, resource: null, policyName: policyName);
+        }
+
+        /// <summary>
+        /// Checks if a user meets a specific requirement for the specified resource
+        /// </summary>
+        /// <param name="user"></param>
+        /// <param name="resource"></param>
+        /// <param name="requirement"></param>
+        /// <returns></returns>
+        public static bool Authorize([NotNull] this IAuthorizationService service, ClaimsPrincipal user, object resource, [NotNull] IAuthorizationRequirement requirement)
+        {
+            return service.Authorize(user, resource, new IAuthorizationRequirement[] { requirement });
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Authorization/DefaultAuthorizationService.cs
+++ b/src/Microsoft.AspNet.Authorization/DefaultAuthorizationService.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Microsoft.Framework.Internal;
 using Microsoft.Framework.OptionsModel;
 
 namespace Microsoft.AspNet.Authorization
@@ -28,7 +29,7 @@ namespace Microsoft.AspNet.Authorization
                 : this.Authorize(user, resource, policy);
         }
 
-        public bool Authorize(ClaimsPrincipal user, object resource, params IAuthorizationRequirement[] requirements)
+        public bool Authorize(ClaimsPrincipal user, object resource, [NotNull] IEnumerable<IAuthorizationRequirement> requirements)
         {
             var authContext = new AuthorizationContext(requirements, user, resource);
             foreach (var handler in _handlers)
@@ -38,7 +39,7 @@ namespace Microsoft.AspNet.Authorization
             return authContext.HasSucceeded;
         }
 
-        public async Task<bool> AuthorizeAsync(ClaimsPrincipal user, object resource, params IAuthorizationRequirement[] requirements)
+        public async Task<bool> AuthorizeAsync(ClaimsPrincipal user, object resource, [NotNull] IEnumerable<IAuthorizationRequirement> requirements)
         {
             var authContext = new AuthorizationContext(requirements, user, resource);
             foreach (var handler in _handlers)

--- a/src/Microsoft.AspNet.Authorization/IAuthorizationService.cs
+++ b/src/Microsoft.AspNet.Authorization/IAuthorizationService.cs
@@ -1,8 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Authorization
 {
@@ -18,7 +20,7 @@ namespace Microsoft.AspNet.Authorization
         /// <param name="resource"></param>
         /// <param name="requirements"></param>
         /// <returns></returns>
-        Task<bool> AuthorizeAsync(ClaimsPrincipal user, object resource, params IAuthorizationRequirement[] requirements);
+        Task<bool> AuthorizeAsync(ClaimsPrincipal user, object resource, [NotNull] IEnumerable<IAuthorizationRequirement> requirements);
 
         /// <summary>
         /// Checks if a user meets a specific set of requirements for the specified resource
@@ -27,7 +29,7 @@ namespace Microsoft.AspNet.Authorization
         /// <param name="resource"></param>
         /// <param name="requirements"></param>
         /// <returns></returns>
-        bool Authorize(ClaimsPrincipal user, object resource, params IAuthorizationRequirement[] requirements);
+        bool Authorize(ClaimsPrincipal user, object resource, [NotNull] IEnumerable<IAuthorizationRequirement> requirements);
 
         /// <summary>
         /// Checks if a user meets a specific authorization policy
@@ -36,7 +38,7 @@ namespace Microsoft.AspNet.Authorization
         /// <param name="resource">The resource the policy should be checked with.</param>
         /// <param name="policyName">The name of the policy to check against a specific context.</param>
         /// <returns><value>true</value> when the user fulfills the policy, <value>false</value> otherwise.</returns>
-        Task<bool> AuthorizeAsync(ClaimsPrincipal user, object resource, string policyName);
+        Task<bool> AuthorizeAsync(ClaimsPrincipal user, object resource, [NotNull] string policyName);
 
         /// <summary>
         /// Checks if a user meets a specific authorization policy
@@ -45,6 +47,6 @@ namespace Microsoft.AspNet.Authorization
         /// <param name="resource">The resource the policy should be checked with.</param>
         /// <param name="policyName">The name of the policy to check against a specific context.</param>
         /// <returns><value>true</value> when the user fulfills the policy, <value>false</value> otherwise.</returns>
-        bool Authorize(ClaimsPrincipal user, object resource, string policyName);
+        bool Authorize(ClaimsPrincipal user, object resource, [NotNull] string policyName);
     }
 }

--- a/src/Microsoft.AspNet.Authorization/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Authorization/Properties/Resources.Designer.cs
@@ -27,6 +27,22 @@ namespace Microsoft.AspNet.Authorization
         }
 
         /// <summary>
+        /// AuthorizationPolicy must have at least one requirement.
+        /// </summary>
+        internal static string Exception_AuthorizationPolicyEmpty
+        {
+            get { return GetString("Exception_AuthorizationPolicyEmpty"); }
+        }
+
+        /// <summary>
+        /// AuthorizationPolicy must have at least one requirement.
+        /// </summary>
+        internal static string FormatException_AuthorizationPolicyEmpty(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Exception_AuthorizationPolicyEmpty"), p0);
+        }
+
+        /// <summary>
         /// At least one role must be specified.
         /// </summary>
         internal static string Exception_RoleRequirementEmpty

--- a/src/Microsoft.AspNet.Authorization/Resources.resx
+++ b/src/Microsoft.AspNet.Authorization/Resources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Exception_AuthorizationPolicyEmpty" xml:space="preserve">
+    <value>AuthorizationPolicy must have at least one requirement.</value>
+  </data>
   <data name="Exception_AuthorizationPolicyNotFound" xml:space="preserve">
     <value>The AuthorizationPolicy named: '{0}' was not found.</value>
   </data>

--- a/test/Microsoft.AspNet.Authorization.Test/DefaultAuthorizationServiceTests.cs
+++ b/test/Microsoft.AspNet.Authorization.Test/DefaultAuthorizationServiceTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
@@ -47,7 +46,7 @@ namespace Microsoft.AspNet.Authorization.Test
             var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { new Claim("Permission", "CanViewPage") }, "Basic"));
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, null, "Basic");
+            var allowed = await authorizationService.AuthorizeAsync(user, "Basic");
 
             // Assert
             Assert.True(allowed);
@@ -67,7 +66,7 @@ namespace Microsoft.AspNet.Authorization.Test
             var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { new Claim("Permission", "CanViewPage") }, "Basic"));
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, null, "Basic");
+            var allowed = await authorizationService.AuthorizeAsync(user, "Basic");
 
             // Assert
             Assert.True(allowed);
@@ -94,7 +93,7 @@ namespace Microsoft.AspNet.Authorization.Test
                 );
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, null, "Basic");
+            var allowed = await authorizationService.AuthorizeAsync(user, "Basic");
 
             // Assert
             Assert.True(allowed);
@@ -120,7 +119,7 @@ namespace Microsoft.AspNet.Authorization.Test
                 );
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, null, "Basic");
+            var allowed = await authorizationService.AuthorizeAsync(user, "Basic");
 
             // Assert
             Assert.False(allowed);
@@ -146,7 +145,7 @@ namespace Microsoft.AspNet.Authorization.Test
                 );
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, null, "Basic");
+            var allowed = await authorizationService.AuthorizeAsync(user, "Basic");
 
             // Assert
             Assert.False(allowed);
@@ -172,7 +171,7 @@ namespace Microsoft.AspNet.Authorization.Test
                 );
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, null, "Basic");
+            var allowed = await authorizationService.AuthorizeAsync(user, "Basic");
 
             // Assert
             Assert.False(allowed);
@@ -196,7 +195,7 @@ namespace Microsoft.AspNet.Authorization.Test
                 );
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, null, "Basic");
+            var allowed = await authorizationService.AuthorizeAsync(user, "Basic");
 
             // Assert
             Assert.False(allowed);
@@ -235,7 +234,7 @@ namespace Microsoft.AspNet.Authorization.Test
             var user = new ClaimsPrincipal(new ClaimsIdentity());
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, null, "Basic");
+            var allowed = await authorizationService.AuthorizeAsync(user, "Basic");
 
             // Assert
             Assert.False(allowed);
@@ -261,7 +260,7 @@ namespace Microsoft.AspNet.Authorization.Test
                 );
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, null, "Basic");
+            var allowed = await authorizationService.AuthorizeAsync(user, "Basic");
 
             // Assert
             Assert.True(allowed);
@@ -281,7 +280,7 @@ namespace Microsoft.AspNet.Authorization.Test
                 );
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, null, "Basic");
+            var allowed = await authorizationService.AuthorizeAsync(user, "Basic");
 
             // Assert
             Assert.False(allowed);
@@ -304,7 +303,7 @@ namespace Microsoft.AspNet.Authorization.Test
                 );
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, null, policy.Build());
+            var allowed = await authorizationService.AuthorizeAsync(user, policy.Build());
 
             // Assert
             Assert.True(allowed);
@@ -325,7 +324,7 @@ namespace Microsoft.AspNet.Authorization.Test
                 );
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, null, policy.Build());
+            var allowed = await authorizationService.AuthorizeAsync(user, policy.Build());
 
             // Assert
             Assert.True(allowed);
@@ -342,7 +341,7 @@ namespace Microsoft.AspNet.Authorization.Test
                 );
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, null, policy.Build());
+            var allowed = await authorizationService.AuthorizeAsync(user, policy.Build());
 
             // Assert
             Assert.True(allowed);
@@ -375,7 +374,7 @@ namespace Microsoft.AspNet.Authorization.Test
                 new ClaimsIdentity(new Claim[] { new Claim(ClaimTypes.Role, "Users") }, "AuthType"));
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, null, policy.Build());
+            var allowed = await authorizationService.AuthorizeAsync(user, policy.Build());
 
             // Assert
             Assert.True(allowed);
@@ -396,7 +395,7 @@ namespace Microsoft.AspNet.Authorization.Test
                 );
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, null, policy.Build());
+            var allowed = await authorizationService.AuthorizeAsync(user, policy.Build());
 
             // Assert
             Assert.False(allowed);
@@ -421,7 +420,7 @@ namespace Microsoft.AspNet.Authorization.Test
                 );
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, null, "Basic");
+            var allowed = await authorizationService.AuthorizeAsync(user, "Basic");
 
             // Assert
             Assert.False(allowed);
@@ -447,7 +446,7 @@ namespace Microsoft.AspNet.Authorization.Test
                 );
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, null, "Basic");
+            var allowed = await authorizationService.AuthorizeAsync(user, "Basic");
 
             // Assert
             Assert.False(allowed);
@@ -473,7 +472,7 @@ namespace Microsoft.AspNet.Authorization.Test
                 );
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, null, "Any");
+            var allowed = await authorizationService.AuthorizeAsync(user, "Any");
 
             // Assert
             Assert.False(allowed);
@@ -499,7 +498,7 @@ namespace Microsoft.AspNet.Authorization.Test
                 );
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, null, "Hao");
+            var allowed = await authorizationService.AuthorizeAsync(user, "Hao");
 
             // Assert
             Assert.True(allowed);
@@ -521,7 +520,7 @@ namespace Microsoft.AspNet.Authorization.Test
             var user = new ClaimsPrincipal(identity);
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, null, "Hao");
+            var allowed = await authorizationService.AuthorizeAsync(user, "Hao");
 
             // Assert
             Assert.True(allowed);
@@ -543,7 +542,7 @@ namespace Microsoft.AspNet.Authorization.Test
             var user = new ClaimsPrincipal(identity);
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, null, "Hao");
+            var allowed = await authorizationService.AuthorizeAsync(user, "Hao");
 
             // Assert
             Assert.True(allowed);

--- a/test/Microsoft.AspNet.Authorization.Test/DefaultAuthorizationServiceTests.cs
+++ b/test/Microsoft.AspNet.Authorization.Test/DefaultAuthorizationServiceTests.cs
@@ -427,29 +427,15 @@ namespace Microsoft.AspNet.Authorization.Test
         }
 
         [Fact]
-        public async Task PolicyFailsWithNoRequirements()
+        public void PolicyThrowsWithNoRequirements()
         {
-            // Arrange
-            var authorizationService = BuildAuthorizationService(services =>
+            Assert.Throws<InvalidOperationException>(() => BuildAuthorizationService(services =>
             {
                 services.ConfigureAuthorization(options =>
                 {
                     options.AddPolicy("Basic", policy => { });
                 });
-            });
-            var user = new ClaimsPrincipal(
-                new ClaimsIdentity(
-                    new Claim[] {
-                        new Claim(ClaimTypes.Name, "Name"),
-                    },
-                    "AuthType")
-                );
-
-            // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, "Basic");
-
-            // Assert
-            Assert.False(allowed);
+            }));
         }
 
         [Fact]


### PR DESCRIPTION
Enables making resource optional in some sugar overloads

cc @blowdart @divega 

