### PR TITLE
Replace INonceCache by IDistributedCache

### DIFF
--- a/src/Microsoft.AspNet.Authentication.OpenIdConnect/OpenIdConnectAuthenticationOptions.cs
+++ b/src/Microsoft.AspNet.Authentication.OpenIdConnect/OpenIdConnectAuthenticationOptions.cs
@@ -8,6 +8,7 @@ using System.IdentityModel.Tokens;
 using System.Net.Http;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Authentication;
+using Microsoft.Framework.Caching.Distributed;
 using Microsoft.Framework.Internal;
 using Microsoft.IdentityModel.Protocols;
 
@@ -173,7 +174,13 @@ namespace Microsoft.AspNet.Authentication.OpenIdConnect
         /// recommends adding a nonce to a request as a mitigation against replay attacks when requesting id_tokens.
         /// By default the runtime uses cookies with unique names generated from a hash of the nonce.
         /// </summary>
-        public INonceCache NonceCache { get; set; }
+        public IDistributedCache NonceCache { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value indicating whether nonces should be stored in the distributed cache or not.
+        /// The default value, <c>false</c>, is used to store nonces in client cookies.
+        /// </summary>
+        public bool CacheNonces { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="OpenIdConnectAuthenticationNotifications"/> to notify when processing OpenIdConnect messages.

--- a/src/Microsoft.AspNet.Authentication.OpenIdConnect/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Authentication.OpenIdConnect/Resources.Designer.cs
@@ -141,11 +141,11 @@ namespace Microsoft.AspNet.Authentication.OpenIdConnect
         }
 
         /// <summary>
-        /// OIDCH_0033: ProtocolValidator.RequireNonce == true. Options.NonceCache.TryAddNonce returned false. This usually indicates the nonce is not unique or has been used. The nonce is: '{0}'.
+        /// OIDCH_0033: ProtocolValidator.RequireNonce == true. The generated nonce already exists: this usually indicates the nonce is not unique or has been used. The nonce is: '{0}'.
         /// </summary>
-        internal static string OIDCH_0033_TryAddNonceFailed
+        internal static string OIDCH_0033_NonceAlreadyExists
         {
-            get { return ResourceManager.GetString("OIDCH_0033_TryAddNonceFailed"); }
+            get { return ResourceManager.GetString("OIDCH_0033_NonceAlreadyExists"); }
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Authentication.OpenIdConnect/Resources.resx
+++ b/src/Microsoft.AspNet.Authentication.OpenIdConnect/Resources.resx
@@ -147,8 +147,8 @@
   <data name="OIDCH_0032_UsingCurrentUriRedirectUri" xml:space="preserve">
     <value>OIDCH_0032: using the CurrentUri for 'local redirect' post authentication: '{0}'.</value>
   </data>
-  <data name="OIDCH_0033_TryAddNonceFailed" xml:space="preserve">
-    <value>OIDCH_0033: ProtocolValidator.RequireNonce == true. Options.NonceCache.TryAddNonce returned false. This usually indicates the nonce is not unique or has been used. The nonce is: '{0}'.</value>
+  <data name="OIDCH_0033_NonceAlreadyExists" xml:space="preserve">
+    <value>OIDCH_0033: ProtocolValidator.RequireNonce == true. The generated nonce already exists: this usually indicates the nonce is not unique or has been used. The nonce is: '{0}'.</value>
   </data>
   <data name="OIDCH_0034_RedirectToIdentityProviderNotificationHandledResponse" xml:space="preserve">
     <value>OIDCH_0034: redirectToIdentityProviderNotification.HandledResponse</value>

--- a/src/Microsoft.AspNet.Authentication.OpenIdConnect/project.json
+++ b/src/Microsoft.AspNet.Authentication.OpenIdConnect/project.json
@@ -3,6 +3,7 @@
     "description": "ASP.NET 5 middleware that enables an application to support OpenIdConnect authentication workflow.",
     "dependencies": {
         "Microsoft.AspNet.Authentication": "1.0.0-*",
+        "Microsoft.Framework.Caching.Abstractions": "1.0.0-*",
         "Microsoft.Framework.NotNullAttribute.Sources": { "type": "build", "version": "1.0.0-*" },
         "Microsoft.IdentityModel.Protocol.Extensions": "2.0.0-beta5-*"
     },

--- a/src/Microsoft.AspNet.Authentication/AuthenticationServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNet.Authentication/AuthenticationServiceCollectionExtensions.cs
@@ -32,6 +32,5 @@ namespace Microsoft.Framework.DependencyInjection
         {
             return services.Configure<ClaimsTransformationOptions>(o => o.Transformer = new ClaimsTransformer { TransformAsyncDelegate = asyncTransform });
         }
-
     }
 }

--- a/test/Microsoft.AspNet.Authentication.Test/OpenIdConnect/OpenIdConnectHandlerTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/OpenIdConnect/OpenIdConnectHandlerTests.cs
@@ -437,6 +437,7 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
                 },
                 services =>
                 {
+                    services.AddAuthentication();
                     services.AddWebEncoders();
                     services.AddDataProtection();
                 }
@@ -456,6 +457,7 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
                 },
                 services =>
                 {
+                    services.AddAuthentication();
                     services.AddWebEncoders();
                     services.AddDataProtection();
                 }
@@ -571,11 +573,12 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
             IDataProtectionProvider dataProtectionProvider,
             ILoggerFactory loggerFactory,
             IUrlEncoder encoder,
+            IServiceProvider services,
             IOptions<ExternalAuthenticationOptions> externalOptions,
             IOptions<OpenIdConnectAuthenticationOptions> options,
             ConfigureOptions<OpenIdConnectAuthenticationOptions> configureOptions = null
             )
-        : base(next, dataProtectionProvider, loggerFactory, encoder, externalOptions, options, configureOptions)
+        : base(next, dataProtectionProvider, loggerFactory, encoder, services, externalOptions, options, configureOptions)
         {
             Logger = (loggerFactory as CustomLoggerFactory).Logger;
         }


### PR DESCRIPTION
Fixes https://github.com/aspnet/Security/issues/212.

For the first attempt, I opted for the "hybrid" approach (https://github.com/aspnet/Security/issues/212#issuecomment-112533342): the distributed cache is retrieved from the options when available, and from the DI container when the user didn't provide his own cache.

Storing nonces in the distributed cache is not enabled by default but can easily be using `StoreNoncesInCache`. I'm not super satisfied with the name, so don't hesitate to suggest another one :smile: 

FYI, I haven't been able to use the `OpenIdConnectSample` app because it delegates authentication to AAD, that doesn't allow me to log in using my live.com account. I worked around this issue using `AspNet.Security.OpenIdConnect.Server` (https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server).

Of course, I'll revert these changes before merging (though depending on AAD is not really a good idea IMHO).

![image](https://cloud.githubusercontent.com/assets/6998306/8285735/90843b96-1905-11e5-813b-7c82d5eae4a7.png)

/cc @Eilon @HaoK @Tratcher