### PR TITLE
Fix OAuth Social sample

### DIFF
--- a/samples/SocialSample/Startup.cs
+++ b/samples/SocialSample/Startup.cs
@@ -52,17 +52,21 @@ namespace CookieSample
                 options.AppSecret = "a124463c4719c94b4228d9a240e5dc1a";
             });
 
-            app.UseOAuthAuthentication("Google-AccessToken", options =>
+            var googleOptions = new OAuthAuthenticationOptions
             {
-                options.ClientId = "560027070069-37ldt4kfuohhu3m495hk2j4pjp92d382.apps.googleusercontent.com";
-                options.ClientSecret = "n2Q-GEw9RQjzcRbU3qhfTj8f";
-                options.CallbackPath = new PathString("/signin-google-token");
-                options.AuthorizationEndpoint = GoogleAuthenticationDefaults.AuthorizationEndpoint;
-                options.TokenEndpoint = GoogleAuthenticationDefaults.TokenEndpoint;
-                options.Scope.Add("openid");
-                options.Scope.Add("profile");
-                options.Scope.Add("email");
-            });
+                AuthenticationScheme = "Google-AccessToken",
+                Caption = "Google-AccessToken",
+                ClientId = "560027070069-37ldt4kfuohhu3m495hk2j4pjp92d382.apps.googleusercontent.com",
+                ClientSecret = "n2Q-GEw9RQjzcRbU3qhfTj8f",
+                CallbackPath = new PathString("/signin-google-token"),
+                AuthorizationEndpoint = GoogleAuthenticationDefaults.AuthorizationEndpoint,
+                TokenEndpoint = GoogleAuthenticationDefaults.TokenEndpoint
+            };
+            googleOptions.Scope.Add("openid");
+            googleOptions.Scope.Add("profile");
+            googleOptions.Scope.Add("email");
+
+            app.UseOAuthAuthentication(googleOptions);
 
             // https://console.developers.google.com/project
             app.UseGoogleAuthentication(options =>
@@ -95,16 +99,18 @@ namespace CookieSample
             The sample app can then be run via:
              dnx . web
             */
-            app.UseOAuthAuthentication("Microsoft-AccessToken", options =>
+            var msOAuthOptions = new OAuthAuthenticationOptions
             {
-                options.Caption = "MicrosoftAccount-AccessToken - Requires project changes";
-                options.ClientId = "00000000480FF62E";
-                options.ClientSecret = "bLw2JIvf8Y1TaToipPEqxTVlOeJwCUsr";
-                options.CallbackPath = new PathString("/signin-microsoft-token");
-                options.AuthorizationEndpoint = MicrosoftAccountAuthenticationDefaults.AuthorizationEndpoint;
-                options.TokenEndpoint = MicrosoftAccountAuthenticationDefaults.TokenEndpoint;
-                options.Scope.Add("wl.basic");
-            });
+                AuthenticationScheme = "Microsoft-AccessToken",
+                Caption = "MicrosoftAccount-AccessToken - Requires project changes",
+                ClientId = "00000000480FF62E",
+                ClientSecret = "bLw2JIvf8Y1TaToipPEqxTVlOeJwCUsr",
+                CallbackPath = new PathString("/signin-microsoft-token"),
+                AuthorizationEndpoint = MicrosoftAccountAuthenticationDefaults.AuthorizationEndpoint,
+                TokenEndpoint = MicrosoftAccountAuthenticationDefaults.TokenEndpoint
+            };
+            msOAuthOptions.Scope.Add("wl.basic");
+            app.UseOAuthAuthentication(msOAuthOptions);
 
             app.UseMicrosoftAccountAuthentication(options =>
             {
@@ -115,27 +121,31 @@ namespace CookieSample
             });
 
             // https://github.com/settings/applications/
-            app.UseOAuthAuthentication("GitHub-AccessToken", options =>
+            app.UseOAuthAuthentication(new OAuthAuthenticationOptions
             {
-                options.ClientId = "8c0c5a572abe8fe89588";
-                options.ClientSecret = "e1d95eaf03461d27acd6f49d4fc7bf19d6ac8cda";
-                options.CallbackPath = new PathString("/signin-github-token");
-                options.AuthorizationEndpoint = "https://github.com/login/oauth/authorize";
-                options.TokenEndpoint = "https://github.com/login/oauth/access_token";
+                AuthenticationScheme = "GitHub-AccessToken",
+                Caption = "Github-AccessToken",
+                ClientId = "8c0c5a572abe8fe89588",
+                ClientSecret = "e1d95eaf03461d27acd6f49d4fc7bf19d6ac8cda",
+                CallbackPath = new PathString("/signin-github-token"),
+                AuthorizationEndpoint = "https://github.com/login/oauth/authorize",
+                TokenEndpoint = "https://github.com/login/oauth/access_token"
             });
 
-            app.UseOAuthAuthentication("GitHub", options =>
+            app.UseOAuthAuthentication(new OAuthAuthenticationOptions
             {
-                options.ClientId = "49e302895d8b09ea5656";
-                options.ClientSecret = "98f1bf028608901e9df91d64ee61536fe562064b";
-                options.CallbackPath = new PathString("/signin-github");
-                options.AuthorizationEndpoint = "https://github.com/login/oauth/authorize";
-                options.TokenEndpoint = "https://github.com/login/oauth/access_token";
-                options.UserInformationEndpoint = "https://api.github.com/user";
-                options.ClaimsIssuer = "OAuth2-Github";
-                options.SaveTokensAsClaims = false;
+                AuthenticationScheme = "GitHub",
+                Caption = "Github",
+                ClientId = "49e302895d8b09ea5656",
+                ClientSecret = "98f1bf028608901e9df91d64ee61536fe562064b",
+                CallbackPath = new PathString("/signin-github"),
+                AuthorizationEndpoint = "https://github.com/login/oauth/authorize",
+                TokenEndpoint = "https://github.com/login/oauth/access_token",
+                UserInformationEndpoint = "https://api.github.com/user",
+                ClaimsIssuer = "OAuth2-Github",
+                SaveTokensAsClaims = false,
                 // Retrieving user information is unique to each provider.
-                options.Events = new OAuthAuthenticationEvents
+                Events = new OAuthAuthenticationEvents
                 {
                     OnAuthenticated = async context =>
                     {
@@ -180,8 +190,8 @@ namespace CookieSample
                                 "urn:github:url", link,
                                 ClaimValueTypes.String, context.Options.ClaimsIssuer));
                         }
-                    },
-                };
+                    }
+                }
             });
 
             // Choose an authentication type

--- a/src/Microsoft.AspNet.Authentication.OAuth/OAuthAuthenticationExtensions.cs
+++ b/src/Microsoft.AspNet.Authentication.OAuth/OAuthAuthenticationExtensions.cs
@@ -19,18 +19,27 @@ namespace Microsoft.AspNet.Builder
         /// <param name="app">The <see cref="IApplicationBuilder"/> passed to the configure method.</param>
         /// <param name="options">The middleware configuration options.</param>
         /// <returns>The updated <see cref="IApplicationBuilder"/>.</returns>
-        public static IApplicationBuilder UseOAuthAuthentication([NotNull] this IApplicationBuilder app, [NotNull] string authenticationScheme, Action<OAuthAuthenticationOptions> configureOptions = null)
+        public static IApplicationBuilder UseOAuthAuthentication([NotNull] this IApplicationBuilder app, [NotNull] string authenticationScheme)
         {
             return app.UseMiddleware<OAuthAuthenticationMiddleware<OAuthAuthenticationOptions>>(
-                new ConfigureOptions<OAuthAuthenticationOptions>(options =>
-                {
-                    options.AuthenticationScheme = authenticationScheme;
-                    options.Caption = authenticationScheme;
-                    if (configureOptions != null)
-                    {
-                        configureOptions(options);
-                    }
-                }));
+                new OAuthAuthenticationOptions {
+                    AuthenticationScheme = authenticationScheme,
+                    Caption = authenticationScheme
+                },
+                new ConfigureOptions<OAuthAuthenticationOptions>(options => { }));
+        }
+
+        /// <summary>
+        /// Authenticate users using OAuth.
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder"/> passed to the configure method.</param>
+        /// <param name="options">The middleware configuration options.</param>
+        /// <returns>The updated <see cref="IApplicationBuilder"/>.</returns>
+        public static IApplicationBuilder UseOAuthAuthentication([NotNull] this IApplicationBuilder app, [NotNull] IOptions<OAuthAuthenticationOptions> options)
+        {
+            return app.UseMiddleware<OAuthAuthenticationMiddleware<OAuthAuthenticationOptions>>(
+                options,
+                new ConfigureOptions<OAuthAuthenticationOptions>(o => { }));
         }
     }
 }

--- a/src/Microsoft.AspNet.Authentication.OAuth/OAuthAuthenticationExtensions.cs
+++ b/src/Microsoft.AspNet.Authentication.OAuth/OAuthAuthenticationExtensions.cs
@@ -19,22 +19,6 @@ namespace Microsoft.AspNet.Builder
         /// <param name="app">The <see cref="IApplicationBuilder"/> passed to the configure method.</param>
         /// <param name="options">The middleware configuration options.</param>
         /// <returns>The updated <see cref="IApplicationBuilder"/>.</returns>
-        public static IApplicationBuilder UseOAuthAuthentication([NotNull] this IApplicationBuilder app, [NotNull] string authenticationScheme)
-        {
-            return app.UseMiddleware<OAuthAuthenticationMiddleware<OAuthAuthenticationOptions>>(
-                new OAuthAuthenticationOptions {
-                    AuthenticationScheme = authenticationScheme,
-                    Caption = authenticationScheme
-                },
-                new ConfigureOptions<OAuthAuthenticationOptions>(options => { }));
-        }
-
-        /// <summary>
-        /// Authenticate users using OAuth.
-        /// </summary>
-        /// <param name="app">The <see cref="IApplicationBuilder"/> passed to the configure method.</param>
-        /// <param name="options">The middleware configuration options.</param>
-        /// <returns>The updated <see cref="IApplicationBuilder"/>.</returns>
         public static IApplicationBuilder UseOAuthAuthentication([NotNull] this IApplicationBuilder app, [NotNull] IOptions<OAuthAuthenticationOptions> options)
         {
             return app.UseMiddleware<OAuthAuthenticationMiddleware<OAuthAuthenticationOptions>>(

--- a/src/Microsoft.AspNet.Authentication.OAuth/OAuthAuthenticationOptions.cs
+++ b/src/Microsoft.AspNet.Authentication.OAuth/OAuthAuthenticationOptions.cs
@@ -4,16 +4,16 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Security.Claims;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Authentication;
+using Microsoft.Framework.OptionsModel;
 
 namespace Microsoft.AspNet.Authentication.OAuth
 {
     /// <summary>
     /// Configuration options for <see cref="OAuthAuthenticationMiddleware"/>.
     /// </summary>
-    public class OAuthAuthenticationOptions : AuthenticationOptions
+    public class OAuthAuthenticationOptions : AuthenticationOptions, IOptions<OAuthAuthenticationOptions>
     {
         /// <summary>
         /// Gets or sets the provider-assigned client id.
@@ -115,5 +115,13 @@ namespace Microsoft.AspNet.Authentication.OAuth
         /// authentication cookie. Note that social providers set this property to <c>false</c> by default.
         /// </summary>
         public bool SaveTokensAsClaims { get; set; } = true;
+
+        OAuthAuthenticationOptions IOptions<OAuthAuthenticationOptions>.Value
+        {
+            get
+            {
+                return this;
+            }
+        }
     }
 }

--- a/test/Microsoft.AspNet.Authentication.Test/Cookies/CookieMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Cookies/CookieMiddlewareTests.cs
@@ -19,7 +19,6 @@ using Microsoft.AspNet.Http.Authentication;
 using Microsoft.AspNet.Http.Features.Authentication;
 using Microsoft.AspNet.TestHost;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.Internal;
 using Shouldly;
 using Xunit;
 


### PR DESCRIPTION
Like cookies OAuthAuthenticationOptions now uses instances of options.

@Tratcher @PinpointTownes this fixes things, but things still feel a bit clunky.  I'd love to nuke ConfigureOptions entirely potentially, so then we could take over the lambda to be configuring a new instance of the options instead of tweaking the one that came from DI.  Thoughts?

