### PR TITLE
Use a cross-platform friendly HttpClient for CoreCLR.

### DIFF
--- a/src/Microsoft.AspNet.Authentication.JwtBearer/JwtBearerAuthenticationMiddleware.cs
+++ b/src/Microsoft.AspNet.Authentication.JwtBearer/JwtBearerAuthenticationMiddleware.cs
@@ -99,7 +99,7 @@ namespace Microsoft.AspNet.Authentication.JwtBearer
                 webRequestHandler.ServerCertificateValidationCallback = options.BackchannelCertificateValidator.Validate;
             }
 #else
-            new WinHttpHandler();
+            new HttpClientHandler();
 #endif
             return handler;
         }

--- a/src/Microsoft.AspNet.Authentication.JwtBearer/project.json
+++ b/src/Microsoft.AspNet.Authentication.JwtBearer/project.json
@@ -19,7 +19,7 @@
         },
         "dnxcore50": {
             "dependencies": {
-                "System.Net.Http.WinHttpHandler": "4.0.0-beta-*"
+                "System.Net.Http": "4.0.1-beta-*"
             }
         }
     }

--- a/src/Microsoft.AspNet.Authentication.MicrosoftAccount/project.json
+++ b/src/Microsoft.AspNet.Authentication.MicrosoftAccount/project.json
@@ -11,11 +11,6 @@
     },
     "frameworks": {
         "dnx451": { },
-        "dnxcore50": {
-            "dependencies": {
-                "System.Dynamic.Runtime": "4.0.11-beta-*",
-                "System.ObjectModel": "4.0.11-beta-*"
-            }
-        }
+        "dnxcore50": { }
     }
 }

--- a/src/Microsoft.AspNet.Authentication.OAuth/OAuthAuthenticationMiddleware.cs
+++ b/src/Microsoft.AspNet.Authentication.OAuth/OAuthAuthenticationMiddleware.cs
@@ -115,7 +115,7 @@ namespace Microsoft.AspNet.Authentication.OAuth
                 webRequestHandler.ServerCertificateValidationCallback = options.BackchannelCertificateValidator.Validate;
             }
 #else
-                new WinHttpHandler();
+                new HttpClientHandler();
 #endif
             return handler;
         }

--- a/src/Microsoft.AspNet.Authentication.OAuth/project.json
+++ b/src/Microsoft.AspNet.Authentication.OAuth/project.json
@@ -19,7 +19,7 @@
         },
         "dnxcore50": {
             "dependencies": {
-                "System.Net.Http.WinHttpHandler": "4.0.0-beta-*"
+                "System.Net.Http": "4.0.1-beta-*"
             }
         }
     }

--- a/src/Microsoft.AspNet.Authentication.OpenIdConnect/OpenIdConnectAuthenticationMiddleware.cs
+++ b/src/Microsoft.AspNet.Authentication.OpenIdConnect/OpenIdConnectAuthenticationMiddleware.cs
@@ -167,7 +167,7 @@ namespace Microsoft.AspNet.Authentication.OpenIdConnect
                 webRequestHandler.ServerCertificateValidationCallback = options.BackchannelCertificateValidator.Validate;
             }
 #else
-                new WinHttpHandler();
+                new HttpClientHandler();
 #endif
             return handler;
         }

--- a/src/Microsoft.AspNet.Authentication.OpenIdConnect/project.json
+++ b/src/Microsoft.AspNet.Authentication.OpenIdConnect/project.json
@@ -21,7 +21,7 @@
         "dnxcore50": {
             "dependencies": {
                 "System.Collections.Specialized": "4.0.1-beta-*",
-                "System.Net.Http.WinHttpHandler": "4.0.0-beta-*"
+                "System.Net.Http": "4.0.1-beta-*"
             }
         }
     }

--- a/src/Microsoft.AspNet.Authentication.Twitter/TwitterAuthenticationMiddleware.cs
+++ b/src/Microsoft.AspNet.Authentication.Twitter/TwitterAuthenticationMiddleware.cs
@@ -109,7 +109,7 @@ namespace Microsoft.AspNet.Authentication.Twitter
                 webRequestHandler.ServerCertificateValidationCallback = options.BackchannelCertificateValidator.Validate;
             }
 #else
-                new WinHttpHandler();
+                new HttpClientHandler();
 #endif
             return handler;
         }

--- a/src/Microsoft.AspNet.Authentication.Twitter/project.json
+++ b/src/Microsoft.AspNet.Authentication.Twitter/project.json
@@ -18,7 +18,7 @@
         },
         "dnxcore50": {
             "dependencies": {
-                "System.Net.Http.WinHttpHandler": "4.0.0-beta-*"
+                "System.Net.Http": "4.0.1-beta-*"
             }
         }
     }


### PR DESCRIPTION
#415 
HttpClientHandler defaults to the new CurlHandler on Mac and Linux, and to WinHttpHandler on Windows.
@BrennanConroy @muratg