### PR TITLE
Fix cookie refresh and authenticate caching

### DIFF
--- a/src/Microsoft.AspNet.Authentication.Cookies/Notifications/CookieValidateIdentityContext.cs
+++ b/src/Microsoft.AspNet.Authentication.Cookies/Notifications/CookieValidateIdentityContext.cs
@@ -40,13 +40,18 @@ namespace Microsoft.AspNet.Authentication.Cookies
         public AuthenticationProperties Properties { get; private set; }
 
         /// <summary>
+        /// If true, the cookie will be renewed
+        /// </summary>
+        public bool ShouldRenew { get; set; }
+
+        /// <summary>
         /// Called to replace the claims principal. The supplied principal will replace the value of the 
         /// Principal property, which determines the identity of the authenticated request.
         /// </summary>
         /// <param name="identity">The identity used as the replacement</param>
-        public void ReplacePrincipal(IPrincipal principal)
+        public void ReplacePrincipal(ClaimsPrincipal principal)
         {
-            Principal = new ClaimsPrincipal(principal);
+            Principal = principal;
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Authentication.OAuth/OAuthAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.OAuth/OAuthAuthenticationHandler.cs
@@ -79,7 +79,7 @@ namespace Microsoft.AspNet.Authentication.OAuth
             return context.IsRequestCompleted;
         }
 
-        public override async Task<AuthenticationTicket> AuthenticateAsync()
+        protected override async Task<AuthenticationTicket> AuthenticateAsync()
         {
             AuthenticationProperties properties = null;
             try

--- a/src/Microsoft.AspNet.Authentication.OAuthBearer/OAuthBearerAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.OAuthBearer/OAuthBearerAuthenticationHandler.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNet.Authentication.OAuthBearer
         /// Searches the 'Authorization' header for a 'Bearer' token. If the 'Bearer' token is found, it is validated using <see cref="TokenValidationParameters"/> set in the options.
         /// </summary>
         /// <returns></returns>
-        public override async Task<AuthenticationTicket> AuthenticateAsync()
+        protected override async Task<AuthenticationTicket> AuthenticateAsync()
         {
             string token = null;
             try

--- a/src/Microsoft.AspNet.Authentication.OpenIdConnect/OpenIdConnectAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.OpenIdConnect/OpenIdConnectAuthenticationHandler.cs
@@ -201,7 +201,7 @@ namespace Microsoft.AspNet.Authentication.OpenIdConnect
         /// </summary>
         /// <returns>An <see cref="AuthenticationTicket"/> if successful.</returns>
         /// <remarks>Uses log id's OIDCH-0000 - OIDCH-0025</remarks>
-        public override async Task<AuthenticationTicket> AuthenticateAsync()
+        protected override async Task<AuthenticationTicket> AuthenticateAsync()
         {
             Logger.LogDebug(Resources.OIDCH_0000_AuthenticateCoreAsync, this.GetType());
 

--- a/src/Microsoft.AspNet.Authentication.Twitter/TwitterAuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.Twitter/TwitterAuthenticationHandler.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNet.Authentication.Twitter
             return false;
         }
 
-        public override async Task<AuthenticationTicket> AuthenticateAsync()
+        protected override async Task<AuthenticationTicket> AuthenticateAsync()
         {
             AuthenticationProperties properties = null;
             try

--- a/test/Microsoft.AspNet.Authentication.Test/AuthenticationHandlerFacts.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/AuthenticationHandlerFacts.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNet.Authentication
                 Options.AuthenticationScheme = scheme;
             }
 
-            public override Task<AuthenticationTicket> AuthenticateAsync()
+            protected override Task<AuthenticationTicket> AuthenticateAsync()
             {
                 throw new NotImplementedException();
             }
@@ -86,7 +86,7 @@ namespace Microsoft.AspNet.Authentication
                 Options.AutomaticAuthentication = auto;
             }
 
-            public override Task<AuthenticationTicket> AuthenticateAsync()
+            protected override Task<AuthenticationTicket> AuthenticateAsync()
             {
                 throw new NotImplementedException();
             }

--- a/test/Microsoft.AspNet.Authentication.Test/Cookies/CookieMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Cookies/CookieMiddlewareTests.cs
@@ -342,6 +342,95 @@ namespace Microsoft.AspNet.Authentication.Cookies
         }
 
         [Fact]
+        public async Task CookieCanBeRenewedByValidator()
+        {
+            var clock = new TestClock();
+            var server = CreateServer(options =>
+            {
+                options.SystemClock = clock;
+                options.ExpireTimeSpan = TimeSpan.FromMinutes(10);
+                options.SlidingExpiration = false;
+                options.Notifications = new CookieAuthenticationNotifications
+                {
+                    OnValidatePrincipal = ctx =>
+                    {
+                        ctx.ShouldRenew = true;
+                        return Task.FromResult(0);
+                    }
+                };
+            },
+            context =>
+                context.Authentication.SignInAsync("Cookies",
+                    new ClaimsPrincipal(new ClaimsIdentity(new GenericIdentity("Alice", "Cookies")))));
+
+            var transaction1 = await SendAsync(server, "http://example.com/testpath");
+
+            var transaction2 = await SendAsync(server, "http://example.com/me/Cookies", transaction1.CookieNameValue);
+
+            clock.Add(TimeSpan.FromMinutes(5));
+
+            var transaction3 = await SendAsync(server, "http://example.com/me/Cookies", transaction1.CookieNameValue);
+
+            clock.Add(TimeSpan.FromMinutes(6));
+
+            var transaction4 = await SendAsync(server, "http://example.com/me/Cookies", transaction1.CookieNameValue);
+
+            transaction2.SetCookie.ShouldBe(null);
+            FindClaimValue(transaction2, ClaimTypes.Name).ShouldBe("Alice");
+            transaction3.SetCookie.ShouldBe(null);
+            FindClaimValue(transaction3, ClaimTypes.Name).ShouldBe("Alice");
+            transaction4.SetCookie.ShouldBe(null);
+            FindClaimValue(transaction4, ClaimTypes.Name).ShouldBe(null);
+        }
+
+        [Fact]
+        public async Task CookieCanBeRenewedByValidatorWithSlidingExpiry()
+        {
+            var clock = new TestClock();
+            var server = CreateServer(options =>
+            {
+                options.SystemClock = clock;
+                options.ExpireTimeSpan = TimeSpan.FromMinutes(10);
+                options.Notifications = new CookieAuthenticationNotifications
+                {
+                    OnValidatePrincipal = ctx =>
+                    {
+                        ctx.ShouldRenew = true;
+                        return Task.FromResult(0);
+                    }
+                };
+            },
+            context =>
+                context.Authentication.SignInAsync("Cookies",
+                    new ClaimsPrincipal(new ClaimsIdentity(new GenericIdentity("Alice", "Cookies")))));
+
+            var transaction1 = await SendAsync(server, "http://example.com/testpath");
+
+            var transaction2 = await SendAsync(server, "http://example.com/me/Cookies", transaction1.CookieNameValue);
+
+            clock.Add(TimeSpan.FromMinutes(5));
+
+            var transaction3 = await SendAsync(server, "http://example.com/me/Cookies", transaction2.CookieNameValue);
+
+            clock.Add(TimeSpan.FromMinutes(6));
+
+            var transaction4 = await SendAsync(server, "http://example.com/me/Cookies", transaction3.CookieNameValue);
+
+            clock.Add(TimeSpan.FromMinutes(11));
+
+            var transaction5 = await SendAsync(server, "http://example.com/me/Cookies", transaction4.CookieNameValue);
+
+            transaction2.SetCookie.ShouldNotBe(null);
+            FindClaimValue(transaction2, ClaimTypes.Name).ShouldBe("Alice");
+            transaction3.SetCookie.ShouldNotBe(null);
+            FindClaimValue(transaction3, ClaimTypes.Name).ShouldBe("Alice");
+            transaction4.SetCookie.ShouldNotBe(null);
+            FindClaimValue(transaction4, ClaimTypes.Name).ShouldBe("Alice");
+            transaction5.SetCookie.ShouldBe(null);
+            FindClaimValue(transaction5, ClaimTypes.Name).ShouldBe(null);
+        }
+
+        [Fact]
         public async Task CookieExpirationCanBeOverridenInEvent()
         {
             var clock = new TestClock();

--- a/test/Microsoft.AspNet.Authentication.Test/Cookies/CookieMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Cookies/CookieMiddlewareTests.cs
@@ -400,18 +400,24 @@ namespace Microsoft.AspNet.Authentication.Cookies
 
             clock.Add(TimeSpan.FromMinutes(5));
 
-            var transaction3 = await SendAsync(server, "http://example.com/me/Cookies", transaction1.CookieNameValue);
+            var transaction3 = await SendAsync(server, "http://example.com/me/Cookies", transaction2.CookieNameValue);
 
             clock.Add(TimeSpan.FromMinutes(6));
 
             var transaction4 = await SendAsync(server, "http://example.com/me/Cookies", transaction1.CookieNameValue);
 
-            transaction2.SetCookie.ShouldBe(null);
+            clock.Add(TimeSpan.FromMinutes(5));
+
+            var transaction5 = await SendAsync(server, "http://example.com/me/Cookies", transaction2.CookieNameValue);
+
+            transaction2.SetCookie.ShouldNotBe(null);
             FindClaimValue(transaction2, ClaimTypes.Name).ShouldBe("Alice");
-            transaction3.SetCookie.ShouldBe(null);
+            transaction3.SetCookie.ShouldNotBe(null);
             FindClaimValue(transaction3, ClaimTypes.Name).ShouldBe("Alice");
             transaction4.SetCookie.ShouldBe(null);
             FindClaimValue(transaction4, ClaimTypes.Name).ShouldBe(null);
+            transaction5.SetCookie.ShouldBe(null);
+            FindClaimValue(transaction5, ClaimTypes.Name).ShouldBe(null);
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Authentication.Test/DataHandler/Encoder/TicketSerializerTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/DataHandler/Encoder/TicketSerializerTests.cs
@@ -52,6 +52,5 @@ namespace Microsoft.AspNet.Authentication.DataHandler.Encoder
                 readTicket.AuthenticationScheme.ShouldBe("Hello");
             }
         }
-
     }
 }

--- a/test/Microsoft.AspNet.Authentication.Test/DataHandler/Encoder/TicketSerializerTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/DataHandler/Encoder/TicketSerializerTests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Linq;
+using System.Security.Claims;
+using Microsoft.AspNet.Authentication.DataHandler.Serializer;
+using Microsoft.AspNet.Http.Authentication;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.AspNet.Authentication.DataHandler.Encoder
+{
+    public class TicketSerializerTests
+    {
+        [Fact]
+        public void CanRoundTripNullPrincipal()
+        {
+            var properties = new AuthenticationProperties();
+            properties.RedirectUri = "bye";
+            var ticket = new AuthenticationTicket(properties, "Hello");
+
+            using (var stream = new MemoryStream())
+            using (var writer = new BinaryWriter(stream))
+            using (var reader = new BinaryReader(stream))
+            {
+                TicketSerializer.Write(writer, ticket);
+                stream.Position = 0;
+                var readTicket = TicketSerializer.Read(reader);
+                readTicket.Principal.ShouldBe(null);
+                readTicket.Properties.RedirectUri.ShouldBe("bye");
+                readTicket.AuthenticationScheme.ShouldBe("Hello");
+            }
+        }
+
+        [Fact]
+        public void CanRoundTripEmptyPrincipal()
+        {
+            var properties = new AuthenticationProperties();
+            properties.RedirectUri = "bye";
+            var ticket = new AuthenticationTicket(new ClaimsPrincipal(), properties, "Hello");
+
+            using (var stream = new MemoryStream())
+            using (var writer = new BinaryWriter(stream))
+            using (var reader = new BinaryReader(stream))
+            {
+                TicketSerializer.Write(writer, ticket);
+                stream.Position = 0;
+                var readTicket = TicketSerializer.Read(reader);
+                readTicket.Principal.Identities.Count().ShouldBe(0);
+                readTicket.Properties.RedirectUri.ShouldBe("bye");
+                readTicket.AuthenticationScheme.ShouldBe("Hello");
+            }
+        }
+
+    }
+}

--- a/test/Microsoft.AspNet.Authentication.Test/Facebook/FacebookMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Facebook/FacebookMiddlewareTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Builder;
@@ -63,6 +62,7 @@ namespace Microsoft.AspNet.Authentication.Facebook
             var query = transaction.Response.Headers.Location.Query;
             query.ShouldContain("custom=test");
         }
+
         [Fact]
         public async Task MapWillNotAffectRedirect()
         {

--- a/test/Microsoft.AspNet.Authentication.Test/Facebook/FacebookMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Facebook/FacebookMiddlewareTests.cs
@@ -125,67 +125,6 @@ namespace Microsoft.AspNet.Authentication.Facebook
         }
 
         [Fact]
-        public async Task NestedMapWillNotAffectRedirect()
-        {
-            var server = CreateServer(app =>
-                app.Map("/base", map => {
-                    map.UseFacebookAuthentication();
-                    map.Map("/login", signoutApp => signoutApp.Run(context => context.Authentication.ChallengeAsync("Facebook", new AuthenticationProperties() { RedirectUri = "/" })));
-                }),
-                services =>
-                {
-                    services.AddAuthentication();
-                    services.ConfigureFacebookAuthentication(options =>
-                    {
-                        options.AppId = "Test App Id";
-                        options.AppSecret = "Test App Secret";
-                        options.SignInScheme = "External";
-                    });
-                },
-                handler: null);
-            var transaction = await server.SendAsync("http://example.com/base/login");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            var location = transaction.Response.Headers.Location.AbsoluteUri;
-            location.ShouldContain("https://www.facebook.com/v2.2/dialog/oauth");
-            location.ShouldContain("response_type=code");
-            location.ShouldContain("client_id=");
-            location.ShouldContain("redirect_uri=" + UrlEncoder.Default.UrlEncode("http://example.com/base/signin-facebook"));
-            location.ShouldContain("scope=");
-            location.ShouldContain("state=");
-        }
-
-        [Fact]
-        public async Task MapWillNotAffectRedirect()
-        {
-            var server = CreateServer(
-                app =>
-                {
-                    app.UseFacebookAuthentication();
-                    app.Map("/login", signoutApp => signoutApp.Run(context => context.Authentication.ChallengeAsync("Facebook", new AuthenticationProperties() { RedirectUri = "/" })));
-                },
-                services =>
-                {
-                    services.AddAuthentication();
-                    services.ConfigureFacebookAuthentication(options =>
-                    {
-                        options.AppId = "Test App Id";
-                        options.AppSecret = "Test App Secret";
-                        options.SignInScheme = "External";
-                    });
-                },
-                handler: null);
-            var transaction = await server.SendAsync("http://example.com/login");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            var location = transaction.Response.Headers.Location.AbsoluteUri;
-            location.ShouldContain("https://www.facebook.com/v2.2/dialog/oauth");
-            location.ShouldContain("response_type=code");
-            location.ShouldContain("client_id=");
-            location.ShouldContain("redirect_uri="+ UrlEncoder.Default.UrlEncode("http://example.com/signin-facebook"));
-            location.ShouldContain("scope=");
-            location.ShouldContain("state=");
-        }
-
-        [Fact]
         public async Task ChallengeWillTriggerRedirection()
         {
             var server = CreateServer(

--- a/test/Microsoft.AspNet.Authentication.Test/Facebook/FacebookMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Facebook/FacebookMiddlewareTests.cs
@@ -64,6 +64,36 @@ namespace Microsoft.AspNet.Authentication.Facebook
         }
 
         [Fact]
+        public async Task NestedMapWillNotAffectRedirect()
+        {
+            var server = CreateServer(app =>
+                app.Map("/base", map => {
+                    map.UseFacebookAuthentication();
+                    map.Map("/login", signoutApp => signoutApp.Run(context => context.Authentication.ChallengeAsync("Facebook", new AuthenticationProperties() { RedirectUri = "/" })));
+                }),
+                services =>
+                {
+                    services.AddAuthentication();
+                    services.ConfigureFacebookAuthentication(options =>
+                    {
+                        options.AppId = "Test App Id";
+                        options.AppSecret = "Test App Secret";
+                        options.SignInScheme = "External";
+                    });
+                },
+                handler: null);
+            var transaction = await server.SendAsync("http://example.com/base/login");
+            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            var location = transaction.Response.Headers.Location.AbsoluteUri;
+            location.ShouldContain("https://www.facebook.com/v2.2/dialog/oauth");
+            location.ShouldContain("response_type=code");
+            location.ShouldContain("client_id=");
+            location.ShouldContain("redirect_uri=" + UrlEncoder.Default.UrlEncode("http://example.com/base/signin-facebook"));
+            location.ShouldContain("scope=");
+            location.ShouldContain("state=");
+        }
+
+        [Fact]
         public async Task MapWillNotAffectRedirect()
         {
             var server = CreateServer(


### PR DESCRIPTION
Fixes https://github.com/aspnet/Security/issues/309

Also addresses Authenticate being called repeatedly which was a regression (ticket should be generated once and cached)

Added a ShouldRenew for the CookieValidateContext which explicitly tells the cookie to renew the cookie.  Identity used to call SignInDirectly but that would trigger infinite validation loops.  Not sure this is the right fix but it appears to work.  Thoughts? @Tratcher 