### PR TITLE
Add sugar for UseClaimsTransformation

### DIFF
--- a/src/Microsoft.AspNet.Authentication/ClaimsTransformationAppBuilderExtensions.cs
+++ b/src/Microsoft.AspNet.Authentication/ClaimsTransformationAppBuilderExtensions.cs
@@ -3,6 +3,8 @@
 
 using System;
 using Microsoft.AspNet.Authentication;
+using Microsoft.Framework.Internal;
+using Microsoft.Framework.OptionsModel;
 
 namespace Microsoft.AspNet.Builder
 {
@@ -15,12 +17,34 @@ namespace Microsoft.AspNet.Builder
         /// Adds a claims transformation middleware to your web application pipeline.
         /// </summary>
         /// <param name="app">The IApplicationBuilder passed to your configuration method</param>
-        /// <param name="configureOptions">Used to configure the options for the middleware</param>
-        /// <param name="optionsName">The name of the options class that controls the middleware behavior, null will use the default options</param>
         /// <returns>The original app parameter</returns>
         public static IApplicationBuilder UseClaimsTransformation(this IApplicationBuilder app)
         {
-            return app.UseMiddleware<ClaimsTransformationMiddleware>();
+            return app.UseClaimsTransformation(configureOptions: o => { }, optionsName: string.Empty);
+        }
+
+        /// <summary>
+        /// Adds a claims transformation middleware to your web application pipeline.
+        /// </summary>
+        /// <param name="app">The IApplicationBuilder passed to your configuration method</param>
+        /// <param name="configureOptions">Used to configure the options for the middleware</param>
+        /// <returns>The original app parameter</returns>
+        public static IApplicationBuilder UseClaimsTransformation(this IApplicationBuilder app, [NotNull] Action<ClaimsTransformationOptions> configureOptions)
+        {
+            return app.UseClaimsTransformation(configureOptions: configureOptions, optionsName: string.Empty);
+        }
+
+        /// <summary>
+        /// Adds a claims transformation middleware to your web application pipeline.
+        /// </summary>
+        /// <param name="app">The IApplicationBuilder passed to your configuration method</param>
+        /// <param name="configureOptions">Used to configure the options for the middleware</param>
+        /// <param name="optionsName">The name of the options class that controls the middleware behavior, null will use the default options</param>
+        /// <returns>The original app parameter</returns>
+        public static IApplicationBuilder UseClaimsTransformation(this IApplicationBuilder app, [NotNull] Action<ClaimsTransformationOptions> configureOptions, [NotNull] string optionsName)
+        {
+            return app.UseMiddleware<ClaimsTransformationMiddleware>(
+                new ConfigureOptions<ClaimsTransformationOptions>(configureOptions) { Name = optionsName });
         }
     }
 }

--- a/src/Microsoft.AspNet.Authentication/ClaimsTransformationMiddleware.cs
+++ b/src/Microsoft.AspNet.Authentication/ClaimsTransformationMiddleware.cs
@@ -15,10 +15,18 @@ namespace Microsoft.AspNet.Authentication
 
         public ClaimsTransformationMiddleware(
             [NotNull] RequestDelegate next,
-            [NotNull] IOptions<ClaimsTransformationOptions> options)
+            [NotNull] IOptions<ClaimsTransformationOptions> options,
+            ConfigureOptions<ClaimsTransformationOptions> configureOptions)
         {
-            // REVIEW: do we need to take ConfigureOptions<ClaimsTransformationOptions>??
-            Options = options.Options;
+            if (configureOptions != null)
+            {
+                Options = options.GetNamedOptions(configureOptions.Name);
+                configureOptions.Configure(Options, configureOptions.Name);
+            }
+            else
+            {
+                Options = options.Options;
+            }
             _next = next;
         }
 

--- a/src/Microsoft.AspNet.Authentication/ClaimsTransformationOptions.cs
+++ b/src/Microsoft.AspNet.Authentication/ClaimsTransformationOptions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Security.Claims;
+using System.Threading.Tasks;
 
 namespace Microsoft.AspNet.Authentication
 {

--- a/src/Microsoft.AspNet.Authentication/ClaimsTransformationOptions.cs
+++ b/src/Microsoft.AspNet.Authentication/ClaimsTransformationOptions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Security.Claims;
-using System.Threading.Tasks;
 
 namespace Microsoft.AspNet.Authentication
 {

--- a/test/Microsoft.AspNet.Authentication.Test/Google/GoogleMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Google/GoogleMiddlewareTests.cs
@@ -461,7 +461,16 @@ namespace Microsoft.AspNet.Authentication.Google
                     options.AutomaticAuthentication = true;
                 });
                 app.UseGoogleAuthentication(configureOptions);
-                app.UseClaimsTransformation();
+                app.UseClaimsTransformation(o =>
+                {
+                    o.Transformation = p =>
+                    {
+                        var id = new ClaimsIdentity("xform");
+                        id.AddClaim(new Claim("xform", "yup"));
+                        p.AddIdentity(id);
+                        return p;
+                    };
+                });
                 app.Use(async (context, next) =>
                 {
                     var req = context.Request;
@@ -507,13 +516,6 @@ namespace Microsoft.AspNet.Authentication.Google
                 services.Configure<ExternalAuthenticationOptions>(options =>
                 {
                     options.SignInScheme = TestExtensions.CookieAuthenticationScheme;
-                });
-                services.ConfigureClaimsTransformation(p =>
-                {
-                    var id = new ClaimsIdentity("xform");
-                    id.AddClaim(new Claim("xform", "yup"));
-                    p.AddIdentity(id);
-                    return p;
                 });
             });
         }


### PR DESCRIPTION
Allows configuration of claims transformation inline with UseClaimsTransformation just like the other Auth middlewares

Fixes https://github.com/aspnet/Security/issues/236

cc @Tratcher @blowdart 
