### PR TITLE
Fix Forbidden Challenge for AutomaticAuthentication

### DIFF
--- a/src/Microsoft.AspNet.Authentication/AuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication/AuthenticationHandler.cs
@@ -85,6 +85,7 @@ namespace Microsoft.AspNet.Authentication
                 var ticket = await AuthenticateAsync();
                 if (ticket?.Principal != null)
                 {
+                    AuthenticateCalled = true;
                     SecurityHelper.AddUserPrincipal(Context, ticket.Principal);
                 }
             }


### PR DESCRIPTION
`AuthenticateCalled` is not marked as true when `AutomaticAuthentication` is used, then `ShouldConvertChallengeToForbidden` was returning `false` and the resulting StatusCode was 401 in place of 403.