### PR TITLE
Fix invalid challenge in CookieAuthenticationHandler.ApplyResponseChallenge

### DIFF
--- a/src/Microsoft.AspNet.Authentication.Cookies/CookieAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.Cookies/CookieAuthenticationHandler.cs
@@ -363,29 +363,29 @@ namespace Microsoft.AspNet.Authentication.Cookies
                 return;
             }
 
-            var loginUri = string.Empty;
+            var redirectUri = string.Empty;
             if (ChallengeContext != null)
             {
-                loginUri = new AuthenticationProperties(ChallengeContext.Properties).RedirectUri;
+                redirectUri = new AuthenticationProperties(ChallengeContext.Properties).RedirectUri;
             }
 
             try
             {
-                if (string.IsNullOrWhiteSpace(loginUri))
+                if (string.IsNullOrWhiteSpace(redirectUri))
                 {
-                    var currentUri =
+                    redirectUri =
                         Request.PathBase +
                         Request.Path +
                         Request.QueryString;
-
-                    loginUri =
-                        Request.Scheme +
-                        "://" +
-                        Request.Host +
-                        Request.PathBase +
-                        Options.LoginPath +
-                        QueryString.Create(Options.ReturnUrlParameter, currentUri);
                 }
+
+                var loginUri =
+                    Request.Scheme +
+                    "://" +
+                    Request.Host +
+                    Request.PathBase +
+                    Options.LoginPath +
+                    QueryString.Create(Options.ReturnUrlParameter, redirectUri);
 
                 var redirectContext = new CookieApplyRedirectContext(Context, Options, loginUri);
                 Options.Notifications.ApplyRedirect(redirectContext);

--- a/test/Microsoft.AspNet.Authentication.Test/Cookies/CookieMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Cookies/CookieMiddlewareTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNet.Authentication.Cookies
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task ProtectedCustomRequestShouldRedirectToCustomLogin(bool auto)
+        public async Task ProtectedCustomRequestShouldRedirectToCustomRedirectUri(bool auto)
         {
             var server = CreateServer(options =>
             {
@@ -73,7 +73,7 @@ namespace Microsoft.AspNet.Authentication.Cookies
             if (auto)
             {
                 Uri location = transaction.Response.Headers.Location;
-                location.ToString().ShouldBe("/CustomRedirect");
+                location.ToString().ShouldBe("http://example.com/login?ReturnUrl=%2FCustomRedirect");
             }
         }
 


### PR DESCRIPTION
When @Tratcher implemented this feature request (http://katanaproject.codeplex.com/workitem/283) in Katana 3, he mixed up two different things: the login URL and the redirect URL. The ticket was actually only about being able to specify the second one via `AuthenticationProperties` but the commit (http://katanaproject.codeplex.com/SourceControl/changeset/693edfa8a4765076a99d6f578c2b71317535747f) added the ability to override the whole login URL (which is not really convenient and basically pointless as it's easier to redirect the user agent to another login URL using a good old 302 response than using `Challenge`).

/cc @HaoK @Tratcher 