### PR TITLE
Add new CookiePolicy middleware

### DIFF
--- a/Security.sln
+++ b/Security.sln
@@ -46,6 +46,10 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.Authorizat
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.Authorization", "src\Microsoft.AspNet.Authorization\Microsoft.AspNet.Authorization.xproj", "{6AB3E514-5894-4131-9399-DC7D5284ADDB}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.CookiePolicy", "src\Microsoft.AspNet.CookiePolicy\Microsoft.AspNet.CookiePolicy.xproj", "{86183DC3-02A8-4A68-8B60-71ECEC066E79}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.CookiePolicy.Test", "test\Microsoft.AspNet.CookiePolicy.Test\Microsoft.AspNet.CookiePolicy.Test.xproj", "{1790E052-646F-4529-B90E-6FEA95520D69}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -242,6 +246,30 @@ Global
 		{6AB3E514-5894-4131-9399-DC7D5284ADDB}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{6AB3E514-5894-4131-9399-DC7D5284ADDB}.Release|x86.ActiveCfg = Release|Any CPU
 		{6AB3E514-5894-4131-9399-DC7D5284ADDB}.Release|x86.Build.0 = Release|Any CPU
+		{86183DC3-02A8-4A68-8B60-71ECEC066E79}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86183DC3-02A8-4A68-8B60-71ECEC066E79}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86183DC3-02A8-4A68-8B60-71ECEC066E79}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{86183DC3-02A8-4A68-8B60-71ECEC066E79}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{86183DC3-02A8-4A68-8B60-71ECEC066E79}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{86183DC3-02A8-4A68-8B60-71ECEC066E79}.Debug|x86.Build.0 = Debug|Any CPU
+		{86183DC3-02A8-4A68-8B60-71ECEC066E79}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{86183DC3-02A8-4A68-8B60-71ECEC066E79}.Release|Any CPU.Build.0 = Release|Any CPU
+		{86183DC3-02A8-4A68-8B60-71ECEC066E79}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{86183DC3-02A8-4A68-8B60-71ECEC066E79}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{86183DC3-02A8-4A68-8B60-71ECEC066E79}.Release|x86.ActiveCfg = Release|Any CPU
+		{86183DC3-02A8-4A68-8B60-71ECEC066E79}.Release|x86.Build.0 = Release|Any CPU
+		{1790E052-646F-4529-B90E-6FEA95520D69}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1790E052-646F-4529-B90E-6FEA95520D69}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1790E052-646F-4529-B90E-6FEA95520D69}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{1790E052-646F-4529-B90E-6FEA95520D69}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{1790E052-646F-4529-B90E-6FEA95520D69}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1790E052-646F-4529-B90E-6FEA95520D69}.Debug|x86.Build.0 = Debug|Any CPU
+		{1790E052-646F-4529-B90E-6FEA95520D69}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1790E052-646F-4529-B90E-6FEA95520D69}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1790E052-646F-4529-B90E-6FEA95520D69}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{1790E052-646F-4529-B90E-6FEA95520D69}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{1790E052-646F-4529-B90E-6FEA95520D69}.Release|x86.ActiveCfg = Release|Any CPU
+		{1790E052-646F-4529-B90E-6FEA95520D69}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -263,5 +291,7 @@ Global
 		{2755BFE5-7421-4A31-A644-F817DF5CAA98} = {4D2B6A51-2F9F-44F5-8131-EA5CAC053652}
 		{7AF5AD96-EB6E-4D0E-8ABE-C0B543C0F4C2} = {7BF11F3A-60B6-4796-B504-579C67FFBA34}
 		{6AB3E514-5894-4131-9399-DC7D5284ADDB} = {4D2B6A51-2F9F-44F5-8131-EA5CAC053652}
+		{86183DC3-02A8-4A68-8B60-71ECEC066E79} = {4D2B6A51-2F9F-44F5-8131-EA5CAC053652}
+		{1790E052-646F-4529-B90E-6FEA95520D69} = {7BF11F3A-60B6-4796-B504-579C67FFBA34}
 	EndGlobalSection
 EndGlobal

--- a/src/Microsoft.AspNet.CookiePolicy/AppendCookieContext.cs
+++ b/src/Microsoft.AspNet.CookiePolicy/AppendCookieContext.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Http;
+
+namespace Microsoft.AspNet.CookiePolicy
+{
+    public class AppendCookieContext
+    {
+        public AppendCookieContext(HttpContext context, CookieOptions options, string name, string value)
+        {
+            Context = context;
+            CookieOptions = options;
+            CookieName = name;
+            CookieValue = value;
+        }
+
+        public HttpContext Context { get; }
+        public CookieOptions CookieOptions { get; }
+        public string CookieName { get; set; }
+        public string CookieValue { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.CookiePolicy/CookiePolicyAppBuilderExtensions.cs
+++ b/src/Microsoft.AspNet.CookiePolicy/CookiePolicyAppBuilderExtensions.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNet.CookiePolicy;
+
+namespace Microsoft.AspNet.Builder
+{
+    /// <summary>
+    /// Extension methods provided by the cookie policy middleware
+    /// </summary>
+    public static class CookiePolicyAppBuilderExtensions
+    {
+        /// <summary>
+        /// Adds a claims transformation middleware to your web application pipeline.
+        /// </summary>
+        /// <param name="app">The IApplicationBuilder passed to your configuration method</param>
+        /// <returns>The original app parameter</returns>
+        public static IApplicationBuilder UseCookiePolicy(this IApplicationBuilder app)
+        {
+            return app.UseCookiePolicy(configureOptions: o => { });
+        }
+
+        /// <summary>
+        /// Adds a claims transformation middleware to your web application pipeline.
+        /// </summary>
+        /// <param name="app">The IApplicationBuilder passed to your configuration method</param>
+        /// <param name="configureOptions">Used to configure the options for the middleware</param>
+        /// <returns>The original app parameter</returns>
+        public static IApplicationBuilder UseCookiePolicy(this IApplicationBuilder app, Action<CookiePolicyOptions> configureOptions)
+        {
+            return app.UseMiddleware<CookiePolicyMiddleware>(configureOptions);
+        }
+    }
+}

--- a/src/Microsoft.AspNet.CookiePolicy/CookiePolicyAppBuilderExtensions.cs
+++ b/src/Microsoft.AspNet.CookiePolicy/CookiePolicyAppBuilderExtensions.cs
@@ -15,10 +15,11 @@ namespace Microsoft.AspNet.Builder
         /// Adds a cookie policy middleware to your web application pipeline.
         /// </summary>
         /// <param name="app">The IApplicationBuilder passed to your configuration method</param>
+        /// <param name="options">The options for the middleware</param>
         /// <returns>The original app parameter</returns>
-        public static IApplicationBuilder UseCookiePolicy(this IApplicationBuilder app)
+        public static IApplicationBuilder UseCookiePolicy(this IApplicationBuilder app, CookiePolicyOptions options)
         {
-            return app.UseCookiePolicy(configureOptions: o => { });
+            return app.UseMiddleware<CookiePolicyMiddleware>(options);
         }
 
         /// <summary>
@@ -29,7 +30,12 @@ namespace Microsoft.AspNet.Builder
         /// <returns>The original app parameter</returns>
         public static IApplicationBuilder UseCookiePolicy(this IApplicationBuilder app, Action<CookiePolicyOptions> configureOptions)
         {
-            return app.UseMiddleware<CookiePolicyMiddleware>(configureOptions);
+            var options = new CookiePolicyOptions();
+            if (configureOptions != null)
+            {
+                configureOptions(options);
+            }
+            return app.UseCookiePolicy(options);
         }
     }
 }

--- a/src/Microsoft.AspNet.CookiePolicy/CookiePolicyAppBuilderExtensions.cs
+++ b/src/Microsoft.AspNet.CookiePolicy/CookiePolicyAppBuilderExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNet.Builder
     public static class CookiePolicyAppBuilderExtensions
     {
         /// <summary>
-        /// Adds a claims transformation middleware to your web application pipeline.
+        /// Adds a cookie policy middleware to your web application pipeline.
         /// </summary>
         /// <param name="app">The IApplicationBuilder passed to your configuration method</param>
         /// <returns>The original app parameter</returns>
@@ -22,7 +22,7 @@ namespace Microsoft.AspNet.Builder
         }
 
         /// <summary>
-        /// Adds a claims transformation middleware to your web application pipeline.
+        /// Adds a cookie policy middleware to your web application pipeline.
         /// </summary>
         /// <param name="app">The IApplicationBuilder passed to your configuration method</param>
         /// <param name="configureOptions">Used to configure the options for the middleware</param>

--- a/src/Microsoft.AspNet.CookiePolicy/CookiePolicyMiddleware.cs
+++ b/src/Microsoft.AspNet.CookiePolicy/CookiePolicyMiddleware.cs
@@ -133,7 +133,6 @@ namespace Microsoft.AspNet.CookiePolicy
                 Cookies.Delete(key, options);
             }
 
-            // Returns true if cookie options need to be applied
             private void ApplyPolicy(CookieOptions options)
             {
                 switch (Policy.Secure)

--- a/src/Microsoft.AspNet.CookiePolicy/CookiePolicyMiddleware.cs
+++ b/src/Microsoft.AspNet.CookiePolicy/CookiePolicyMiddleware.cs
@@ -25,11 +25,8 @@ namespace Microsoft.AspNet.CookiePolicy
 
         public Task Invoke(HttpContext context)
         {
-            // Check if there is a SendFile feature already present
-            if (context.Features.Get<IHttpSendFileFeature>() == null)
-            {
-                context.Features.Set<IResponseCookiesFeature>(new CookiesWrapperFeature(context, Options));
-            }
+            // REVIEW: Do we need to check if there is a Cookie feature already present like SendFile??
+            context.Features.Set<IResponseCookiesFeature>(new CookiesWrapperFeature(context, Options));
 
             return _next(context);
         }

--- a/src/Microsoft.AspNet.CookiePolicy/CookiePolicyMiddleware.cs
+++ b/src/Microsoft.AspNet.CookiePolicy/CookiePolicyMiddleware.cs
@@ -71,18 +71,10 @@ namespace Microsoft.AspNet.CookiePolicy
 
             public void Append(string key, string value)
             {
-                if (PolicyRequiresCookieOptions())
+                if (PolicyRequiresCookieOptions() || Policy.OnAppendCookie != null)
                 {
                     Append(key, value, new CookieOptions());
                     return;
-                }
-
-                if (Policy.OnAppendCookie != null)
-                {
-                    var context = new AppendCookieContext(Context, options: null, name: key, value: value);
-                    Policy.OnAppendCookie(context);
-                    key = context.CookieName;
-                    value = context.CookieValue;
                 }
                 Cookies.Append(key, value);
             }
@@ -102,12 +94,11 @@ namespace Microsoft.AspNet.CookiePolicy
 
             public void Delete(string key)
             {
-                if (PolicyRequiresCookieOptions())
+                if (PolicyRequiresCookieOptions() || Policy.OnDeleteCookie != null)
                 {
                     Delete(key, new CookieOptions());
                     return;
                 }
-
 
                 if (Policy.OnDeleteCookie != null)
                 {

--- a/src/Microsoft.AspNet.CookiePolicy/CookiePolicyMiddleware.cs
+++ b/src/Microsoft.AspNet.CookiePolicy/CookiePolicyMiddleware.cs
@@ -26,9 +26,7 @@ namespace Microsoft.AspNet.CookiePolicy
 
         public Task Invoke(HttpContext context)
         {
-            // REVIEW: Do we need to check if there is a Cookie feature already present like SendFile??
             context.Features.Set<IResponseCookiesFeature>(new CookiesWrapperFeature(context, Options));
-
             return _next(context);
         }
 

--- a/src/Microsoft.AspNet.CookiePolicy/CookiePolicyMiddleware.cs
+++ b/src/Microsoft.AspNet.CookiePolicy/CookiePolicyMiddleware.cs
@@ -1,12 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Features;
-using Microsoft.Framework.OptionsModel;
 using Microsoft.AspNet.Http.Features.Internal;
 
 namespace Microsoft.AspNet.CookiePolicy
@@ -17,14 +15,9 @@ namespace Microsoft.AspNet.CookiePolicy
 
         public CookiePolicyMiddleware(
             RequestDelegate next,
-            IOptions<CookiePolicyOptions> options,
-            Action<CookiePolicyOptions> configureOptions)
+            CookiePolicyOptions options)
         {
-            Options = options.Value ?? new CookiePolicyOptions(); // REVIEW: or should we throw ArgumentNull exception?
-            if (configureOptions != null)
-            {
-                configureOptions(Options);
-            }
+            Options = options;
             _next = next;
         }
 

--- a/src/Microsoft.AspNet.CookiePolicy/CookiePolicyMiddleware.cs
+++ b/src/Microsoft.AspNet.CookiePolicy/CookiePolicyMiddleware.cs
@@ -1,0 +1,168 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Builder;
+using Microsoft.AspNet.Http;
+using Microsoft.AspNet.Http.Features;
+using Microsoft.Framework.OptionsModel;
+using Microsoft.AspNet.Http.Features.Internal;
+
+namespace Microsoft.AspNet.CookiePolicy
+{
+    public class CookiePolicyMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public CookiePolicyMiddleware(
+            RequestDelegate next,
+            IOptions<CookiePolicyOptions> options,
+            Action<CookiePolicyOptions> configureOptions)
+        {
+            Options = options.Value ?? new CookiePolicyOptions(); // REVIEW: or should we throw ArgumentNull exception?
+            if (configureOptions != null)
+            {
+                configureOptions(Options);
+            }
+            _next = next;
+        }
+
+        public CookiePolicyOptions Options { get; set; }
+
+        public Task Invoke(HttpContext context)
+        {
+            // Check if there is a SendFile feature already present
+            if (context.Features.Get<IHttpSendFileFeature>() == null)
+            {
+                context.Features.Set<IResponseCookiesFeature>(new CookiesWrapperFeature(context, Options));
+            }
+
+            return _next(context);
+        }
+
+        private class CookiesWrapperFeature : IResponseCookiesFeature
+        {
+            public CookiesWrapperFeature(HttpContext context, CookiePolicyOptions options)
+            {
+                Wrapper = new CookiesWrapper(context, options, context.Response.Cookies);
+            }
+
+            public IResponseCookies Wrapper { get; }
+
+            public IResponseCookies Cookies
+            {
+                get
+                {
+                    return Wrapper;
+                }
+            }
+        }
+
+        private class CookiesWrapper : IResponseCookies
+        {
+            public CookiesWrapper(HttpContext context, CookiePolicyOptions options, IResponseCookies cookies)
+            {
+                Context = context;
+                Cookies = cookies;
+                Policy = options;
+            }
+
+            public HttpContext Context { get; }
+
+            public IResponseCookies Cookies { get; }
+
+            public CookiePolicyOptions Policy { get; }
+
+            private bool PolicyRequiresCookieOptions()
+            {
+                return Policy.HttpOnly != HttpOnlyPolicy.None || Policy.Secure != SecurePolicy.None;
+            }
+
+            public void Append(string key, string value)
+            {
+                if (PolicyRequiresCookieOptions())
+                {
+                    Append(key, value, new CookieOptions());
+                    return;
+                }
+
+                if (Policy.OnAppendCookie != null)
+                {
+                    var context = new AppendCookieContext(Context, options: null, name: key, value: value);
+                    Policy.OnAppendCookie(context);
+                    key = context.CookieName;
+                    value = context.CookieValue;
+                }
+                Cookies.Append(key, value);
+            }
+
+            public void Append(string key, string value, CookieOptions options)
+            {
+                ApplyPolicy(options);
+                if (Policy.OnAppendCookie != null)
+                {
+                    var context = new AppendCookieContext(Context, options, key, value);
+                    Policy.OnAppendCookie(context);
+                    key = context.CookieName;
+                    value = context.CookieValue;
+                }
+                Cookies.Append(key, value, options);
+            }
+
+            public void Delete(string key)
+            {
+                if (PolicyRequiresCookieOptions())
+                {
+                    Delete(key, new CookieOptions());
+                    return;
+                }
+
+
+                if (Policy.OnDeleteCookie != null)
+                {
+                    var context = new DeleteCookieContext(Context, options: null, name: key);
+                    Policy.OnDeleteCookie(context);
+                    key = context.CookieName;
+                }
+                Cookies.Delete(key);
+            }
+
+            public void Delete(string key, CookieOptions options)
+            {
+                ApplyPolicy(options);
+                if (Policy.OnDeleteCookie != null)
+                {
+                    var context = new DeleteCookieContext(Context, options, key);
+                    Policy.OnDeleteCookie(context);
+                    key = context.CookieName;
+                }
+                Cookies.Delete(key, options);
+            }
+
+            // Returns true if cookie options need to be applied
+            private void ApplyPolicy(CookieOptions options)
+            {
+                switch (Policy.Secure)
+                {
+                    case SecurePolicy.Always:
+                        options.Secure = true;
+                        break;
+                    case SecurePolicy.SameAsRequest:
+                        options.Secure = Context.Request.IsHttps;
+                        break;
+                    case SecurePolicy.None:
+                        break;
+                }
+                switch (Policy.HttpOnly)
+                {
+                    case HttpOnlyPolicy.Always:
+                        options.HttpOnly = true;
+                        break;
+                    case HttpOnlyPolicy.None:
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNet.CookiePolicy/CookiePolicyOptions.cs
+++ b/src/Microsoft.AspNet.CookiePolicy/CookiePolicyOptions.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNet.CookiePolicy
+{
+    public class CookiePolicyOptions
+    {
+        public HttpOnlyPolicy HttpOnly { get; set; } = HttpOnlyPolicy.None;
+        public SecurePolicy Secure { get; set; } = SecurePolicy.None;
+
+        public Action<AppendCookieContext> OnAppendCookie { get; set; }
+        public Action<DeleteCookieContext> OnDeleteCookie { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.CookiePolicy/DeleteCookieContext.cs
+++ b/src/Microsoft.AspNet.CookiePolicy/DeleteCookieContext.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Http;
+
+namespace Microsoft.AspNet.CookiePolicy
+{
+    public class DeleteCookieContext
+    {
+        public DeleteCookieContext(HttpContext context, CookieOptions options, string name)
+        {
+            Context = context;
+            CookieOptions = options;
+            CookieName = name;
+        }
+
+        public HttpContext Context { get; }
+        public CookieOptions CookieOptions { get; }
+        public string CookieName { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.CookiePolicy/HttpOnlyPolicy.cs
+++ b/src/Microsoft.AspNet.CookiePolicy/HttpOnlyPolicy.cs
@@ -1,0 +1,11 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNet.CookiePolicy
+{
+    public enum HttpOnlyPolicy
+    {
+        None,
+        Always
+    }
+}

--- a/src/Microsoft.AspNet.CookiePolicy/Microsoft.AspNet.CookiePolicy.xproj
+++ b/src/Microsoft.AspNet.CookiePolicy/Microsoft.AspNet.CookiePolicy.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>86183dc3-02a8-4a68-8b60-71ecec066e79</ProjectGuid>
+    <RootNamespace>Microsoft.AspNet.CookiePolicy</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/Microsoft.AspNet.CookiePolicy/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.AspNet.CookiePolicy/Properties/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using System.Resources;
+
+[assembly: AssemblyMetadata("Serviceable", "True")]
+[assembly: NeutralResourcesLanguage("en-us")]

--- a/src/Microsoft.AspNet.CookiePolicy/SecurePolicy.cs
+++ b/src/Microsoft.AspNet.CookiePolicy/SecurePolicy.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNet.CookiePolicy
+{
+    public enum SecurePolicy
+    {
+        None,
+        Always,
+        SameAsRequest
+    }
+}

--- a/src/Microsoft.AspNet.CookiePolicy/project.json
+++ b/src/Microsoft.AspNet.CookiePolicy/project.json
@@ -1,0 +1,18 @@
+{
+    "version": "1.0.0-*",
+    "description": "ASP.NET 5 cookie policy classes.",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/aspnet/security"
+    },
+    "dependencies": {
+        "Microsoft.AspNet.Http.Abstractions": "1.0.0-*",
+        "Microsoft.AspNet.Http.Features": "1.0.0-*",
+        "Microsoft.AspNet.Http": "1.0.0-*",
+        "Microsoft.Framework.OptionsModel": "1.0.0-*"
+    },
+    "frameworks": {
+        "dnx451": { },
+        "dnxcore50": { }
+    }
+}

--- a/src/Microsoft.AspNet.CookiePolicy/project.json
+++ b/src/Microsoft.AspNet.CookiePolicy/project.json
@@ -6,8 +6,7 @@
         "url": "git://github.com/aspnet/security"
     },
     "dependencies": {
-        "Microsoft.AspNet.Http": "1.0.0-*",
-        "Microsoft.Framework.OptionsModel": "1.0.0-*"
+        "Microsoft.AspNet.Http": "1.0.0-*"
     },
     "frameworks": {
         "dnx451": { },

--- a/src/Microsoft.AspNet.CookiePolicy/project.json
+++ b/src/Microsoft.AspNet.CookiePolicy/project.json
@@ -6,8 +6,6 @@
         "url": "git://github.com/aspnet/security"
     },
     "dependencies": {
-        "Microsoft.AspNet.Http.Abstractions": "1.0.0-*",
-        "Microsoft.AspNet.Http.Features": "1.0.0-*",
         "Microsoft.AspNet.Http": "1.0.0-*",
         "Microsoft.Framework.OptionsModel": "1.0.0-*"
     },

--- a/test/Microsoft.AspNet.Authentication.Test/Cookies/CookieMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Cookies/CookieMiddlewareTests.cs
@@ -731,7 +731,7 @@ namespace Microsoft.AspNet.Authentication.Cookies
             transaction.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
         }
 
-/*        [Fact]
+        [Fact]
         public async Task UseCookieWithInstanceDoesntUseSharedOptions()
         {
             var server = TestServer.Create(app =>
@@ -761,7 +761,7 @@ namespace Microsoft.AspNet.Authentication.Cookies
 
             transaction.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
             Assert.True(transaction.SetCookie[0].StartsWith("One="));
-        }*/
+        }
 
         [Fact]
         public async Task MapWithSignInOnlyRedirectToReturnUrlOnLoginPath()

--- a/test/Microsoft.AspNet.CookiePolicy.Test/CookiePolicyTests.cs
+++ b/test/Microsoft.AspNet.CookiePolicy.Test/CookiePolicyTests.cs
@@ -12,9 +12,129 @@ namespace Microsoft.AspNet.CookiePolicy.Test
     public class CookiePolicyTests
     {
         [Fact]
-        public async Task UseMapToTestSecurePolicyAndHttpOnlyModes()
+        public async Task SecureAlwaysSetsSecure()
+        {
+            var server = CreateTestServer();
+            var transaction = await server.SendAsync("http://example.com/secureAlways");
+
+            Assert.NotNull(transaction.SetCookie);
+            Assert.Equal("A=A; path=/; secure", transaction.SetCookie[0]);
+            Assert.Equal("B=B; path=/; secure", transaction.SetCookie[1]);
+            Assert.Equal("C=C; path=/; secure", transaction.SetCookie[2]);
+            Assert.Equal("D=D; path=/; secure", transaction.SetCookie[3]);
+        }
+
+        [Fact]
+        public async Task SecureNoneLeavesSecureUnchanged()
+        {
+            var server = CreateTestServer();
+            var transaction = await server.SendAsync("http://example.com/secureNone");
+
+            Assert.NotNull(transaction.SetCookie);
+            Assert.Equal("A=A; path=/", transaction.SetCookie[0]);
+            Assert.Equal("B=B; path=/", transaction.SetCookie[1]);
+            Assert.Equal("C=C; path=/", transaction.SetCookie[2]);
+            Assert.Equal("D=D; path=/; secure", transaction.SetCookie[3]);
+        }
+
+        [Fact]
+        public async Task SecureSameUsesRequest()
+        {
+            var server = CreateTestServer();
+            var transaction = await server.SendAsync("http://example.com/secureSame");
+
+            Assert.NotNull(transaction.SetCookie);
+            Assert.Equal("A=A; path=/", transaction.SetCookie[0]);
+            Assert.Equal("B=B; path=/", transaction.SetCookie[1]);
+            Assert.Equal("C=C; path=/", transaction.SetCookie[2]);
+            Assert.Equal("D=D; path=/", transaction.SetCookie[3]);
+
+            transaction = await server.SendAsync("https://example.com/secureSame");
+
+            Assert.NotNull(transaction.SetCookie);
+            Assert.Equal("A=A; path=/; secure", transaction.SetCookie[0]);
+            Assert.Equal("B=B; path=/; secure", transaction.SetCookie[1]);
+            Assert.Equal("C=C; path=/; secure", transaction.SetCookie[2]);
+            Assert.Equal("D=D; path=/; secure", transaction.SetCookie[3]);
+        }
+
+        [Fact]
+        public async Task HttpOnlyAlwaysSetsItAlways()
+        {
+            var server = CreateTestServer();
+            var transaction = await server.SendAsync("http://example.com/httpOnlyAlways");
+
+            Assert.NotNull(transaction.SetCookie);
+            Assert.Equal("A=A; path=/; httponly", transaction.SetCookie[0]);
+            Assert.Equal("B=B; path=/; httponly", transaction.SetCookie[1]);
+            Assert.Equal("C=C; path=/; httponly", transaction.SetCookie[2]);
+            Assert.Equal("D=D; path=/; httponly", transaction.SetCookie[3]);
+        }
+
+        [Fact]
+        public async Task HttpOnlyNoneLeavesItAlone()
+        {
+            var server = CreateTestServer();
+            var transaction = await server.SendAsync("http://example.com/httpOnlyNone");
+
+            Assert.NotNull(transaction.SetCookie);
+            Assert.Equal("A=A; path=/", transaction.SetCookie[0]);
+            Assert.Equal("B=B; path=/", transaction.SetCookie[1]);
+            Assert.Equal("C=C; path=/", transaction.SetCookie[2]);
+            Assert.Equal("D=D; path=/; httponly", transaction.SetCookie[3]);
+        }
+
+        [Fact]
+        public async Task CookiePolicyCanHijackAppend()
         {
             var server = TestServer.Create(app =>
+            {
+                app.UseCookiePolicy(options => options.OnAppendCookie = ctx => ctx.CookieName = ctx.CookieValue = "Hao");
+                app.Run(context =>
+                {
+                    context.Response.Cookies.Append("A", "A");
+                    context.Response.Cookies.Append("B", "B", new CookieOptions { Secure = false });
+                    context.Response.Cookies.Append("C", "C", new CookieOptions());
+                    context.Response.Cookies.Append("D", "D", new CookieOptions { Secure = true });
+                    return Task.FromResult(0);
+                });
+            });
+
+            var transaction = await server.SendAsync("http://example.com/login");
+
+            Assert.NotNull(transaction.SetCookie);
+            Assert.Equal("Hao=Hao; path=/", transaction.SetCookie[0]);
+            Assert.Equal("Hao=Hao; path=/", transaction.SetCookie[1]);
+            Assert.Equal("Hao=Hao; path=/", transaction.SetCookie[2]);
+            Assert.Equal("Hao=Hao; path=/; secure", transaction.SetCookie[3]);
+        }
+
+        [Fact]
+        public async Task CookiePolicyCanHijackDelete()
+        {
+            var server = TestServer.Create(app =>
+            {
+                app.UseCookiePolicy(options => options.OnDeleteCookie = ctx => ctx.CookieName = "A");
+                app.Run(context =>
+                {
+                    context.Response.Cookies.Delete("A");
+                    context.Response.Cookies.Delete("B", new CookieOptions { Secure = false });
+                    context.Response.Cookies.Delete("C", new CookieOptions());
+                    context.Response.Cookies.Delete("D", new CookieOptions { Secure = true });
+                    return Task.FromResult(0);
+                });
+            });
+
+            var transaction = await server.SendAsync("http://example.com/login");
+
+            Assert.NotNull(transaction.SetCookie);
+            Assert.Equal(1, transaction.SetCookie.Count);
+            Assert.Equal("A=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/", transaction.SetCookie[0]);
+        }
+
+        private TestServer CreateTestServer()
+        {
+            return TestServer.Create(app =>
             {
                 app.Map("/secureAlways", map =>
                 {
@@ -79,103 +199,6 @@ namespace Microsoft.AspNet.CookiePolicy.Test
 
             });
 
-            var transaction = await server.SendAsync("http://example.com/secureAlways");
-
-            Assert.NotNull(transaction.SetCookie);
-            Assert.Equal("A=A; path=/; secure", transaction.SetCookie[0]);
-            Assert.Equal("B=B; path=/; secure", transaction.SetCookie[1]);
-            Assert.Equal("C=C; path=/; secure", transaction.SetCookie[2]);
-            Assert.Equal("D=D; path=/; secure", transaction.SetCookie[3]);
-
-            transaction = await server.SendAsync("http://example.com/secureNone");
-
-            Assert.NotNull(transaction.SetCookie);
-            Assert.Equal("A=A; path=/", transaction.SetCookie[0]);
-            Assert.Equal("B=B; path=/", transaction.SetCookie[1]);
-            Assert.Equal("C=C; path=/", transaction.SetCookie[2]);
-            Assert.Equal("D=D; path=/; secure", transaction.SetCookie[3]);
-
-            transaction = await server.SendAsync("http://example.com/secureSame");
-
-            Assert.NotNull(transaction.SetCookie);
-            Assert.Equal("A=A; path=/", transaction.SetCookie[0]);
-            Assert.Equal("B=B; path=/", transaction.SetCookie[1]);
-            Assert.Equal("C=C; path=/", transaction.SetCookie[2]);
-            Assert.Equal("D=D; path=/", transaction.SetCookie[3]);
-
-            transaction = await server.SendAsync("https://example.com/secureSame");
-
-            Assert.NotNull(transaction.SetCookie);
-            Assert.Equal("A=A; path=/; secure", transaction.SetCookie[0]);
-            Assert.Equal("B=B; path=/; secure", transaction.SetCookie[1]);
-            Assert.Equal("C=C; path=/; secure", transaction.SetCookie[2]);
-            Assert.Equal("D=D; path=/; secure", transaction.SetCookie[3]);
-
-            transaction = await server.SendAsync("http://example.com/httpOnlyAlways");
-
-            Assert.NotNull(transaction.SetCookie);
-            Assert.Equal("A=A; path=/; httponly", transaction.SetCookie[0]);
-            Assert.Equal("B=B; path=/; httponly", transaction.SetCookie[1]);
-            Assert.Equal("C=C; path=/; httponly", transaction.SetCookie[2]);
-            Assert.Equal("D=D; path=/; httponly", transaction.SetCookie[3]);
-
-            transaction = await server.SendAsync("http://example.com/httpOnlyNone");
-
-            Assert.NotNull(transaction.SetCookie);
-            Assert.Equal("A=A; path=/", transaction.SetCookie[0]);
-            Assert.Equal("B=B; path=/", transaction.SetCookie[1]);
-            Assert.Equal("C=C; path=/", transaction.SetCookie[2]);
-            Assert.Equal("D=D; path=/; httponly", transaction.SetCookie[3]);
-
-        }
-
-        [Fact]
-        public async Task CookiePolicyCanHijackAppend()
-        {
-            var server = TestServer.Create(app =>
-            {
-                app.UseCookiePolicy(options => options.OnAppendCookie = ctx => ctx.CookieName = ctx.CookieValue = "Hao");
-                app.Run(context =>
-                {
-                    context.Response.Cookies.Append("A", "A");
-                    context.Response.Cookies.Append("B", "B", new CookieOptions { Secure = false });
-                    context.Response.Cookies.Append("C", "C", new CookieOptions());
-                    context.Response.Cookies.Append("D", "D", new CookieOptions { Secure = true });
-                    return Task.FromResult(0);
-                });
-            });
-
-            var transaction = await server.SendAsync("http://example.com/login");
-
-            Assert.NotNull(transaction.SetCookie);
-            Assert.Equal("Hao=Hao; path=/", transaction.SetCookie[0]);
-            Assert.Equal("Hao=Hao; path=/", transaction.SetCookie[1]);
-            Assert.Equal("Hao=Hao; path=/", transaction.SetCookie[2]);
-            Assert.Equal("Hao=Hao; path=/; secure", transaction.SetCookie[3]);
-        }
-
-        [Fact]
-        public async Task CookiePolicyCanHijackDelete()
-        {
-            var server = TestServer.Create(app =>
-            {
-                app.UseCookiePolicy(options => options.OnDeleteCookie = ctx => ctx.CookieName = "A");
-                app.Run(context =>
-                {
-                    context.Response.Cookies.Delete("A");
-                    context.Response.Cookies.Delete("B", new CookieOptions { Secure = false });
-                    context.Response.Cookies.Delete("C", new CookieOptions());
-                    context.Response.Cookies.Delete("D", new CookieOptions { Secure = true });
-                    return Task.FromResult(0);
-                });
-            });
-
-            var transaction = await server.SendAsync("http://example.com/login");
-
-            Assert.NotNull(transaction.SetCookie);
-            Assert.Equal(2, transaction.SetCookie.Count);
-            Assert.Equal("A=; expires=Thu, 01-Jan-1970 00:00:00 GMT", transaction.SetCookie[0]);
-            Assert.Equal("A=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/", transaction.SetCookie[1]);
         }
 
     }

--- a/test/Microsoft.AspNet.CookiePolicy.Test/CookiePolicyTests.cs
+++ b/test/Microsoft.AspNet.CookiePolicy.Test/CookiePolicyTests.cs
@@ -1,0 +1,231 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.AspNet.Builder;
+using Microsoft.AspNet.Http;
+using Microsoft.AspNet.TestHost;
+using Microsoft.Framework.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.AspNet.CookiePolicy.Test
+{
+    public class CookiePolicyTests
+    {
+        [Fact]
+        public async Task CookiePolicySecureAlwaysSetsSecure()
+        {
+            var server = TestServer.Create(app =>
+            {
+                app.UseCookiePolicy(options => options.Secure = SecurePolicy.Always);
+                app.UseCookieAuthentication(options => options.LoginPath = new PathString("/page"));
+                app.Run(context =>
+                {
+                    context.Response.Cookies.Append("A", "A");
+                    context.Response.Cookies.Append("B", "B", new CookieOptions { Secure = false });
+                    context.Response.Cookies.Append("C", "C", new CookieOptions());
+                    context.Response.Cookies.Append("D", "D", new CookieOptions { Secure = true });
+                    return Task.FromResult(0);
+                });
+            },
+                services => services.AddAuthentication());
+
+            var transaction = await server.SendAsync("http://example.com/login");
+
+            Assert.NotNull(transaction.SetCookie);
+            Assert.Equal("A=A; path=/; secure", transaction.SetCookie[0]);
+            Assert.Equal("B=B; path=/; secure", transaction.SetCookie[1]);
+            Assert.Equal("C=C; path=/; secure", transaction.SetCookie[2]);
+            Assert.Equal("D=D; path=/; secure", transaction.SetCookie[3]);
+        }
+
+        [Fact]
+        public async Task CookiePolicySecureNoneLeavesSecureAlone()
+        {
+            var server = TestServer.Create(app =>
+            {
+                app.UseCookiePolicy(options => options.Secure = SecurePolicy.None);
+                app.UseCookieAuthentication(options => options.LoginPath = new PathString("/page"));
+                app.Run(context =>
+                {
+                    context.Response.Cookies.Append("A", "A");
+                    context.Response.Cookies.Append("B", "B", new CookieOptions { Secure = false });
+                    context.Response.Cookies.Append("C", "C", new CookieOptions());
+                    context.Response.Cookies.Append("D", "D", new CookieOptions { Secure = true });
+                    return Task.FromResult(0);
+                });
+            },
+                services => services.AddAuthentication());
+
+            var transaction = await server.SendAsync("http://example.com/login");
+
+            Assert.NotNull(transaction.SetCookie);
+            Assert.Equal("A=A; path=/", transaction.SetCookie[0]);
+            Assert.Equal("B=B; path=/", transaction.SetCookie[1]);
+            Assert.Equal("C=C; path=/", transaction.SetCookie[2]);
+            Assert.Equal("D=D; path=/; secure", transaction.SetCookie[3]);
+        }
+
+        [Fact]
+        public async Task CookiePolicySecureSameAsRequestIsFalseOnHttp()
+        {
+            var server = TestServer.Create(app =>
+            {
+                app.UseCookiePolicy(options => options.Secure = SecurePolicy.SameAsRequest);
+                app.UseCookieAuthentication(options => options.LoginPath = new PathString("/page"));
+                app.Run(context =>
+                {
+                    context.Response.Cookies.Append("A", "A");
+                    context.Response.Cookies.Append("B", "B", new CookieOptions { Secure = false });
+                    context.Response.Cookies.Append("C", "C", new CookieOptions());
+                    context.Response.Cookies.Append("D", "D", new CookieOptions { Secure = true });
+                    return Task.FromResult(0);
+                });
+            },
+                services => services.AddAuthentication());
+
+            var transaction = await server.SendAsync("http://example.com/login");
+
+            Assert.NotNull(transaction.SetCookie);
+            Assert.Equal("A=A; path=/", transaction.SetCookie[0]);
+            Assert.Equal("B=B; path=/", transaction.SetCookie[1]);
+            Assert.Equal("C=C; path=/", transaction.SetCookie[2]);
+            Assert.Equal("D=D; path=/", transaction.SetCookie[3]);
+        }
+
+        [Fact]
+        public async Task CookiePolicySecureSameAsRequestIsTrueOnHttps()
+        {
+            var server = TestServer.Create(app =>
+            {
+                app.UseCookiePolicy(options => options.Secure = SecurePolicy.SameAsRequest);
+                app.UseCookieAuthentication(options => options.LoginPath = new PathString("/page"));
+                app.Run(context =>
+                {
+                    context.Response.Cookies.Append("A", "A");
+                    context.Response.Cookies.Append("B", "B", new CookieOptions { Secure = false });
+                    context.Response.Cookies.Append("C", "C", new CookieOptions());
+                    context.Response.Cookies.Append("D", "D", new CookieOptions { Secure = true });
+                    return Task.FromResult(0);
+                });
+            },
+                services => services.AddAuthentication());
+
+            var transaction = await server.SendAsync("https://example.com/login");
+
+            Assert.NotNull(transaction.SetCookie);
+            Assert.Equal("A=A; path=/; secure", transaction.SetCookie[0]);
+            Assert.Equal("B=B; path=/; secure", transaction.SetCookie[1]);
+            Assert.Equal("C=C; path=/; secure", transaction.SetCookie[2]);
+            Assert.Equal("D=D; path=/; secure", transaction.SetCookie[3]);
+        }
+
+        [Fact]
+        public async Task CookiePolicyHttpOnlyAlwaysSetsHttpOnly()
+        {
+            var server = TestServer.Create(app =>
+            {
+                app.UseCookiePolicy(options => options.HttpOnly = HttpOnlyPolicy.Always);
+                app.UseCookieAuthentication(options => options.LoginPath = new PathString("/page"));
+                app.Run(context =>
+                {
+                    context.Response.Cookies.Append("A", "A");
+                    context.Response.Cookies.Append("B", "B", new CookieOptions { HttpOnly = false });
+                    context.Response.Cookies.Append("C", "C", new CookieOptions());
+                    context.Response.Cookies.Append("D", "D", new CookieOptions { HttpOnly = true });
+                    return Task.FromResult(0);
+                });
+            },
+                services => services.AddAuthentication());
+
+            var transaction = await server.SendAsync("http://example.com/login");
+
+            Assert.NotNull(transaction.SetCookie);
+            Assert.Equal("A=A; path=/; httponly", transaction.SetCookie[0]);
+            Assert.Equal("B=B; path=/; httponly", transaction.SetCookie[1]);
+            Assert.Equal("C=C; path=/; httponly", transaction.SetCookie[2]);
+            Assert.Equal("D=D; path=/; httponly", transaction.SetCookie[3]);
+        }
+
+        [Fact]
+        public async Task CookiePolicyHttpOnlyNoneLeavesItAlone()
+        {
+            var server = TestServer.Create(app =>
+            {
+                app.UseCookiePolicy(options => options.HttpOnly = HttpOnlyPolicy.None);
+                app.UseCookieAuthentication(options => options.LoginPath = new PathString("/page"));
+                app.Run(context =>
+                {
+                    context.Response.Cookies.Append("A", "A");
+                    context.Response.Cookies.Append("B", "B", new CookieOptions { HttpOnly = false });
+                    context.Response.Cookies.Append("C", "C", new CookieOptions());
+                    context.Response.Cookies.Append("D", "D", new CookieOptions { HttpOnly = true });
+                    return Task.FromResult(0);
+                });
+            },
+                services => services.AddAuthentication());
+
+            var transaction = await server.SendAsync("http://example.com/login");
+
+            Assert.NotNull(transaction.SetCookie);
+            Assert.Equal("A=A; path=/", transaction.SetCookie[0]);
+            Assert.Equal("B=B; path=/", transaction.SetCookie[1]);
+            Assert.Equal("C=C; path=/", transaction.SetCookie[2]);
+            Assert.Equal("D=D; path=/; httponly", transaction.SetCookie[3]);
+        }
+
+        [Fact]
+        public async Task CookiePolicyCanHijackAppend()
+        {
+            var server = TestServer.Create(app =>
+            {
+                app.UseCookiePolicy(options => options.OnAppendCookie = ctx => ctx.CookieName = ctx.CookieValue = "Hao");
+                app.UseCookieAuthentication(options => options.LoginPath = new PathString("/page"));
+                app.Run(context =>
+                {
+                    context.Response.Cookies.Append("A", "A");
+                    context.Response.Cookies.Append("B", "B", new CookieOptions { Secure = false });
+                    context.Response.Cookies.Append("C", "C", new CookieOptions());
+                    context.Response.Cookies.Append("D", "D", new CookieOptions { Secure = true });
+                    return Task.FromResult(0);
+                });
+            },
+                services => services.AddAuthentication());
+
+            var transaction = await server.SendAsync("http://example.com/login");
+
+            Assert.NotNull(transaction.SetCookie);
+            Assert.Equal("Hao=Hao; path=/", transaction.SetCookie[0]);
+            Assert.Equal("Hao=Hao; path=/", transaction.SetCookie[1]);
+            Assert.Equal("Hao=Hao; path=/", transaction.SetCookie[2]);
+            Assert.Equal("Hao=Hao; path=/; secure", transaction.SetCookie[3]);
+        }
+
+        [Fact]
+        public async Task CookiePolicyCanHijackDelete()
+        {
+            var server = TestServer.Create(app =>
+            {
+                app.UseCookiePolicy(options => options.OnDeleteCookie = ctx => ctx.CookieName = "A");
+                app.UseCookieAuthentication(options => options.LoginPath = new PathString("/page"));
+                app.Run(context =>
+                {
+                    context.Response.Cookies.Delete("A");
+                    context.Response.Cookies.Delete("B", new CookieOptions { Secure = false });
+                    context.Response.Cookies.Delete("C", new CookieOptions());
+                    context.Response.Cookies.Delete("D", new CookieOptions { Secure = true });
+                    return Task.FromResult(0);
+                });
+            },
+                services => services.AddAuthentication());
+
+            var transaction = await server.SendAsync("http://example.com/login");
+
+            Assert.NotNull(transaction.SetCookie);
+            Assert.Equal(2, transaction.SetCookie.Count);
+            Assert.Equal("A=; expires=Thu, 01-Jan-1970 00:00:00 GMT", transaction.SetCookie[0]);
+            Assert.Equal("A=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/", transaction.SetCookie[1]);
+        }
+
+    }
+}

--- a/test/Microsoft.AspNet.CookiePolicy.Test/Microsoft.AspNet.CookiePolicy.Test.xproj
+++ b/test/Microsoft.AspNet.CookiePolicy.Test/Microsoft.AspNet.CookiePolicy.Test.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>1790e052-646f-4529-b90e-6fea95520d69</ProjectGuid>
+    <RootNamespace>Microsoft.AspNet.CookiePolicy.Test</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/Microsoft.AspNet.CookiePolicy.Test/TestExtensions.cs
+++ b/test/Microsoft.AspNet.CookiePolicy.Test/TestExtensions.cs
@@ -1,0 +1,74 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+using Microsoft.AspNet.Http;
+using Microsoft.AspNet.TestHost;
+
+namespace Microsoft.AspNet.CookiePolicy
+{
+    // REVIEW: Should find a shared home for these potentially (Copied from Auth tests)
+    public static class TestExtensions
+    {
+        public const string CookieAuthenticationScheme = "External";
+
+        public static async Task<Transaction> SendAsync(this TestServer server, string uri, string cookieHeader = null)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, uri);
+            if (!string.IsNullOrEmpty(cookieHeader))
+            {
+                request.Headers.Add("Cookie", cookieHeader);
+            }
+            var transaction = new Transaction
+            {
+                Request = request,
+                Response = await server.CreateClient().SendAsync(request),
+            };
+            if (transaction.Response.Headers.Contains("Set-Cookie"))
+            {
+                transaction.SetCookie = transaction.Response.Headers.GetValues("Set-Cookie").ToList();
+            }
+            transaction.ResponseText = await transaction.Response.Content.ReadAsStringAsync();
+
+            if (transaction.Response.Content != null &&
+                transaction.Response.Content.Headers.ContentType != null &&
+                transaction.Response.Content.Headers.ContentType.MediaType == "text/xml")
+            {
+                transaction.ResponseElement = XElement.Parse(transaction.ResponseText);
+            }
+            return transaction;
+        }
+
+        public static void Describe(this HttpResponse res, ClaimsPrincipal principal)
+        {
+            res.StatusCode = 200;
+            res.ContentType = "text/xml";
+            var xml = new XElement("xml");
+            if (principal != null)
+            {
+                foreach (var identity in principal.Identities)
+                {
+                    xml.Add(identity.Claims.Select(claim => 
+                        new XElement("claim", new XAttribute("type", claim.Type), 
+                        new XAttribute("value", claim.Value), 
+                        new XAttribute("issuer", claim.Issuer))));
+                }
+            }
+            using (var memory = new MemoryStream())
+            {
+                using (var writer = new XmlTextWriter(memory, Encoding.UTF8))
+                {
+                    xml.WriteTo(writer);
+                }
+                res.Body.Write(memory.ToArray(), 0, memory.ToArray().Length);
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.CookiePolicy.Test/Transaction.cs
+++ b/test/Microsoft.AspNet.CookiePolicy.Test/Transaction.cs
@@ -1,0 +1,51 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Xml.Linq;
+
+namespace Microsoft.AspNet.CookiePolicy
+{
+    // REVIEW: Should find a shared home for these potentially (Copied from Auth tests)
+    public class Transaction
+    {
+        public HttpRequestMessage Request { get; set; }
+        public HttpResponseMessage Response { get; set; }
+
+        public IList<string> SetCookie { get; set; }
+
+        public string ResponseText { get; set; }
+        public XElement ResponseElement { get; set; }
+
+        public string AuthenticationCookieValue
+        {
+            get
+            {
+                if (SetCookie != null && SetCookie.Count > 0)
+                {
+                    var authCookie = SetCookie.SingleOrDefault(c => c.Contains(".AspNet." + TestExtensions.CookieAuthenticationScheme + "="));
+                    if (authCookie != null)
+                    {
+                        return authCookie.Substring(0, authCookie.IndexOf(';'));
+                    }
+                }
+
+                return null;
+            }
+        }
+
+        public string FindClaimValue(string claimType, string issuer = null)
+        {
+            var claim = ResponseElement.Elements("claim")
+                .SingleOrDefault(elt => elt.Attribute("type").Value == claimType &&
+                    (issuer == null || elt.Attribute("issuer").Value == issuer));
+            if (claim == null)
+            {
+                return null;
+            }
+            return claim.Attribute("value").Value;
+        }
+    }
+}

--- a/test/Microsoft.AspNet.CookiePolicy.Test/project.json
+++ b/test/Microsoft.AspNet.CookiePolicy.Test/project.json
@@ -6,16 +6,13 @@
         "Microsoft.AspNet.CookiePolicy": "1.0.0-*",
         "Microsoft.AspNet.TestHost": "1.0.0-*",
         "Microsoft.Framework.DependencyInjection": "1.0.0-*",
-        "Moq": "4.2.1312.1622",
         "xunit.runner.aspnet": "2.0.0-aspnet-*"
     },
     "commands": {
         "test": "xunit.runner.aspnet"
     },
     "frameworks": {
-        "dnx451": {
-            "dependencies": {
-            }
-        }
+        "dnx451": { },
+        "dnxcore50": { }
     }
 }

--- a/test/Microsoft.AspNet.CookiePolicy.Test/project.json
+++ b/test/Microsoft.AspNet.CookiePolicy.Test/project.json
@@ -1,0 +1,21 @@
+{
+    "compilationOptions": {
+        "warningsAsErrors": true
+    },
+    "dependencies": {
+        "Microsoft.AspNet.CookiePolicy": "1.0.0-*",
+        "Microsoft.AspNet.TestHost": "1.0.0-*",
+        "Microsoft.Framework.DependencyInjection": "1.0.0-*",
+        "Moq": "4.2.1312.1622",
+        "xunit.runner.aspnet": "2.0.0-aspnet-*"
+    },
+    "commands": {
+        "test": "xunit.runner.aspnet"
+    },
+    "frameworks": {
+        "dnx451": {
+            "dependencies": {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/aspnet/HttpAbstractions/issues/42

cc @Tratcher @divega @lodejard @davidfowl @blowdart 

Note: one quirk of the new instance based options Use methods .  `Configure<CookiePolicyOptions>` in ConfigureServices will ALWAYS be ignored silently.