### PR TITLE
Fix OAuthHandler to use OriginalPathBase

### DIFF
--- a/src/Microsoft.AspNet.Authentication.Cookies/CookieAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.Cookies/CookieAuthenticationHandler.cs
@@ -117,7 +117,7 @@ namespace Microsoft.AspNet.Authentication.Cookies
             {
                 Domain = Options.CookieDomain,
                 HttpOnly = Options.CookieHttpOnly,
-                Path = Options.CookiePath ?? (RequestPathBase.HasValue ? RequestPathBase.ToString() : "/"),
+                Path = Options.CookiePath ?? (OriginalPathBase.HasValue ? OriginalPathBase.ToString() : "/"),
             };
             if (Options.CookieSecure == CookieSecureOption.SameAsRequest)
             {

--- a/src/Microsoft.AspNet.Authentication.OAuth/OAuthAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.OAuth/OAuthAuthenticationHandler.cs
@@ -117,7 +117,7 @@ namespace Microsoft.AspNet.Authentication.OAuth
                 }
 
                 var requestPrefix = Request.Scheme + "://" + Request.Host;
-                var redirectUri = requestPrefix + RequestPathBase + Options.CallbackPath;
+                var redirectUri = requestPrefix + OriginalPathBase + Options.CallbackPath;
 
                 var tokens = await ExchangeCodeAsync(code, redirectUri);
 
@@ -172,20 +172,16 @@ namespace Microsoft.AspNet.Authentication.OAuth
 
         protected override Task<bool> HandleUnauthorizedAsync([NotNull] ChallengeContext context)
         {
-            var baseUri = Request.Scheme + "://" + Request.Host + Request.PathBase;
-            var currentUri = baseUri + Request.Path + Request.QueryString;
-            var redirectUri = baseUri + Options.CallbackPath;
-
             var properties = new AuthenticationProperties(context.Properties);
             if (string.IsNullOrEmpty(properties.RedirectUri))
             {
-                properties.RedirectUri = currentUri;
+                properties.RedirectUri = CurrentUri;
             }
 
             // OAuth2 10.12 CSRF
             GenerateCorrelationId(properties);
 
-            var authorizationEndpoint = BuildChallengeUrl(properties, redirectUri);
+            var authorizationEndpoint = BuildChallengeUrl(properties, BuildRedirectUri(Options.CallbackPath));
 
             var redirectContext = new OAuthApplyRedirectContext(
                 Context, Options,

--- a/src/Microsoft.AspNet.Authentication.Twitter/TwitterAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.Twitter/TwitterAuthenticationHandler.cs
@@ -120,16 +120,13 @@ namespace Microsoft.AspNet.Authentication.Twitter
         }
         protected override async Task<bool> HandleUnauthorizedAsync([NotNull] ChallengeContext context)
         {
-            var requestPrefix = Request.Scheme + "://" + Request.Host;
-            var callBackUrl = requestPrefix + RequestPathBase + Options.CallbackPath;
-
             var properties = new AuthenticationProperties(context.Properties);
             if (string.IsNullOrEmpty(properties.RedirectUri))
             {
-                properties.RedirectUri = requestPrefix + Request.PathBase + Request.Path + Request.QueryString;
+                properties.RedirectUri = CurrentUri;
             }
 
-            var requestToken = await ObtainRequestTokenAsync(Options.ConsumerKey, Options.ConsumerSecret, callBackUrl, properties);
+            var requestToken = await ObtainRequestTokenAsync(Options.ConsumerKey, Options.ConsumerSecret, BuildRedirectUri(Options.CallbackPath), properties);
             if (requestToken.CallbackConfirmed)
             {
                 var twitterAuthenticationEndpoint = AuthenticationEndpoint + requestToken.Token;

--- a/src/Microsoft.AspNet.Authentication/AuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication/AuthenticationHandler.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNet.Authentication
             get { return Context.Response; }
         }
 
-        protected PathString RequestPathBase { get; private set; }
+        protected PathString OriginalPathBase { get; private set; }
 
         protected ILogger Logger { get; private set; }
 
@@ -48,11 +48,19 @@ namespace Microsoft.AspNet.Authentication
 
         public IAuthenticationHandler PriorHandler { get; set; }
 
+        protected string CurrentUri
+        {
+            get
+            {
+                return Request.Scheme + "://" + Request.Host + Request.PathBase + Request.Path + Request.QueryString;
+            }
+        }
+
         protected async Task BaseInitializeAsync([NotNull] AuthenticationOptions options, [NotNull] HttpContext context, [NotNull] ILogger logger, [NotNull] IUrlEncoder encoder)
         {
             _baseOptions = options;
             Context = context;
-            RequestPathBase = Request.PathBase;
+            OriginalPathBase = Request.PathBase;
             Logger = logger;
             UrlEncoder = encoder;
 
@@ -68,6 +76,11 @@ namespace Microsoft.AspNet.Authentication
                     SecurityHelper.AddUserPrincipal(Context, ticket.Principal);
                 }
             }
+        }
+
+        protected string BuildRedirectUri(string targetPath)
+        {
+            return Request.Scheme + "://" + Request.Host + OriginalPathBase + targetPath;
         }
 
         private static async Task OnStartingCallback(object state)

--- a/test/Microsoft.AspNet.Authentication.Test/Facebook/FacebookMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Facebook/FacebookMiddlewareTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Builder;
@@ -63,6 +62,7 @@ namespace Microsoft.AspNet.Authentication.Facebook
             var query = transaction.Response.Headers.Location.Query;
             query.ShouldContain("custom=test");
         }
+
         [Fact]
         public async Task MapWillNotAffectRedirect()
         {

--- a/test/Microsoft.AspNet.Authentication.Test/Facebook/FacebookMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Facebook/FacebookMiddlewareTests.cs
@@ -2,12 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Http;
+using Microsoft.AspNet.Http.Authentication;
 using Microsoft.AspNet.TestHost;
 using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.WebEncoders;
 using Shouldly;
 using Xunit;
 
@@ -59,6 +62,36 @@ namespace Microsoft.AspNet.Authentication.Facebook
             transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
             var query = transaction.Response.Headers.Location.Query;
             query.ShouldContain("custom=test");
+        }
+        [Fact]
+        public async Task MapWillNotAffectRedirect()
+        {
+            var server = CreateServer(
+                app =>
+                {
+                    app.UseFacebookAuthentication();
+                    app.Map("/login", signoutApp => signoutApp.Run(context => context.Authentication.ChallengeAsync("Facebook", new AuthenticationProperties() { RedirectUri = "/" })));
+                },
+                services =>
+                {
+                    services.AddAuthentication();
+                    services.ConfigureFacebookAuthentication(options =>
+                    {
+                        options.AppId = "Test App Id";
+                        options.AppSecret = "Test App Secret";
+                        options.SignInScheme = "External";
+                    });
+                },
+                handler: null);
+            var transaction = await server.SendAsync("http://example.com/login");
+            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            var location = transaction.Response.Headers.Location.AbsoluteUri;
+            location.ShouldContain("https://www.facebook.com/v2.2/dialog/oauth");
+            location.ShouldContain("response_type=code");
+            location.ShouldContain("client_id=");
+            location.ShouldContain("redirect_uri="+ UrlEncoder.Default.UrlEncode("http://example.com/signin-facebook"));
+            location.ShouldContain("scope=");
+            location.ShouldContain("state=");
         }
 
         [Fact]


### PR DESCRIPTION
Fixes Map path issue, and consolidates the logic into common helpers now

(Unfortunately can't write a test for twitter like fb since it doesn't surface the redirectUrl easily)

cc @Tratcher 