### PR TITLE
Make AddAuthorization() idempotent

### DIFF
--- a/src/Microsoft.AspNet.Authorization/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNet.Authorization/ServiceCollectionExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Framework.DependencyInjection
         {
             services.AddOptions();
             services.TryAdd(ServiceDescriptor.Transient<IAuthorizationService, DefaultAuthorizationService>());
-            services.AddTransient<IAuthorizationHandler, PassThroughAuthorizationHandler>();
+            services.TryAddEnumerable(ServiceDescriptor.Transient<IAuthorizationHandler, PassThroughAuthorizationHandler>());
             return services;
         }
     }


### PR DESCRIPTION
Found this issue which looking into making AddMvc() idempotent. You'll end
up with multiple pass-through handlers registered if two components call
AddAuthorization(). This is very possible to happen if used two frameworks
in the same app.