### PR TITLE
AuthenticationHandler now fully Async, SignOut/SignIn/Challenge API changes 

### DIFF
--- a/Security.sln
+++ b/Security.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22605.0
+VisualStudioVersion = 14.0.22815.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{4D2B6A51-2F9F-44F5-8131-EA5CAC053652}"
 EndProject
@@ -45,6 +45,24 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.Authorization.Test", "test\Microsoft.AspNet.Authorization.Test\Microsoft.AspNet.Authorization.Test.xproj", "{7AF5AD96-EB6E-4D0E-8ABE-C0B543C0F4C2}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.Authorization", "src\Microsoft.AspNet.Authorization\Microsoft.AspNet.Authorization.xproj", "{6AB3E514-5894-4131-9399-DC7D5284ADDB}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.WebEncoders", "..\HttpAbstractions\src\Microsoft.Framework.WebEncoders\Microsoft.Framework.WebEncoders.xproj", "{DD2CE416-765E-4000-A03E-C2FF165DA1B6}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.Http", "..\HttpAbstractions\src\Microsoft.AspNet.Http\Microsoft.AspNet.Http.xproj", "{BCF0F967-8753-4438-BD07-AADCA9CE509A}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.Http.Extensions", "..\HttpAbstractions\src\Microsoft.AspNet.Http.Extensions\Microsoft.AspNet.Http.Extensions.xproj", "{CCC4363E-81E2-4058-94DD-00494E9E992A}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.WebEncoders.Core", "..\HttpAbstractions\src\Microsoft.Framework.WebEncoders.Core\Microsoft.Framework.WebEncoders.Core.xproj", "{BE9112CB-D87D-4080-9CC3-24492D49CBE6}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.FeatureModel", "..\HttpAbstractions\src\Microsoft.AspNet.FeatureModel\Microsoft.AspNet.FeatureModel.xproj", "{32A4C918-30EE-41DB-8E26-8A3BB88ED231}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.Http.Features", "..\HttpAbstractions\src\Microsoft.AspNet.Http.Features\Microsoft.AspNet.Http.Features.xproj", "{D9128247-8F97-48B8-A863-F1F21A029FCE}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.Http.Abstractions", "..\HttpAbstractions\src\Microsoft.AspNet.Http.Abstractions\Microsoft.AspNet.Http.Abstractions.xproj", "{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.WebUtilities", "..\HttpAbstractions\src\Microsoft.AspNet.WebUtilities\Microsoft.AspNet.WebUtilities.xproj", "{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Net.Http.Headers", "..\HttpAbstractions\src\Microsoft.Net.Http.Headers\Microsoft.Net.Http.Headers.xproj", "{60AA2FDB-8121-4826-8D00-9A143FEFAF66}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -242,6 +260,114 @@ Global
 		{6AB3E514-5894-4131-9399-DC7D5284ADDB}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{6AB3E514-5894-4131-9399-DC7D5284ADDB}.Release|x86.ActiveCfg = Release|Any CPU
 		{6AB3E514-5894-4131-9399-DC7D5284ADDB}.Release|x86.Build.0 = Release|Any CPU
+		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Debug|x86.Build.0 = Debug|Any CPU
+		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Release|x86.ActiveCfg = Release|Any CPU
+		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Release|x86.Build.0 = Release|Any CPU
+		{BCF0F967-8753-4438-BD07-AADCA9CE509A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BCF0F967-8753-4438-BD07-AADCA9CE509A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BCF0F967-8753-4438-BD07-AADCA9CE509A}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{BCF0F967-8753-4438-BD07-AADCA9CE509A}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{BCF0F967-8753-4438-BD07-AADCA9CE509A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BCF0F967-8753-4438-BD07-AADCA9CE509A}.Debug|x86.Build.0 = Debug|Any CPU
+		{BCF0F967-8753-4438-BD07-AADCA9CE509A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BCF0F967-8753-4438-BD07-AADCA9CE509A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BCF0F967-8753-4438-BD07-AADCA9CE509A}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{BCF0F967-8753-4438-BD07-AADCA9CE509A}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{BCF0F967-8753-4438-BD07-AADCA9CE509A}.Release|x86.ActiveCfg = Release|Any CPU
+		{BCF0F967-8753-4438-BD07-AADCA9CE509A}.Release|x86.Build.0 = Release|Any CPU
+		{CCC4363E-81E2-4058-94DD-00494E9E992A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CCC4363E-81E2-4058-94DD-00494E9E992A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CCC4363E-81E2-4058-94DD-00494E9E992A}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{CCC4363E-81E2-4058-94DD-00494E9E992A}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{CCC4363E-81E2-4058-94DD-00494E9E992A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CCC4363E-81E2-4058-94DD-00494E9E992A}.Debug|x86.Build.0 = Debug|Any CPU
+		{CCC4363E-81E2-4058-94DD-00494E9E992A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CCC4363E-81E2-4058-94DD-00494E9E992A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CCC4363E-81E2-4058-94DD-00494E9E992A}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{CCC4363E-81E2-4058-94DD-00494E9E992A}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{CCC4363E-81E2-4058-94DD-00494E9E992A}.Release|x86.ActiveCfg = Release|Any CPU
+		{CCC4363E-81E2-4058-94DD-00494E9E992A}.Release|x86.Build.0 = Release|Any CPU
+		{BE9112CB-D87D-4080-9CC3-24492D49CBE6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE9112CB-D87D-4080-9CC3-24492D49CBE6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE9112CB-D87D-4080-9CC3-24492D49CBE6}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{BE9112CB-D87D-4080-9CC3-24492D49CBE6}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{BE9112CB-D87D-4080-9CC3-24492D49CBE6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BE9112CB-D87D-4080-9CC3-24492D49CBE6}.Debug|x86.Build.0 = Debug|Any CPU
+		{BE9112CB-D87D-4080-9CC3-24492D49CBE6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE9112CB-D87D-4080-9CC3-24492D49CBE6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE9112CB-D87D-4080-9CC3-24492D49CBE6}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{BE9112CB-D87D-4080-9CC3-24492D49CBE6}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{BE9112CB-D87D-4080-9CC3-24492D49CBE6}.Release|x86.ActiveCfg = Release|Any CPU
+		{BE9112CB-D87D-4080-9CC3-24492D49CBE6}.Release|x86.Build.0 = Release|Any CPU
+		{32A4C918-30EE-41DB-8E26-8A3BB88ED231}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{32A4C918-30EE-41DB-8E26-8A3BB88ED231}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{32A4C918-30EE-41DB-8E26-8A3BB88ED231}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{32A4C918-30EE-41DB-8E26-8A3BB88ED231}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{32A4C918-30EE-41DB-8E26-8A3BB88ED231}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{32A4C918-30EE-41DB-8E26-8A3BB88ED231}.Debug|x86.Build.0 = Debug|Any CPU
+		{32A4C918-30EE-41DB-8E26-8A3BB88ED231}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{32A4C918-30EE-41DB-8E26-8A3BB88ED231}.Release|Any CPU.Build.0 = Release|Any CPU
+		{32A4C918-30EE-41DB-8E26-8A3BB88ED231}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{32A4C918-30EE-41DB-8E26-8A3BB88ED231}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{32A4C918-30EE-41DB-8E26-8A3BB88ED231}.Release|x86.ActiveCfg = Release|Any CPU
+		{32A4C918-30EE-41DB-8E26-8A3BB88ED231}.Release|x86.Build.0 = Release|Any CPU
+		{D9128247-8F97-48B8-A863-F1F21A029FCE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9128247-8F97-48B8-A863-F1F21A029FCE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9128247-8F97-48B8-A863-F1F21A029FCE}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{D9128247-8F97-48B8-A863-F1F21A029FCE}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{D9128247-8F97-48B8-A863-F1F21A029FCE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D9128247-8F97-48B8-A863-F1F21A029FCE}.Debug|x86.Build.0 = Debug|Any CPU
+		{D9128247-8F97-48B8-A863-F1F21A029FCE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9128247-8F97-48B8-A863-F1F21A029FCE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D9128247-8F97-48B8-A863-F1F21A029FCE}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{D9128247-8F97-48B8-A863-F1F21A029FCE}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{D9128247-8F97-48B8-A863-F1F21A029FCE}.Release|x86.ActiveCfg = Release|Any CPU
+		{D9128247-8F97-48B8-A863-F1F21A029FCE}.Release|x86.Build.0 = Release|Any CPU
+		{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}.Debug|x86.Build.0 = Debug|Any CPU
+		{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}.Release|x86.ActiveCfg = Release|Any CPU
+		{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}.Release|x86.Build.0 = Release|Any CPU
+		{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}.Debug|x86.Build.0 = Debug|Any CPU
+		{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}.Release|x86.ActiveCfg = Release|Any CPU
+		{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}.Release|x86.Build.0 = Release|Any CPU
+		{60AA2FDB-8121-4826-8D00-9A143FEFAF66}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{60AA2FDB-8121-4826-8D00-9A143FEFAF66}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{60AA2FDB-8121-4826-8D00-9A143FEFAF66}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{60AA2FDB-8121-4826-8D00-9A143FEFAF66}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{60AA2FDB-8121-4826-8D00-9A143FEFAF66}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{60AA2FDB-8121-4826-8D00-9A143FEFAF66}.Debug|x86.Build.0 = Debug|Any CPU
+		{60AA2FDB-8121-4826-8D00-9A143FEFAF66}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{60AA2FDB-8121-4826-8D00-9A143FEFAF66}.Release|Any CPU.Build.0 = Release|Any CPU
+		{60AA2FDB-8121-4826-8D00-9A143FEFAF66}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{60AA2FDB-8121-4826-8D00-9A143FEFAF66}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{60AA2FDB-8121-4826-8D00-9A143FEFAF66}.Release|x86.ActiveCfg = Release|Any CPU
+		{60AA2FDB-8121-4826-8D00-9A143FEFAF66}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Security.sln
+++ b/Security.sln
@@ -46,24 +46,6 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.Authorizat
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.Authorization", "src\Microsoft.AspNet.Authorization\Microsoft.AspNet.Authorization.xproj", "{6AB3E514-5894-4131-9399-DC7D5284ADDB}"
 EndProject
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.WebEncoders", "..\HttpAbstractions\src\Microsoft.Framework.WebEncoders\Microsoft.Framework.WebEncoders.xproj", "{DD2CE416-765E-4000-A03E-C2FF165DA1B6}"
-EndProject
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.Http", "..\HttpAbstractions\src\Microsoft.AspNet.Http\Microsoft.AspNet.Http.xproj", "{BCF0F967-8753-4438-BD07-AADCA9CE509A}"
-EndProject
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.Http.Extensions", "..\HttpAbstractions\src\Microsoft.AspNet.Http.Extensions\Microsoft.AspNet.Http.Extensions.xproj", "{CCC4363E-81E2-4058-94DD-00494E9E992A}"
-EndProject
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.WebEncoders.Core", "..\HttpAbstractions\src\Microsoft.Framework.WebEncoders.Core\Microsoft.Framework.WebEncoders.Core.xproj", "{BE9112CB-D87D-4080-9CC3-24492D49CBE6}"
-EndProject
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.FeatureModel", "..\HttpAbstractions\src\Microsoft.AspNet.FeatureModel\Microsoft.AspNet.FeatureModel.xproj", "{32A4C918-30EE-41DB-8E26-8A3BB88ED231}"
-EndProject
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.Http.Features", "..\HttpAbstractions\src\Microsoft.AspNet.Http.Features\Microsoft.AspNet.Http.Features.xproj", "{D9128247-8F97-48B8-A863-F1F21A029FCE}"
-EndProject
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.Http.Abstractions", "..\HttpAbstractions\src\Microsoft.AspNet.Http.Abstractions\Microsoft.AspNet.Http.Abstractions.xproj", "{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}"
-EndProject
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.WebUtilities", "..\HttpAbstractions\src\Microsoft.AspNet.WebUtilities\Microsoft.AspNet.WebUtilities.xproj", "{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}"
-EndProject
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Net.Http.Headers", "..\HttpAbstractions\src\Microsoft.Net.Http.Headers\Microsoft.Net.Http.Headers.xproj", "{60AA2FDB-8121-4826-8D00-9A143FEFAF66}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -260,114 +242,6 @@ Global
 		{6AB3E514-5894-4131-9399-DC7D5284ADDB}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{6AB3E514-5894-4131-9399-DC7D5284ADDB}.Release|x86.ActiveCfg = Release|Any CPU
 		{6AB3E514-5894-4131-9399-DC7D5284ADDB}.Release|x86.Build.0 = Release|Any CPU
-		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Debug|x86.Build.0 = Debug|Any CPU
-		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Release|x86.ActiveCfg = Release|Any CPU
-		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Release|x86.Build.0 = Release|Any CPU
-		{BCF0F967-8753-4438-BD07-AADCA9CE509A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BCF0F967-8753-4438-BD07-AADCA9CE509A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BCF0F967-8753-4438-BD07-AADCA9CE509A}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{BCF0F967-8753-4438-BD07-AADCA9CE509A}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{BCF0F967-8753-4438-BD07-AADCA9CE509A}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{BCF0F967-8753-4438-BD07-AADCA9CE509A}.Debug|x86.Build.0 = Debug|Any CPU
-		{BCF0F967-8753-4438-BD07-AADCA9CE509A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BCF0F967-8753-4438-BD07-AADCA9CE509A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BCF0F967-8753-4438-BD07-AADCA9CE509A}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{BCF0F967-8753-4438-BD07-AADCA9CE509A}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{BCF0F967-8753-4438-BD07-AADCA9CE509A}.Release|x86.ActiveCfg = Release|Any CPU
-		{BCF0F967-8753-4438-BD07-AADCA9CE509A}.Release|x86.Build.0 = Release|Any CPU
-		{CCC4363E-81E2-4058-94DD-00494E9E992A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{CCC4363E-81E2-4058-94DD-00494E9E992A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{CCC4363E-81E2-4058-94DD-00494E9E992A}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{CCC4363E-81E2-4058-94DD-00494E9E992A}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{CCC4363E-81E2-4058-94DD-00494E9E992A}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{CCC4363E-81E2-4058-94DD-00494E9E992A}.Debug|x86.Build.0 = Debug|Any CPU
-		{CCC4363E-81E2-4058-94DD-00494E9E992A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{CCC4363E-81E2-4058-94DD-00494E9E992A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{CCC4363E-81E2-4058-94DD-00494E9E992A}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{CCC4363E-81E2-4058-94DD-00494E9E992A}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{CCC4363E-81E2-4058-94DD-00494E9E992A}.Release|x86.ActiveCfg = Release|Any CPU
-		{CCC4363E-81E2-4058-94DD-00494E9E992A}.Release|x86.Build.0 = Release|Any CPU
-		{BE9112CB-D87D-4080-9CC3-24492D49CBE6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BE9112CB-D87D-4080-9CC3-24492D49CBE6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BE9112CB-D87D-4080-9CC3-24492D49CBE6}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{BE9112CB-D87D-4080-9CC3-24492D49CBE6}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{BE9112CB-D87D-4080-9CC3-24492D49CBE6}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{BE9112CB-D87D-4080-9CC3-24492D49CBE6}.Debug|x86.Build.0 = Debug|Any CPU
-		{BE9112CB-D87D-4080-9CC3-24492D49CBE6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BE9112CB-D87D-4080-9CC3-24492D49CBE6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BE9112CB-D87D-4080-9CC3-24492D49CBE6}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{BE9112CB-D87D-4080-9CC3-24492D49CBE6}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{BE9112CB-D87D-4080-9CC3-24492D49CBE6}.Release|x86.ActiveCfg = Release|Any CPU
-		{BE9112CB-D87D-4080-9CC3-24492D49CBE6}.Release|x86.Build.0 = Release|Any CPU
-		{32A4C918-30EE-41DB-8E26-8A3BB88ED231}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{32A4C918-30EE-41DB-8E26-8A3BB88ED231}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{32A4C918-30EE-41DB-8E26-8A3BB88ED231}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{32A4C918-30EE-41DB-8E26-8A3BB88ED231}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{32A4C918-30EE-41DB-8E26-8A3BB88ED231}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{32A4C918-30EE-41DB-8E26-8A3BB88ED231}.Debug|x86.Build.0 = Debug|Any CPU
-		{32A4C918-30EE-41DB-8E26-8A3BB88ED231}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{32A4C918-30EE-41DB-8E26-8A3BB88ED231}.Release|Any CPU.Build.0 = Release|Any CPU
-		{32A4C918-30EE-41DB-8E26-8A3BB88ED231}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{32A4C918-30EE-41DB-8E26-8A3BB88ED231}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{32A4C918-30EE-41DB-8E26-8A3BB88ED231}.Release|x86.ActiveCfg = Release|Any CPU
-		{32A4C918-30EE-41DB-8E26-8A3BB88ED231}.Release|x86.Build.0 = Release|Any CPU
-		{D9128247-8F97-48B8-A863-F1F21A029FCE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D9128247-8F97-48B8-A863-F1F21A029FCE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D9128247-8F97-48B8-A863-F1F21A029FCE}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{D9128247-8F97-48B8-A863-F1F21A029FCE}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{D9128247-8F97-48B8-A863-F1F21A029FCE}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{D9128247-8F97-48B8-A863-F1F21A029FCE}.Debug|x86.Build.0 = Debug|Any CPU
-		{D9128247-8F97-48B8-A863-F1F21A029FCE}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D9128247-8F97-48B8-A863-F1F21A029FCE}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D9128247-8F97-48B8-A863-F1F21A029FCE}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{D9128247-8F97-48B8-A863-F1F21A029FCE}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{D9128247-8F97-48B8-A863-F1F21A029FCE}.Release|x86.ActiveCfg = Release|Any CPU
-		{D9128247-8F97-48B8-A863-F1F21A029FCE}.Release|x86.Build.0 = Release|Any CPU
-		{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}.Debug|x86.Build.0 = Debug|Any CPU
-		{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}.Release|Any CPU.Build.0 = Release|Any CPU
-		{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}.Release|x86.ActiveCfg = Release|Any CPU
-		{22071333-15BA-4D16-A1D5-4D5B1A83FBDD}.Release|x86.Build.0 = Release|Any CPU
-		{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}.Debug|x86.Build.0 = Debug|Any CPU
-		{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}.Release|x86.ActiveCfg = Release|Any CPU
-		{A2FB7838-0031-4FAD-BA3E-83C30B3AF406}.Release|x86.Build.0 = Release|Any CPU
-		{60AA2FDB-8121-4826-8D00-9A143FEFAF66}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{60AA2FDB-8121-4826-8D00-9A143FEFAF66}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{60AA2FDB-8121-4826-8D00-9A143FEFAF66}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{60AA2FDB-8121-4826-8D00-9A143FEFAF66}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{60AA2FDB-8121-4826-8D00-9A143FEFAF66}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{60AA2FDB-8121-4826-8D00-9A143FEFAF66}.Debug|x86.Build.0 = Debug|Any CPU
-		{60AA2FDB-8121-4826-8D00-9A143FEFAF66}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{60AA2FDB-8121-4826-8D00-9A143FEFAF66}.Release|Any CPU.Build.0 = Release|Any CPU
-		{60AA2FDB-8121-4826-8D00-9A143FEFAF66}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{60AA2FDB-8121-4826-8D00-9A143FEFAF66}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{60AA2FDB-8121-4826-8D00-9A143FEFAF66}.Release|x86.ActiveCfg = Release|Any CPU
-		{60AA2FDB-8121-4826-8D00-9A143FEFAF66}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/CookieSample/Startup.cs
+++ b/samples/CookieSample/Startup.cs
@@ -28,7 +28,7 @@ namespace CookieSample
                 if (string.IsNullOrEmpty(context.User.Identity.Name))
                 {
                     var user = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, "bob") }));
-                    context.Authentication.SignIn(CookieAuthenticationDefaults.AuthenticationScheme, user);
+                    await context.Authentication.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, user);
                     context.Response.ContentType = "text/plain";
                     await context.Response.WriteAsync("Hello First timer");
                     return;

--- a/samples/CookieSessionSample/Startup.cs
+++ b/samples/CookieSessionSample/Startup.cs
@@ -36,7 +36,7 @@ namespace CookieSessionSample
                     {
                         claims.Add(new Claim(ClaimTypes.Role, "SomeRandomGroup" + i, ClaimValueTypes.String, "IssuedByBob", "OriginalIssuerJoe"));
                     }
-                    context.Authentication.SignIn(CookieAuthenticationDefaults.AuthenticationScheme, new ClaimsPrincipal(new ClaimsIdentity(claims)));
+                    await context.Authentication.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, new ClaimsPrincipal(new ClaimsIdentity(claims)));
                     context.Response.ContentType = "text/plain";
                     await context.Response.WriteAsync("Hello First timer");
                     return;

--- a/samples/OpenIdConnectSample/Startup.cs
+++ b/samples/OpenIdConnectSample/Startup.cs
@@ -40,7 +40,7 @@ namespace OpenIdConnectSample
             {
                 if (string.IsNullOrEmpty(context.User.Identity.Name))
                 {
-                    context.Authentication.Challenge(OpenIdConnectAuthenticationDefaults.AuthenticationScheme, new AuthenticationProperties { RedirectUri = "/" });
+                    await context.Authentication.ChallengeAsync(OpenIdConnectAuthenticationDefaults.AuthenticationScheme, new AuthenticationProperties { RedirectUri = "/" });
 
                     context.Response.ContentType = "text/plain";
                     await context.Response.WriteAsync("Hello First timer");

--- a/samples/SocialSample/Startup.cs
+++ b/samples/SocialSample/Startup.cs
@@ -187,7 +187,7 @@ namespace CookieSample
                     {
                         // By default the client will be redirect back to the URL that issued the challenge (/login?authtype=foo),
                         // send them to the home page instead (/).
-                        context.Authentication.Challenge(authType, new AuthenticationProperties() { RedirectUri = "/" });
+                        await context.Authentication.ChallengeAsync(authType, new AuthenticationProperties() { RedirectUri = "/" });
                         return;
                     }
 
@@ -207,7 +207,7 @@ namespace CookieSample
             {
                 signoutApp.Run(async context =>
                 {
-                    context.Authentication.SignOut(CookieAuthenticationDefaults.AuthenticationScheme);
+                    await context.Authentication.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
                     context.Response.ContentType = "text/html";
                     await context.Response.WriteAsync("<html><body>");
                     await context.Response.WriteAsync("You have been logged out. Goodbye " + context.User.Identity.Name + "<br>");
@@ -222,7 +222,7 @@ namespace CookieSample
                 if (string.IsNullOrEmpty(context.User.Identity.Name))
                 {
                     // The cookie middleware will intercept this 401 and redirect to /login
-                    context.Authentication.Challenge();
+                    await context.Authentication.ChallengeAsync();
                     return;
                 }
                 await next();

--- a/src/Microsoft.AspNet.Authentication.Cookies/CookieAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.Cookies/CookieAuthenticationHandler.cs
@@ -176,7 +176,7 @@ namespace Microsoft.AspNet.Authentication.Cookies
         protected override async Task FinishResponseAsync()
         {
             // Only renew if requested, and neither sign in or sign out was called
-            if (!_shouldRenew || SignInCalled || SignOutCalled)
+            if (!_shouldRenew || SignInAccepted || SignOutAccepted)
             {
                 return;
             }

--- a/src/Microsoft.AspNet.Authentication.Cookies/CookieAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.Cookies/CookieAuthenticationHandler.cs
@@ -172,10 +172,10 @@ namespace Microsoft.AspNet.Authentication.Cookies
                 HeaderValueMinusOne);
         }
 
-        protected override async Task TeardownCoreAsync()
+        protected override async Task ApplyResponseStartingAsync()
         {
             // Only renew if requested, and neither sign in or sign out was called
-            if (!_shouldRenew || !SignInCalled || SignOutCalled)
+            if (!_shouldRenew || SignInCalled || SignOutCalled)
             {
                 return;
             }

--- a/src/Microsoft.AspNet.Authentication.OAuth/OAuthAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.OAuth/OAuthAuthenticationHandler.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNet.Authentication.OAuth
 
             if (context.SignInScheme != null && context.Principal != null)
             {
-                Context.Authentication.SignIn(context.SignInScheme, context.Principal, context.Properties);
+                await Context.Authentication.SignInAsync(context.SignInScheme, context.Principal, context.Properties);
             }
 
             if (!context.IsRequestCompleted && context.RedirectUri != null)
@@ -72,12 +72,7 @@ namespace Microsoft.AspNet.Authentication.OAuth
             return context.IsRequestCompleted;
         }
 
-        protected override AuthenticationTicket AuthenticateCore()
-        {
-            return AuthenticateCoreAsync().GetAwaiter().GetResult();
-        }
-
-        protected override async Task<AuthenticationTicket> AuthenticateCoreAsync()
+        public override async Task<AuthenticationTicket> AuthenticateAsync()
         {
             AuthenticationProperties properties = null;
             try
@@ -168,18 +163,18 @@ namespace Microsoft.AspNet.Authentication.OAuth
             return new AuthenticationTicket(context.Principal, context.Properties, Options.AuthenticationScheme);
         }
 
-        protected override void ApplyResponseChallenge()
+        protected override Task ApplyResponseChallengeAsync()
         {
             // REVIEW: do we need this 401 check?
             if (Response.StatusCode != 401)
             {
-                return;
+                return Task.FromResult(0);
             }
 
             // When Automatic should redirect on 401 even if there wasn't an explicit challenge.
             if (ChallengeContext == null && !Options.AutomaticAuthentication)
             {
-                return;
+                return Task.FromResult(0);
             }
 
             var baseUri = Request.Scheme + "://" + Request.Host + Request.PathBase;
@@ -209,6 +204,7 @@ namespace Microsoft.AspNet.Authentication.OAuth
                 Context, Options,
                 properties, authorizationEndpoint);
             Options.Notifications.ApplyRedirect(redirectContext);
+            return Task.FromResult(0);
         }
 
         protected virtual string BuildChallengeUrl(AuthenticationProperties properties, string redirectUri)
@@ -234,9 +230,10 @@ namespace Microsoft.AspNet.Authentication.OAuth
             return string.Join(" ", Options.Scope);
         }
 
-        protected override void ApplyResponseGrant()
+        protected override Task ApplyResponseGrantAsync()
         {
             // N/A - No SignIn or SignOut support.
+            return Task.FromResult(0);
         }
     }
 }

--- a/src/Microsoft.AspNet.Authentication.OAuth/OAuthAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.OAuth/OAuthAuthenticationHandler.cs
@@ -229,11 +229,5 @@ namespace Microsoft.AspNet.Authentication.OAuth
             // OAuth2 3.3 space separated
             return string.Join(" ", Options.Scope);
         }
-
-        protected override Task ApplyResponseGrantAsync()
-        {
-            // N/A - No SignIn or SignOut support.
-            return Task.FromResult(0);
-        }
     }
 }

--- a/src/Microsoft.AspNet.Authentication.OAuthBearer/OAuthBearerAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.OAuthBearer/OAuthBearerAuthenticationHandler.cs
@@ -175,22 +175,11 @@ namespace Microsoft.AspNet.Authentication.OAuthBearer
             }
         }
 
-        protected override async Task HandleUnauthorizedAsync(ChallengeContext context)
+        protected override async Task<bool> HandleUnauthorizedAsync(ChallengeContext context)
         {
-            await base.HandleUnauthorizedAsync(context);
-
-            // REVIEW: GROSS!! See if we can remove this
+            Response.StatusCode = 401;
             await Options.Notifications.ApplyChallenge(new AuthenticationChallengeNotification<OAuthBearerAuthenticationOptions>(Context, Options));
-        }
-
-        protected override async Task ApplyResponseChallengeAsync()
-        {
-            if ((Response.StatusCode != 401) || (ChallengeContext == null && !Options.AutomaticAuthentication))
-            {
-                return;
-            }
-
-            await Options.Notifications.ApplyChallenge(new AuthenticationChallengeNotification<OAuthBearerAuthenticationOptions>(Context, Options));
+            return true;
         }
     }
 }

--- a/src/Microsoft.AspNet.Authentication.OAuthBearer/OAuthBearerAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.OAuthBearer/OAuthBearerAuthenticationHandler.cs
@@ -192,11 +192,5 @@ namespace Microsoft.AspNet.Authentication.OAuthBearer
 
             await Options.Notifications.ApplyChallenge(new AuthenticationChallengeNotification<OAuthBearerAuthenticationOptions>(Context, Options));
         }
-
-        protected override Task ApplyResponseGrantAsync()
-        {
-            // N/A
-            return Task.FromResult(0);
-        }
     }
 }

--- a/src/Microsoft.AspNet.Authentication.OAuthBearer/OAuthBearerAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.OAuthBearer/OAuthBearerAuthenticationHandler.cs
@@ -20,16 +20,11 @@ namespace Microsoft.AspNet.Authentication.OAuthBearer
     {
         private OpenIdConnectConfiguration _configuration;
 
-        protected override AuthenticationTicket AuthenticateCore()
-        {
-            return AuthenticateCoreAsync().GetAwaiter().GetResult();
-        }
-
         /// <summary>
         /// Searches the 'Authorization' header for a 'Bearer' token. If the 'Bearer' token is found, it is validated using <see cref="TokenValidationParameters"/> set in the options.
         /// </summary>
         /// <returns></returns>
-        protected override async Task<AuthenticationTicket> AuthenticateCoreAsync()
+        public override async Task<AuthenticationTicket> AuthenticateAsync()
         {
             string token = null;
             try
@@ -180,18 +175,12 @@ namespace Microsoft.AspNet.Authentication.OAuthBearer
             }
         }
 
-        protected override void HandleUnauthorized(ChallengeContext context)
+        protected override async Task HandleUnauthorizedAsync(ChallengeContext context)
         {
-            base.HandleUnauthorized(context);
+            await base.HandleUnauthorizedAsync(context);
 
             // REVIEW: GROSS!! See if we can remove this
-            Options.Notifications.ApplyChallenge(new AuthenticationChallengeNotification<OAuthBearerAuthenticationOptions>(Context, Options))
-                .GetAwaiter().GetResult();
-        }
-
-        protected override void ApplyResponseChallenge()
-        {
-            ApplyResponseChallengeAsync().GetAwaiter().GetResult();
+            await Options.Notifications.ApplyChallenge(new AuthenticationChallengeNotification<OAuthBearerAuthenticationOptions>(Context, Options));
         }
 
         protected override async Task ApplyResponseChallengeAsync()
@@ -204,9 +193,10 @@ namespace Microsoft.AspNet.Authentication.OAuthBearer
             await Options.Notifications.ApplyChallenge(new AuthenticationChallengeNotification<OAuthBearerAuthenticationOptions>(Context, Options));
         }
 
-        protected override void ApplyResponseGrant()
+        protected override Task ApplyResponseGrantAsync()
         {
             // N/A
+            return Task.FromResult(0);
         }
     }
 }

--- a/src/Microsoft.AspNet.Authentication.OpenIdConnect/OpenIdConnectAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.OpenIdConnect/OpenIdConnectAuthenticationHandler.cs
@@ -110,13 +110,6 @@ namespace Microsoft.AspNet.Authentication.OpenIdConnect
         {
             Logger.LogDebug(Resources.OIDCH_0026_ApplyResponseChallengeAsync, this.GetType());
 
-            if (ShouldConvertChallengeToForbidden())
-            {
-                Logger.LogDebug(Resources.OIDCH_0027_401_ConvertedTo_403);
-                Response.StatusCode = 403;
-                return;
-            }
-
             if (Response.StatusCode != 401)
             {
                 Logger.LogDebug(Resources.OIDCH_0028_StatusCodeNot401, Response.StatusCode);

--- a/src/Microsoft.AspNet.Authentication.OpenIdConnect/OpenIdConnectAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.OpenIdConnect/OpenIdConnectAuthenticationHandler.cs
@@ -38,11 +38,6 @@ namespace Microsoft.AspNet.Authentication.OpenIdConnect
             }
         }
 
-        protected override void ApplyResponseGrant()
-        {
-            ApplyResponseGrantAsync().GetAwaiter().GetResult();
-        }
-
         /// <summary>
         /// Handles Signout
         /// </summary>
@@ -94,11 +89,6 @@ namespace Microsoft.AspNet.Authentication.OpenIdConnect
                     Response.Redirect(redirectUri);
                 }
             }
-        }
-
-        protected override void ApplyResponseChallenge()
-        {
-            ApplyResponseChallengeAsync().GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -219,17 +209,12 @@ namespace Microsoft.AspNet.Authentication.OpenIdConnect
             Response.Redirect(redirectUri);
         }
 
-        protected override AuthenticationTicket AuthenticateCore()
-        {
-            return AuthenticateCoreAsync().GetAwaiter().GetResult();
-        }
-
         /// <summary>
         /// Invoked to process incoming OpenIdConnect messages.
         /// </summary>
         /// <returns>An <see cref="AuthenticationTicket"/> if successful.</returns>
         /// <remarks>Uses log id's OIDCH-0000 - OIDCH-0025</remarks>
-        protected override async Task<AuthenticationTicket> AuthenticateCoreAsync()
+        public override async Task<AuthenticationTicket> AuthenticateAsync()
         {
             Logger.LogDebug(Resources.OIDCH_0000_AuthenticateCoreAsync, this.GetType());
 
@@ -625,7 +610,7 @@ namespace Microsoft.AspNet.Authentication.OpenIdConnect
             {
                 if (ticket.Principal != null)
                 {
-                    Request.HttpContext.Authentication.SignIn(Options.SignInScheme, ticket.Principal, ticket.Properties);
+                    await Request.HttpContext.Authentication.SignInAsync(Options.SignInScheme, ticket.Principal, ticket.Properties);
                 }
 
                 // Redirect back to the original secured resource, if any.

--- a/src/Microsoft.AspNet.Authentication.OpenIdConnect/OpenIdConnectAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.OpenIdConnect/OpenIdConnectAuthenticationHandler.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNet.Authentication.Notifications;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Authentication;
+using Microsoft.AspNet.Http.Features.Authentication;
 using Microsoft.Framework.Logging;
 using Microsoft.IdentityModel.Protocols;
 
@@ -42,9 +43,8 @@ namespace Microsoft.AspNet.Authentication.OpenIdConnect
         /// Handles Signout
         /// </summary>
         /// <returns></returns>
-        protected override async Task ApplyResponseGrantAsync()
+        protected override async Task HandleSignOutAsync(SignOutContext signout)
         {
-            var signout = SignOutContext;
             if (signout != null)
             {
                 if (_configuration == null && Options.ConfigurationManager != null)

--- a/src/Microsoft.AspNet.Authentication.Twitter/TwitterAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.Twitter/TwitterAuthenticationHandler.cs
@@ -128,11 +128,7 @@ namespace Microsoft.AspNet.Authentication.Twitter
 
         protected override async Task ApplyResponseChallengeAsync()
         {
-            if (ShouldConvertChallengeToForbidden())
-            {
-                Response.StatusCode = 403;
-                return;
-            }
+            // REVIEW: should we check if status code is 401?
 
             if (Response.StatusCode != 401)
             {

--- a/src/Microsoft.AspNet.Authentication.Twitter/TwitterAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.Twitter/TwitterAuthenticationHandler.cs
@@ -42,12 +42,7 @@ namespace Microsoft.AspNet.Authentication.Twitter
             return false;
         }
 
-        protected override AuthenticationTicket AuthenticateCore()
-        {
-            return AuthenticateCoreAsync().GetAwaiter().GetResult();
-        }
-
-        protected override async Task<AuthenticationTicket> AuthenticateCoreAsync()
+        public override async Task<AuthenticationTicket> AuthenticateAsync()
         {
             AuthenticationProperties properties = null;
             try
@@ -121,11 +116,6 @@ namespace Microsoft.AspNet.Authentication.Twitter
                 return new AuthenticationTicket(properties, Options.AuthenticationScheme);
             }
         }
-        protected override void ApplyResponseChallenge()
-        {
-            ApplyResponseChallengeAsync().GetAwaiter().GetResult();
-        }
-
         protected override async Task ApplyResponseChallengeAsync()
         {
             // REVIEW: should we check if status code is 401?
@@ -204,7 +194,7 @@ namespace Microsoft.AspNet.Authentication.Twitter
 
             if (context.SignInScheme != null && context.Principal != null)
             {
-                Context.Authentication.SignIn(context.SignInScheme, context.Principal, context.Properties);
+                await Context.Authentication.SignInAsync(context.SignInScheme, context.Principal, context.Properties);
             }
 
             if (!context.IsRequestCompleted && context.RedirectUri != null)
@@ -377,9 +367,10 @@ namespace Microsoft.AspNet.Authentication.Twitter
             }
         }
 
-        protected override void ApplyResponseGrant()
+        protected override Task ApplyResponseGrantAsync()
         {
             // N/A - No SignIn or SignOut support.
+            return Task.FromResult(0);
         }
     }
 }

--- a/src/Microsoft.AspNet.Authentication.Twitter/TwitterAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.Twitter/TwitterAuthenticationHandler.cs
@@ -366,11 +366,5 @@ namespace Microsoft.AspNet.Authentication.Twitter
                 return Convert.ToBase64String(hash);
             }
         }
-
-        protected override Task ApplyResponseGrantAsync()
-        {
-            // N/A - No SignIn or SignOut support.
-            return Task.FromResult(0);
-        }
     }
 }

--- a/src/Microsoft.AspNet.Authentication/AuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication/AuthenticationHandler.cs
@@ -328,6 +328,12 @@ namespace Microsoft.AspNet.Authentication
             return Task.FromResult(0);
         }
 
+        public virtual bool ShouldHandleScheme(string authenticationScheme)
+        {
+            return string.Equals(BaseOptions.AuthenticationScheme, authenticationScheme, StringComparison.Ordinal) ||
+                (BaseOptions.AutomaticAuthentication && string.IsNullOrWhiteSpace(authenticationScheme));
+        }
+
         public virtual void SignIn(SignInContext context)
         {
             if (ShouldHandleScheme(context.AuthenticationScheme))
@@ -412,19 +418,17 @@ namespace Microsoft.AspNet.Authentication
             }
         }
 
-        private void ApplyResponseChallengeOnce()
+        /// <summary>
+        /// Calls ApplyResponseChallenge at most once (via this method)
+        /// </summary>
+        /// <returns></returns>
+        protected void ApplyResponseChallengeOnce()
         {
             if (!_challengeApplied)
             {
                 ApplyResponseChallenge();
                 _challengeApplied = true;
             }
-        }
-
-        public virtual bool ShouldHandleScheme(string authenticationScheme)
-        {
-            return string.Equals(BaseOptions.AuthenticationScheme, authenticationScheme, StringComparison.Ordinal) ||
-                (BaseOptions.AutomaticAuthentication && string.IsNullOrWhiteSpace(authenticationScheme));
         }
 
         /// <summary>
@@ -447,7 +451,11 @@ namespace Microsoft.AspNet.Authentication
             return Task.FromResult(0);
         }
 
-        private async Task ApplyResponseChallengeOnceAsync()
+        /// <summary>
+        /// Calls ApplyResponseChallenge at most once (via this method)
+        /// </summary>
+        /// <returns></returns>
+        protected async Task ApplyResponseChallengeOnceAsync()
         {
             if (!_challengeApplied)
             {

--- a/src/Microsoft.AspNet.Authentication/AuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication/AuthenticationHandler.cs
@@ -400,22 +400,17 @@ namespace Microsoft.AspNet.Authentication
 
         public virtual void Challenge(ChallengeContext context)
         {
-            ProcessChallenge(context);
-
-            if (PriorHandler != null)
-            {
-                PriorHandler.Challenge(context);
-            }
-        }
-
-        protected virtual void ProcessChallenge(ChallengeContext context)
-        {
             if (ShouldHandleScheme(context.AuthenticationScheme))
             {
                 ChallengeContext = context;
                 HandleChallenge(context);
                 ChallengeCalled = true;
                 context.Accept();
+            }
+
+            if (PriorHandler != null)
+            {
+                PriorHandler.Challenge(context);
             }
         }
 
@@ -434,16 +429,6 @@ namespace Microsoft.AspNet.Authentication
             return string.Equals(BaseOptions.AuthenticationScheme, authenticationScheme, StringComparison.Ordinal) ||
                 (BaseOptions.AutomaticAuthentication && string.IsNullOrWhiteSpace(authenticationScheme));
         }
-
-        //protected virtual bool ShouldConvertChallengeToForbidden()
-        //{
-        //    // Return 403 iff 401 and this handler's authenticate was called
-        //    // and the challenge is for the authentication type
-        //    return Response.StatusCode == 401 &&
-        //        AuthenticateCalled &&
-        //        ChallengeContext != null &&
-        //        ShouldHandleScheme(ChallengeContext.AuthenticationScheme);
-        //}
 
         /// <summary>
         /// Override this method to deal with 401 challenge concerns, if an authentication scheme in question

--- a/src/Microsoft.AspNet.Authentication/AuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication/AuthenticationHandler.cs
@@ -95,7 +95,17 @@ namespace Microsoft.AspNet.Authentication
         private static void OnSendingHeaderCallback(object state)
         {
             var handler = (AuthenticationHandler)state;
+            handler.ApplyResponseStartingAsync().GetAwaiter().GetResult();
             handler.ApplyResponseChallengeOnceAsync().GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Hook that is called when the response about to be sent
+        /// </summary>
+        /// <returns></returns>
+        protected virtual Task ApplyResponseStartingAsync()
+        {
+            return Task.FromResult(0);
         }
 
         protected virtual Task InitializeCoreAsync()
@@ -221,13 +231,10 @@ namespace Microsoft.AspNet.Authentication
                 await PriorHandler.SignInAsync(context);
             }
         }
-
-        // REVIEW: We could just use SignInContext property instead of parameter
         protected virtual Task HandleSignInAsync(SignInContext context)
         {
             return Task.FromResult(0);
         }
-
 
         public virtual async Task SignOutAsync(SignOutContext context)
         {

--- a/src/Microsoft.AspNet.Authentication/AuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication/AuthenticationHandler.cs
@@ -24,8 +24,8 @@ namespace Microsoft.AspNet.Authentication
         private bool _finishCalled;
         private AuthenticationOptions _baseOptions;
 
-        protected bool SignInCalled { get; set; }
-        protected bool SignOutCalled { get; set; }
+        protected bool SignInAccepted { get; set; }
+        protected bool SignOutAccepted { get; set; }
         protected bool ChallengeCalled { get; set; }
 
         protected HttpContext Context { get; private set; }
@@ -53,8 +53,6 @@ namespace Microsoft.AspNet.Authentication
 
         public IAuthenticationHandler PriorHandler { get; set; }
 
-        public bool Faulted { get; set; }
-
         protected async Task BaseInitializeAsync([NotNull] AuthenticationOptions options, [NotNull] HttpContext context, [NotNull] ILogger logger, [NotNull] IUrlEncoder encoder)
         {
             _baseOptions = options;
@@ -65,7 +63,7 @@ namespace Microsoft.AspNet.Authentication
 
             RegisterAuthenticationHandler();
 
-            Response.OnResponseStarting(OnResponseStartingCallback, this);
+            Response.OnResponseStarting(OnResponseStartingCallback);
 
             if (BaseOptions.AutomaticAuthentication)
             {
@@ -77,10 +75,10 @@ namespace Microsoft.AspNet.Authentication
             }
         }
 
-        private static async Task OnResponseStartingCallback(object state)
+        private async Task OnResponseStartingCallback()
         {
-            var handler = (AuthenticationHandler)state;
-            await handler.FinishResponseOnce();
+            //var handler = (AuthenticationHandler)state;
+            await FinishResponseOnce();
         }
 
         private async Task FinishResponseOnce()
@@ -184,7 +182,7 @@ namespace Microsoft.AspNet.Authentication
         {
             if (ShouldHandleScheme(context.AuthenticationScheme))
             {
-                SignInCalled = true;
+                SignInAccepted = true;
                 await HandleSignInAsync(context);
                 context.Accept();
             }
@@ -204,7 +202,7 @@ namespace Microsoft.AspNet.Authentication
         {
             if (ShouldHandleScheme(context.AuthenticationScheme))
             {
-                SignOutCalled = true;
+                SignOutAccepted = true;
                 await HandleSignOutAsync(context);
                 context.Accept();
             }

--- a/src/Microsoft.AspNet.Authentication/AuthenticationMiddleware.cs
+++ b/src/Microsoft.AspNet.Authentication/AuthenticationMiddleware.cs
@@ -67,7 +67,6 @@ namespace Microsoft.AspNet.Authentication
             {
                 try
                 {
-                    handler.Faulted = true;
                     await handler.TeardownAsync();
                 }
                 catch (Exception)

--- a/src/Microsoft.AspNet.Authentication/ClaimsTransformationAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication/ClaimsTransformationAuthenticationHandler.cs
@@ -39,15 +39,6 @@ namespace Microsoft.AspNet.Authentication
 
         }
 
-        public void Authenticate(AuthenticateContext context)
-        {
-            if (PriorHandler != null)
-            {
-                PriorHandler.Authenticate(context);
-                ApplyTransform(context);
-            }
-        }
-
         public async Task AuthenticateAsync(AuthenticateContext context)
         {
             if (PriorHandler != null)
@@ -57,12 +48,13 @@ namespace Microsoft.AspNet.Authentication
             }
         }
 
-        public void Challenge(ChallengeContext context)
+        public Task ChallengeAsync(ChallengeContext context)
         {
             if (PriorHandler != null)
             {
-                PriorHandler.Challenge(context);
+                return PriorHandler.ChallengeAsync(context);
             }
+            return Task.FromResult(0);
         }
 
         public void GetDescriptions(DescribeSchemesContext context)
@@ -73,20 +65,22 @@ namespace Microsoft.AspNet.Authentication
             }
         }
 
-        public void SignIn(SignInContext context)
+        public Task SignInAsync(SignInContext context)
         {
             if (PriorHandler != null)
             {
-                PriorHandler.SignIn(context);
+                return PriorHandler.SignInAsync(context);
             }
+            return Task.FromResult(0);
         }
 
-        public void SignOut(SignOutContext context)
+        public Task SignOutAsync(SignOutContext context)
         {
             if (PriorHandler != null)
             {
-                PriorHandler.SignOut(context);
+                return PriorHandler.SignOutAsync(context);
             }
+            return Task.FromResult(0);
         }
 
         public void RegisterAuthenticationHandler(IHttpAuthenticationFeature auth)

--- a/test/Microsoft.AspNet.Authentication.Test/AuthenticationHandlerFacts.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/AuthenticationHandlerFacts.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.AspNet.Http.Internal;
 using Microsoft.Framework.Logging;
 using Xunit;
@@ -59,17 +60,17 @@ namespace Microsoft.AspNet.Authentication
                 Options.AuthenticationScheme = scheme;
             }
 
-            protected override void ApplyResponseChallenge()
+            public override Task<AuthenticationTicket> AuthenticateAsync()
             {
                 throw new NotImplementedException();
             }
 
-            protected override void ApplyResponseGrant()
+            protected override Task ApplyResponseChallengeAsync()
             {
                 throw new NotImplementedException();
             }
 
-            protected override AuthenticationTicket AuthenticateCore()
+            protected override Task ApplyResponseGrantAsync()
             {
                 throw new NotImplementedException();
             }
@@ -94,17 +95,17 @@ namespace Microsoft.AspNet.Authentication
                 Options.AutomaticAuthentication = auto;
             }
 
-            protected override void ApplyResponseChallenge()
+            public override Task<AuthenticationTicket> AuthenticateAsync()
             {
                 throw new NotImplementedException();
             }
 
-            protected override void ApplyResponseGrant()
+            protected override Task ApplyResponseChallengeAsync()
             {
                 throw new NotImplementedException();
             }
 
-            protected override AuthenticationTicket AuthenticateCore()
+            protected override Task ApplyResponseGrantAsync()
             {
                 throw new NotImplementedException();
             }

--- a/test/Microsoft.AspNet.Authentication.Test/AuthenticationHandlerFacts.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/AuthenticationHandlerFacts.cs
@@ -69,11 +69,6 @@ namespace Microsoft.AspNet.Authentication
             {
                 throw new NotImplementedException();
             }
-
-            protected override Task ApplyResponseGrantAsync()
-            {
-                throw new NotImplementedException();
-            }
         }
 
         private class TestOptions : AuthenticationOptions { }
@@ -101,11 +96,6 @@ namespace Microsoft.AspNet.Authentication
             }
 
             protected override Task ApplyResponseChallengeAsync()
-            {
-                throw new NotImplementedException();
-            }
-
-            protected override Task ApplyResponseGrantAsync()
             {
                 throw new NotImplementedException();
             }

--- a/test/Microsoft.AspNet.Authentication.Test/AuthenticationHandlerFacts.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/AuthenticationHandlerFacts.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Http.Features.Authentication;
 using Microsoft.AspNet.Http.Internal;
 using Microsoft.Framework.Logging;
 using Xunit;
@@ -64,11 +65,6 @@ namespace Microsoft.AspNet.Authentication
             {
                 throw new NotImplementedException();
             }
-
-            protected override Task ApplyResponseChallengeAsync()
-            {
-                throw new NotImplementedException();
-            }
         }
 
         private class TestOptions : AuthenticationOptions { }
@@ -91,11 +87,6 @@ namespace Microsoft.AspNet.Authentication
             }
 
             public override Task<AuthenticationTicket> AuthenticateAsync()
-            {
-                throw new NotImplementedException();
-            }
-
-            protected override Task ApplyResponseChallengeAsync()
             {
                 throw new NotImplementedException();
             }

--- a/test/Microsoft.AspNet.Authentication.Test/Cookies/CookieMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Cookies/CookieMiddlewareTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;

--- a/test/Microsoft.AspNet.Authentication.Test/Cookies/CookieMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Cookies/CookieMiddlewareTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -71,7 +70,8 @@ namespace Microsoft.AspNet.Authentication.Cookies
 
             var transaction = await SendAsync(server, "http://example.com/protected/CustomRedirect");
 
-            transaction.Response.StatusCode.ShouldBe(auto ? HttpStatusCode.Redirect : HttpStatusCode.Unauthorized);
+            // REVIEW: Now when Cookies are not in auto, noone handles the challenge so the Status stays OK, is that reasonable??
+            transaction.Response.StatusCode.ShouldBe(auto ? HttpStatusCode.Redirect : HttpStatusCode.OK);
             if (auto)
             {
                 var location = transaction.Response.Headers.Location;

--- a/test/Microsoft.AspNet.Authentication.Test/Cookies/CookieMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Cookies/CookieMiddlewareTests.cs
@@ -80,24 +80,21 @@ namespace Microsoft.AspNet.Authentication.Cookies
 
         private Task SignInAsAlice(HttpContext context)
         {
-            context.Authentication.SignIn("Cookies",
+            return context.Authentication.SignInAsync("Cookies",
                 new ClaimsPrincipal(new ClaimsIdentity(new GenericIdentity("Alice", "Cookies"))),
                 new AuthenticationProperties());
-            return Task.FromResult<object>(null);
         }
 
         private Task SignInAsWrong(HttpContext context)
         {
-            context.Authentication.SignIn("Oops",
+            return context.Authentication.SignInAsync("Oops",
                 new ClaimsPrincipal(new ClaimsIdentity(new GenericIdentity("Alice", "Cookies"))),
                 new AuthenticationProperties());
-            return Task.FromResult<object>(null);
         }
 
         private Task SignOutAsWrong(HttpContext context)
         {
-            context.Authentication.SignOut("Oops");
-            return Task.FromResult<object>(null);
+            return context.Authentication.SignOutAsync("Oops");
         }
 
         [Fact]
@@ -305,12 +302,9 @@ namespace Microsoft.AspNet.Authentication.Cookies
                 options.SlidingExpiration = false;
             },
             context =>
-            {
-                context.Authentication.SignIn("Cookies",
+                context.Authentication.SignInAsync("Cookies",
                     new ClaimsPrincipal(new ClaimsIdentity(new GenericIdentity("Alice", "Cookies"))),
-                    new AuthenticationProperties() { ExpiresUtc = clock.UtcNow.Add(TimeSpan.FromMinutes(5)) });
-                    return Task.FromResult<object>(null);
-            });
+                    new AuthenticationProperties() { ExpiresUtc = clock.UtcNow.Add(TimeSpan.FromMinutes(5)) }));
 
             var transaction1 = await SendAsync(server, "http://example.com/testpath");
 
@@ -434,9 +428,8 @@ namespace Microsoft.AspNet.Authentication.Cookies
             context =>
             {
                 Assert.Equal(new PathString("/base"), context.Request.PathBase);
-                context.Authentication.SignIn("Cookies", 
+                return context.Authentication.SignInAsync("Cookies", 
                     new ClaimsPrincipal(new ClaimsIdentity(new GenericIdentity("Alice", "Cookies"))));
-                return Task.FromResult<object>(null);
             },
             new Uri("http://example.com/base"));
 
@@ -606,19 +599,19 @@ namespace Microsoft.AspNet.Authentication.Cookies
                     }
                     else if (req.Path == new PathString("/forbid")) // Simulate forbidden 
                     {
-                        context.Authentication.Forbid(CookieAuthenticationDefaults.AuthenticationScheme);
+                        await context.Authentication.ForbidAsync(CookieAuthenticationDefaults.AuthenticationScheme);
                     }
                     else if (req.Path == new PathString("/challenge"))
                     {
-                        context.Authentication.Challenge(CookieAuthenticationDefaults.AuthenticationScheme);
+                        await context.Authentication.ChallengeAsync(CookieAuthenticationDefaults.AuthenticationScheme);
                     }
                     else if (req.Path == new PathString("/unauthorized"))
                     {
-                        context.Authentication.Challenge(CookieAuthenticationDefaults.AuthenticationScheme, new AuthenticationProperties(), ChallengeBehavior.Unauthorized);
+                        await context.Authentication.ChallengeAsync(CookieAuthenticationDefaults.AuthenticationScheme, new AuthenticationProperties(), ChallengeBehavior.Unauthorized);
                     }
                     else if (req.Path == new PathString("/protected/CustomRedirect"))
                     {
-                        context.Authentication.Challenge(new AuthenticationProperties() { RedirectUri = "/CustomRedirect" });
+                        await context.Authentication.ChallengeAsync(new AuthenticationProperties() { RedirectUri = "/CustomRedirect" });
                     }
                     else if (req.Path == new PathString("/me"))
                     {

--- a/test/Microsoft.AspNet.Authentication.Test/Facebook/FacebookMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Facebook/FacebookMiddlewareTests.cs
@@ -51,7 +51,8 @@ namespace Microsoft.AspNet.Authentication.Facebook
                 },
                 context =>
                 {
-                    context.Authentication.Challenge("Facebook");
+                    // REVIEW: Gross.
+                    context.Authentication.ChallengeAsync("Facebook").GetAwaiter().GetResult();
                     return true;
                 });
             var transaction = await server.SendAsync("http://example.com/challenge");
@@ -88,7 +89,8 @@ namespace Microsoft.AspNet.Authentication.Facebook
                 },
                 context =>
                 {
-                    context.Authentication.Challenge("Facebook");
+                    // REVIEW: gross
+                    context.Authentication.ChallengeAsync("Facebook").GetAwaiter().GetResult();
                     return true;
                 });
             var transaction = await server.SendAsync("http://example.com/challenge");

--- a/test/Microsoft.AspNet.Authentication.Test/Google/GoogleMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Google/GoogleMiddlewareTests.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;

--- a/test/Microsoft.AspNet.Authentication.Test/Google/GoogleMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Google/GoogleMiddlewareTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -142,7 +143,6 @@ namespace Microsoft.AspNet.Authentication.Google
                                 { "approval_prompt", "force" },
                                 { "login_hint", "test@example.com" }
                             }));
-                        res.StatusCode = 401;
                     }
 
                     return Task.FromResult<object>(null);
@@ -476,7 +476,6 @@ namespace Microsoft.AspNet.Authentication.Google
                     if (req.Path == new PathString("/challenge"))
                     {
                         context.Authentication.Challenge("Google");
-                        res.StatusCode = 401;
                     }
                     else if (req.Path == new PathString("/me"))
                     {
@@ -491,7 +490,6 @@ namespace Microsoft.AspNet.Authentication.Google
                     else if (req.Path == new PathString("/unauthorizedAuto"))
                     {
                         var result = await context.Authentication.AuthenticateAsync("Google");
-                        res.StatusCode = 401;
                         context.Authentication.Challenge();
                     }
                     else if (req.Path == new PathString("/401"))

--- a/test/Microsoft.AspNet.Authentication.Test/Google/GoogleMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Google/GoogleMiddlewareTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.AspNet.Authentication.Google
                     var res = context.Response;
                     if (req.Path == new PathString("/challenge2"))
                     {
-                        context.Authentication.Challenge("Google", new AuthenticationProperties(
+                        return context.Authentication.ChallengeAsync("Google", new AuthenticationProperties(
                             new Dictionary<string, string>()
                             {
                                 { "scope", "https://www.googleapis.com/auth/plus.login" },
@@ -474,7 +474,7 @@ namespace Microsoft.AspNet.Authentication.Google
                     var res = context.Response;
                     if (req.Path == new PathString("/challenge"))
                     {
-                        context.Authentication.Challenge("Google");
+                        await context.Authentication.ChallengeAsync("Google");
                     }
                     else if (req.Path == new PathString("/me"))
                     {
@@ -484,12 +484,12 @@ namespace Microsoft.AspNet.Authentication.Google
                     {
                         // Simulate Authorization failure 
                         var result = await context.Authentication.AuthenticateAsync("Google");
-                        context.Authentication.Challenge("Google");
+                        await context.Authentication.ChallengeAsync("Google");
                     }
                     else if (req.Path == new PathString("/unauthorizedAuto"))
                     {
                         var result = await context.Authentication.AuthenticateAsync("Google");
-                        context.Authentication.Challenge();
+                        await context.Authentication.ChallengeAsync();
                     }
                     else if (req.Path == new PathString("/401"))
                     {

--- a/test/Microsoft.AspNet.Authentication.Test/MicrosoftAccount/MicrosoftAccountMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/MicrosoftAccount/MicrosoftAccountMiddlewareTests.cs
@@ -156,7 +156,6 @@ namespace Microsoft.AspNet.Authentication.Tests.MicrosoftAccount
                     if (req.Path == new PathString("/challenge"))
                     {
                         context.Authentication.Challenge("Microsoft");
-                        res.StatusCode = 401;
                     }
                     else if (req.Path == new PathString("/me"))
                     {

--- a/test/Microsoft.AspNet.Authentication.Test/MicrosoftAccount/MicrosoftAccountMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/MicrosoftAccount/MicrosoftAccountMiddlewareTests.cs
@@ -155,7 +155,7 @@ namespace Microsoft.AspNet.Authentication.Tests.MicrosoftAccount
                     var res = context.Response;
                     if (req.Path == new PathString("/challenge"))
                     {
-                        context.Authentication.Challenge("Microsoft");
+                        await context.Authentication.ChallengeAsync("Microsoft");
                     }
                     else if (req.Path == new PathString("/me"))
                     {

--- a/test/Microsoft.AspNet.Authentication.Test/OAuthBearer/OAuthBearerMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/OAuthBearer/OAuthBearerMiddlewareTests.cs
@@ -326,7 +326,7 @@ namespace Microsoft.AspNet.Authentication.OAuthBearer
                     {
                         // Simulate Authorization failure 
                         var result = await context.Authentication.AuthenticateAsync(OAuthBearerAuthenticationDefaults.AuthenticationScheme);
-                        context.Authentication.Challenge(OAuthBearerAuthenticationDefaults.AuthenticationScheme);
+                        await context.Authentication.ChallengeAsync(OAuthBearerAuthenticationDefaults.AuthenticationScheme);
                     }
 
                     else

--- a/test/Microsoft.AspNet.Authentication.Test/OpenIdConnect/OpenIdConnectHandlerTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/OpenIdConnect/OpenIdConnectHandlerTests.cs
@@ -549,23 +549,14 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
             await base.BaseInitializeAsync(options, context, logger, encoder);
         }
 
-        public override bool ShouldHandleScheme(string authenticationScheme)
-        {
-            return true;
-        }
-
-        public override Task ChallengeAsync(ChallengeContext context)
-        {
-            return Task.FromResult(0);
-        }
-
-        protected override async Task ApplyResponseChallengeAsync()
+        protected override async Task<bool> HandleUnauthorizedAsync(ChallengeContext context)
         {
             var redirectToIdentityProviderNotification = new RedirectToIdentityProviderNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions>(Context, Options)
             {
             };
 
             await Options.Notifications.RedirectToIdentityProvider(redirectToIdentityProviderNotification);
+            return true;
         }
     }
 

--- a/test/Microsoft.AspNet.Authentication.Test/OpenIdConnect/OpenIdConnectHandlerTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/OpenIdConnect/OpenIdConnectHandlerTests.cs
@@ -554,12 +554,9 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
             return true;
         }
 
-        public override void Challenge(ChallengeContext context)
+        public override Task ChallengeAsync(ChallengeContext context)
         {
-        }
-
-        protected override void ApplyResponseChallenge()
-        {
+            return Task.FromResult(0);
         }
 
         protected override async Task ApplyResponseChallengeAsync()

--- a/test/Microsoft.AspNet.Authentication.Test/OpenIdConnect/OpenIdConnectMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/OpenIdConnect/OpenIdConnectMiddlewareTests.cs
@@ -206,7 +206,6 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
                     if (req.Path == new PathString("/challenge"))
                     {
                         context.Authentication.Challenge("OpenIdConnect");
-                        res.StatusCode = 401;
                     }
                     else if (req.Path == new PathString("/signin"))
                     {

--- a/test/Microsoft.AspNet.Authentication.Test/OpenIdConnect/OpenIdConnectMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/OpenIdConnect/OpenIdConnectMiddlewareTests.cs
@@ -205,20 +205,20 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
                     var res = context.Response;
                     if (req.Path == new PathString("/challenge"))
                     {
-                        context.Authentication.Challenge("OpenIdConnect");
+                        await context.Authentication.ChallengeAsync("OpenIdConnect");
                     }
                     else if (req.Path == new PathString("/signin"))
                     {
                         // REVIEW: this used to just be res.SignIn()
-                        context.Authentication.SignIn("OpenIdConnect", new ClaimsPrincipal());
+                        await context.Authentication.SignInAsync("OpenIdConnect", new ClaimsPrincipal());
                     }
                     else if (req.Path == new PathString("/signout"))
                     {
-                        context.Authentication.SignOut(OpenIdConnectAuthenticationDefaults.AuthenticationScheme);
+                        await context.Authentication.SignOutAsync(OpenIdConnectAuthenticationDefaults.AuthenticationScheme);
                     }
                     else if (req.Path == new PathString("/signout_with_specific_redirect_uri"))
                     {
-                        context.Authentication.SignOut(
+                        await context.Authentication.SignOutAsync(
                             OpenIdConnectAuthenticationDefaults.AuthenticationScheme,
                             new AuthenticationProperties() { RedirectUri = "http://www.example.com/specific_redirect_uri" });
                     }

--- a/test/Microsoft.AspNet.Authentication.Test/Twitter/TwitterMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Twitter/TwitterMiddlewareTests.cs
@@ -50,9 +50,10 @@ namespace Microsoft.AspNet.Authentication.Twitter
                     };
                     options.BackchannelCertificateValidator = null;
                 }),
-                context =>
+                context => 
                 {
-                    context.Authentication.Challenge("Twitter");
+                    // REVIEW: Gross
+                    context.Authentication.ChallengeAsync("Twitter").GetAwaiter().GetResult();
                     return true;
                 });
             var transaction = await server.SendAsync("http://example.com/challenge");
@@ -90,7 +91,8 @@ namespace Microsoft.AspNet.Authentication.Twitter
                 }),
                 context =>
                 {
-                    context.Authentication.Challenge("Twitter");
+                    // REVIEW: gross
+                    context.Authentication.ChallengeAsync("Twitter").GetAwaiter().GetResult();
                     return true;
                 });
             var transaction = await server.SendAsync("http://example.com/challenge");


### PR DESCRIPTION
Depends on https://github.com/aspnet/HttpAbstractions/pull/323

## Overview of AuthenticationHandler changes:
- Response is mutated directly as part of SignIn/SignOut Challenge invocation (instead of on Teardown)
- Consume ChallengeBehavior: 
   Automatic means (403 if Authenticate produces an identity, 401 otherwise)
   Unauthorized/Forbidden explicitly call the appropriate code path
- new ChallengeCalled flag so ApplyResponseChallenge is only called once
- Cookie now overrides TeardownAsync to continue the old renew/refresh behavior

## New protected virtual methods
- HandleChallenge: default behavior for implementing the ChallengeBehavior functionality
- HandleUnauthorized: (turns around and just calls the existing ApplyResponseChallenge)
- HandleForbidden: sets 403 by default, Cookie overrides to add support for AccessDenied redirect page
- HandleSignIn/Out: lifted out of ApplyResponseGrant, now done immediately

## TODO:
- Its still a bit messy in AuthenticationHandler, need to iterate on that more
- Lou wants the AuthenticationManager.Challenge setting of 401 to move into the handler (that change currently doesn't completely work with the passive challenge flow intercepting 401s)

cc @lodejard @Tratcher @blowdart @divega @davidfowl @muratg 

