### PR TITLE
Tweak SecurityHelper for MVC usage

### DIFF
--- a/src/Microsoft.AspNet.Authentication/AuthenticationHandler.cs
+++ b/src/Microsoft.AspNet.Authentication/AuthenticationHandler.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNet.Authentication
                 var ticket = await AuthenticateOnceAsync();
                 if (ticket?.Principal != null)
                 {
-                    SecurityHelper.AddUserPrincipal(Context, ticket.Principal);
+                    Context.User = SecurityHelper.MergeUserPrincipal(Context.User, ticket.Principal);
                 }
             }
         }

--- a/src/Microsoft.AspNet.Authentication/SecurityHelper.cs
+++ b/src/Microsoft.AspNet.Authentication/SecurityHelper.cs
@@ -19,19 +19,18 @@ namespace Microsoft.AspNet.Authentication
         /// any empty unauthenticated identities from context.User
         /// </summary>
         /// <param name="identity"></param>
-        public static void AddUserPrincipal([NotNull] HttpContext context, [NotNull] ClaimsPrincipal principal)
+        public static ClaimsPrincipal MergeUserPrincipal([NotNull] ClaimsPrincipal existingPrincipal, [NotNull] ClaimsPrincipal additionalPrincipal)
         {
             var newPrincipal = new ClaimsPrincipal();
             // New principal identities go first
-            newPrincipal.AddIdentities(principal.Identities);
+            newPrincipal.AddIdentities(additionalPrincipal.Identities);
 
             // Then add any existing non empty or authenticated identities
-            var existingPrincipal = context.User;
             if (existingPrincipal != null)
             {
                 newPrincipal.AddIdentities(existingPrincipal.Identities.Where(i => i.IsAuthenticated || i.Claims.Count() > 0));
             }
-            context.User = newPrincipal;
+            return newPrincipal;
         }
     }
 }

--- a/test/Microsoft.AspNet.Authentication.Test/SecurityHelperTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/SecurityHelperTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNet.Authentication
             context.User.ShouldNotBe(null);
             context.User.Identity.IsAuthenticated.ShouldBe(false);
 
-            SecurityHelper.AddUserPrincipal(context, new GenericPrincipal(new GenericIdentity("Test1", "Alpha"), new string[0]));
+            context.User = SecurityHelper.MergeUserPrincipal(context.User, new GenericPrincipal(new GenericIdentity("Test1", "Alpha"), new string[0]));
 
             context.User.ShouldNotBe(null);
             context.User.Identity.AuthenticationType.ShouldBe("Alpha");
@@ -40,12 +40,12 @@ namespace Microsoft.AspNet.Authentication
             context.User.Identity.AuthenticationType.ShouldBe("Alpha");
             context.User.Identity.Name.ShouldBe("Test1");
 
-            SecurityHelper.AddUserPrincipal(context, new GenericPrincipal(new GenericIdentity("Test2", "Beta"), new string[0]));
+            context.User = SecurityHelper.MergeUserPrincipal(context.User, new GenericPrincipal(new GenericIdentity("Test2", "Beta"), new string[0]));
 
             context.User.Identity.AuthenticationType.ShouldBe("Beta");
             context.User.Identity.Name.ShouldBe("Test2");
 
-            SecurityHelper.AddUserPrincipal(context, new GenericPrincipal(new GenericIdentity("Test3", "Gamma"), new string[0]));
+            context.User = SecurityHelper.MergeUserPrincipal(context.User, new GenericPrincipal(new GenericIdentity("Test3", "Gamma"), new string[0]));
 
             context.User.Identity.AuthenticationType.ShouldBe("Gamma");
             context.User.Identity.Name.ShouldBe("Test3");
@@ -77,7 +77,7 @@ namespace Microsoft.AspNet.Authentication
             newPrincipal.AddIdentity(newEmptyIdentity);
             newPrincipal.AddIdentity(identityTwo);
 
-            SecurityHelper.AddUserPrincipal(context, newPrincipal);
+            context.User = SecurityHelper.MergeUserPrincipal(context.User, newPrincipal);
 
             // Preserve newPrincipal order
             context.User.Identity.IsAuthenticated.ShouldBe(false);
@@ -91,7 +91,7 @@ namespace Microsoft.AspNet.Authentication
             principal.Identities.Skip(3).First().ShouldBe(identityEmptyWithAuthType);
 
             // This merge should drop newEmptyIdentity since its empty
-            SecurityHelper.AddUserPrincipal(context, new GenericPrincipal(new GenericIdentity("Test3", "Gamma"), new string[0]));
+            context.User = SecurityHelper.MergeUserPrincipal(context.User, new GenericPrincipal(new GenericIdentity("Test3", "Gamma"), new string[0]));
 
             context.User.Identity.AuthenticationType.ShouldBe("Gamma");
             context.User.Identity.Name.ShouldBe("Test3");


### PR DESCRIPTION
Pass/Return HttpContext.user instead of manipulating the context to make this reusable for MVC

cc @Tratcher 