### PR TITLE
set correct expires of cookie when IsPersistent is true.

### DIFF
--- a/src/Microsoft.AspNet.Authentication.Cookies/CookieAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.Cookies/CookieAuthenticationHandler.cs
@@ -161,7 +161,7 @@ namespace Microsoft.AspNet.Authentication.Cookies
             var cookieOptions = BuildCookieOptions();
             if (ticket.Properties.IsPersistent && _renewExpiresUtc.HasValue)
             {
-                cookieOptions.Expires = _renewExpiresUtc.Value.ToUniversalTime().DateTime;
+                cookieOptions.Expires = _renewExpiresUtc.Value.UtcDateTime;
             }
 
             Options.CookieManager.AppendResponseCookie(
@@ -236,7 +236,7 @@ namespace Microsoft.AspNet.Authentication.Cookies
                 if (signInContext.Properties.IsPersistent)
                 {
                     var expiresUtc = signInContext.Properties.ExpiresUtc ?? issuedUtc.Add(Options.ExpireTimeSpan);
-                    signInContext.CookieOptions.Expires = expiresUtc.ToUniversalTime().DateTime;
+                    signInContext.CookieOptions.Expires = expiresUtc.UtcDateTime;
                 }
 
                 model = new AuthenticationTicket(signInContext.Principal, signInContext.Properties, signInContext.AuthenticationScheme);


### PR DESCRIPTION
The `Microsoft.AspNet.Http.CookieOptions.Expires` is of type `DateTime?`,  the `Microsoft.Net.Http.Headers.SetCookieHeaderValue.Expires` is of type `DateTimeOffset?`. Looking into the following source code:
```c#
// CookieAuthenticationHandler.cs, line 184
signInContext.CookieOptions.Expires = expiresUtc.ToUniversalTime().DateTime;

// ChunkingCookieManager.cs, line 129
var template = new SetCookieHeaderValue(escapedKey)
{
    Domain = options.Domain,

    // The result of conversion is unexpected because options.Expires has a UTC value 
    // but its Kind is DateTimeKind.Unspecified
    Expires = options.Expires, 

    HttpOnly = options.HttpOnly,
    Path = options.Path,
    Secure = options.Secure,
};
```

To fix it, using `expiresUtc.UtcDateTime` instead of `expiresUtc.ToUniversalTime().DateTime`.

I also added a test for this.