### PR TITLE
Fix 401-403 for automatic cookies

### DIFF
--- a/src/Microsoft.AspNet.Authentication.Cookies/CookieAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.Cookies/CookieAuthenticationHandler.cs
@@ -99,6 +99,7 @@ namespace Microsoft.AspNet.Authentication.Cookies
 
                 await Options.Notifications.ValidatePrincipal(context);
 
+                AuthenticateCalled = true;
                 return new AuthenticationTicket(context.Principal, context.Properties, Options.AuthenticationScheme);
             }
             catch (Exception exception)

--- a/src/Microsoft.AspNet.Authentication/AuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication/AuthenticationHandler.cs
@@ -59,7 +59,8 @@ namespace Microsoft.AspNet.Authentication
             get { return _baseOptions; }
         }
 
-        internal bool AuthenticateCalled { get; set; }
+        // REVIEW: Overriding Authenticate and not calling base requires manually calling this for 401-403 to work
+        protected bool AuthenticateCalled { get; set; }
 
         public IAuthenticationHandler PriorHandler { get; set; }
 

--- a/test/Microsoft.AspNet.Authentication.Test/Cookies/CookieMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Cookies/CookieMiddlewareTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -443,19 +444,29 @@ namespace Microsoft.AspNet.Authentication.Cookies
             Assert.True(transaction1.SetCookie.Contains("path=/base"));
         }
 
-        [Fact]
-        public async Task CookieTurns401To403IfAuthenticated()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task CookieTurns401To403IfAuthenticated(bool automatic)
         {
             var clock = new TestClock();
             var server = CreateServer(options =>
             {
+                options.AutomaticAuthentication = automatic;
                 options.SystemClock = clock;
             }, 
             SignInAsAlice);
 
+            Debugger.Launch();
+
             var transaction1 = await SendAsync(server, "http://example.com/testpath");
 
-            var transaction2 = await SendAsync(server, "http://example.com/unauthorized", transaction1.CookieNameValue);
+            var url = "http://example.com/unauthorized";
+            if (automatic)
+            {
+                url += "auto";
+            }
+            var transaction2 = await SendAsync(server, url, transaction1.CookieNameValue);
 
             transaction2.Response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
         }
@@ -545,6 +556,11 @@ namespace Microsoft.AspNet.Authentication.Cookies
                     {
                         // Simulate Authorization failure 
                         var result = await context.Authentication.AuthenticateAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+                        context.Authentication.Challenge(CookieAuthenticationDefaults.AuthenticationScheme);
+                    }
+                    else if (req.Path == new PathString("/unauthorizedauto"))
+                    {
+                        // Simulate Authorization failure 
                         context.Authentication.Challenge(CookieAuthenticationDefaults.AuthenticationScheme);
                     }
                     else if (req.Path == new PathString("/protected/CustomRedirect"))

--- a/test/Microsoft.AspNet.Authentication.Test/Cookies/CookieMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Cookies/CookieMiddlewareTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -456,8 +455,6 @@ namespace Microsoft.AspNet.Authentication.Cookies
                 options.SystemClock = clock;
             }, 
             SignInAsAlice);
-
-            Debugger.Launch();
 
             var transaction1 = await SendAsync(server, "http://example.com/testpath");
 


### PR DESCRIPTION
Cookies was overriding the base impl of AuthenticateAsync so the flag wasn't getting set which made the 401-403 check fail...  

Definitely some smell here, filed https://github.com/aspnet/Security/issues/273 to fix

cc @blowdart @Tratcher @lodejard 