### PR TITLE
Removed references to Shouldly

### DIFF
--- a/test/Microsoft.AspNet.Authentication.Test/Cookies/CookieMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Cookies/CookieMiddlewareTests.cs
@@ -19,7 +19,6 @@ using Microsoft.AspNet.Http.Authentication;
 using Microsoft.AspNet.Http.Features.Authentication;
 using Microsoft.AspNet.TestHost;
 using Microsoft.Framework.DependencyInjection;
-using Shouldly;
 using Xunit;
 
 namespace Microsoft.AspNet.Authentication.Cookies
@@ -33,7 +32,7 @@ namespace Microsoft.AspNet.Authentication.Cookies
             {
             });
             var response = await server.CreateClient().GetAsync("http://example.com/normal");
-            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
         [Theory]
@@ -49,12 +48,12 @@ namespace Microsoft.AspNet.Authentication.Cookies
 
             var transaction = await SendAsync(server, "http://example.com/protected");
 
-            transaction.Response.StatusCode.ShouldBe(auto ? HttpStatusCode.Redirect : HttpStatusCode.Unauthorized);
+            Assert.Equal(auto ? HttpStatusCode.Redirect : HttpStatusCode.Unauthorized, transaction.Response.StatusCode);
             if (auto)
             {
                 var location = transaction.Response.Headers.Location;
-                location.LocalPath.ShouldBe("/login");
-                location.Query.ShouldBe("?ReturnUrl=%2Fprotected");
+                Assert.Equal("/login", location.LocalPath);
+                Assert.Equal("?ReturnUrl=%2Fprotected", location.Query);
             }
         }
 
@@ -65,9 +64,9 @@ namespace Microsoft.AspNet.Authentication.Cookies
 
             var transaction = await SendAsync(server, "http://example.com/protected/CustomRedirect");
 
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var location = transaction.Response.Headers.Location;
-            location.ToString().ShouldBe("http://example.com/Account/Login?ReturnUrl=%2FCustomRedirect");
+            Assert.Equal("http://example.com/Account/Login?ReturnUrl=%2FCustomRedirect", location.ToString());
         }
 
         private Task SignInAsAlice(HttpContext context)
@@ -101,12 +100,12 @@ namespace Microsoft.AspNet.Authentication.Cookies
             var transaction = await SendAsync(server, "http://example.com/testpath");
 
             var setCookie = transaction.SetCookie;
-            setCookie.ShouldStartWith("TestCookie=");
-            setCookie.ShouldContain("; path=/");
-            setCookie.ShouldContain("; HttpOnly");
-            setCookie.ShouldNotContain("; expires=");
-            setCookie.ShouldNotContain("; domain=");
-            setCookie.ShouldNotContain("; secure");
+            Assert.StartsWith("TestCookie=", setCookie);
+            Assert.Contains("; path=/", setCookie);
+            Assert.Contains("; httponly", setCookie);
+            Assert.DoesNotContain("; expires=", setCookie);
+            Assert.DoesNotContain("; domain=", setCookie);
+            Assert.DoesNotContain("; secure", setCookie);
         }
 
         [Fact]
@@ -157,11 +156,11 @@ namespace Microsoft.AspNet.Authentication.Cookies
 
             if (shouldBeSecureOnly)
             {
-                setCookie.ShouldContain("; secure");
+                Assert.Contains("; secure", setCookie);
             }
             else
             {
-                setCookie.ShouldNotContain("; secure");
+                Assert.DoesNotContain("; secure", setCookie);
             }
         }
 
@@ -181,11 +180,11 @@ namespace Microsoft.AspNet.Authentication.Cookies
 
             var setCookie1 = transaction1.SetCookie;
 
-            setCookie1.ShouldContain("TestCookie=");
-            setCookie1.ShouldContain(" path=/foo");
-            setCookie1.ShouldContain(" domain=another.com");
-            setCookie1.ShouldContain(" secure");
-            setCookie1.ShouldContain(" HttpOnly");
+            Assert.Contains("TestCookie=", setCookie1);
+            Assert.Contains(" path=/foo", setCookie1);
+            Assert.Contains(" domain=another.com", setCookie1);
+            Assert.Contains(" secure", setCookie1);
+            Assert.Contains(" httponly", setCookie1);
 
             var server2 = CreateServer(options =>
             {
@@ -198,11 +197,11 @@ namespace Microsoft.AspNet.Authentication.Cookies
 
             var setCookie2 = transaction2.SetCookie;
 
-            setCookie2.ShouldContain("SecondCookie=");
-            setCookie2.ShouldContain(" path=/base");
-            setCookie2.ShouldNotContain(" domain=");
-            setCookie2.ShouldNotContain(" secure");
-            setCookie2.ShouldNotContain(" HttpOnly");
+            Assert.Contains("SecondCookie=", setCookie2);
+            Assert.Contains(" path=/base", setCookie2);
+            Assert.DoesNotContain(" domain=", setCookie2);
+            Assert.DoesNotContain(" secure", setCookie2);
+            Assert.DoesNotContain(" httponly", setCookie2);
         }
 
         [Fact]
@@ -218,7 +217,7 @@ namespace Microsoft.AspNet.Authentication.Cookies
 
             var transaction2 = await SendAsync(server, "http://example.com/me/Cookies", transaction1.CookieNameValue);
 
-            FindClaimValue(transaction2, ClaimTypes.Name).ShouldBe("Alice");
+            Assert.Equal("Alice", FindClaimValue(transaction2, ClaimTypes.Name));
         }
 
         [Fact]
@@ -260,10 +259,9 @@ namespace Microsoft.AspNet.Authentication.Cookies
 
             var transaction2 = await SendAsync(server, "http://example.com/me/Cookies", transaction1.CookieNameValue);
 
-            FindClaimValue(transaction2, ClaimTypes.Name).ShouldBe("Alice");
-            FindClaimValue(transaction2, "xform").ShouldBe("yup");
-            FindClaimValue(transaction2, "sync").ShouldBe(null);
-
+            Assert.Equal("Alice", FindClaimValue(transaction2, ClaimTypes.Name));
+            Assert.Equal("yup", FindClaimValue(transaction2, "xform"));
+            Assert.Null(FindClaimValue(transaction2, "sync"));
         }
 
         [Fact]
@@ -289,12 +287,12 @@ namespace Microsoft.AspNet.Authentication.Cookies
 
             var transaction4 = await SendAsync(server, "http://example.com/me/Cookies", transaction1.CookieNameValue);
 
-            transaction2.SetCookie.ShouldBe(null);
-            FindClaimValue(transaction2, ClaimTypes.Name).ShouldBe("Alice");
-            transaction3.SetCookie.ShouldBe(null);
-            FindClaimValue(transaction3, ClaimTypes.Name).ShouldBe("Alice");
-            transaction4.SetCookie.ShouldBe(null);
-            FindClaimValue(transaction4, ClaimTypes.Name).ShouldBe(null);
+            Assert.Null(transaction2.SetCookie);
+            Assert.Equal("Alice", FindClaimValue(transaction2, ClaimTypes.Name));
+            Assert.Null(transaction3.SetCookie);
+            Assert.Equal("Alice", FindClaimValue(transaction3, ClaimTypes.Name));
+            Assert.Null(transaction4.SetCookie);
+            Assert.Null(FindClaimValue(transaction4, ClaimTypes.Name));
         }
 
         [Fact]
@@ -324,12 +322,12 @@ namespace Microsoft.AspNet.Authentication.Cookies
 
             var transaction4 = await SendAsync(server, "http://example.com/me/Cookies", transaction1.CookieNameValue);
 
-            transaction2.SetCookie.ShouldBe(null);
-            FindClaimValue(transaction2, ClaimTypes.Name).ShouldBe("Alice");
-            transaction3.SetCookie.ShouldBe(null);
-            FindClaimValue(transaction3, ClaimTypes.Name).ShouldBe("Alice");
-            transaction4.SetCookie.ShouldBe(null);
-            FindClaimValue(transaction4, ClaimTypes.Name).ShouldBe(null);
+            Assert.Null(transaction2.SetCookie);
+            Assert.Equal("Alice", FindClaimValue(transaction2, ClaimTypes.Name));
+            Assert.Null(transaction3.SetCookie);
+            Assert.Equal("Alice", FindClaimValue(transaction3, ClaimTypes.Name));
+            Assert.Null(transaction4.SetCookie);
+            Assert.Null(FindClaimValue(transaction4, ClaimTypes.Name));
         }
 
         [Fact]
@@ -358,8 +356,8 @@ namespace Microsoft.AspNet.Authentication.Cookies
             clock.Add(TimeSpan.FromMinutes(11));
 
             var transaction2 = await SendAsync(server, "http://example.com/me/Cookies", transaction1.CookieNameValue);
-            transaction2.SetCookie.ShouldBe(null);
-            FindClaimValue(transaction2, ClaimTypes.Name).ShouldBe(null);
+            Assert.Null(transaction2.SetCookie);
+            Assert.Null(FindClaimValue(transaction2, ClaimTypes.Name));
         }
 
         [Fact]
@@ -388,8 +386,8 @@ namespace Microsoft.AspNet.Authentication.Cookies
             var transaction1 = await SendAsync(server, "http://example.com/testpath");
 
             var transaction2 = await SendAsync(server, "http://example.com/me/Cookies", transaction1.CookieNameValue);
-            transaction2.SetCookie.ShouldContain(".AspNet.Cookies=; expires=");
-            FindClaimValue(transaction2, ClaimTypes.Name).ShouldBe(null);
+            Assert.Contains(".AspNet.Cookies=; expires=", transaction2.SetCookie);
+            Assert.Null(FindClaimValue(transaction2, ClaimTypes.Name));
         }
 
         [Fact]
@@ -415,28 +413,28 @@ namespace Microsoft.AspNet.Authentication.Cookies
                     new ClaimsPrincipal(new ClaimsIdentity(new GenericIdentity("Alice", "Cookies")))));
 
             var transaction1 = await SendAsync(server, "http://example.com/testpath");
-
+            
             var transaction2 = await SendAsync(server, "http://example.com/me/Cookies", transaction1.CookieNameValue);
-            transaction2.SetCookie.ShouldNotBe(null);
-            FindClaimValue(transaction2, ClaimTypes.Name).ShouldBe("Alice");
+            Assert.NotNull(transaction2.SetCookie);
+            Assert.Equal("Alice", FindClaimValue(transaction2, ClaimTypes.Name));
 
             clock.Add(TimeSpan.FromMinutes(5));
 
             var transaction3 = await SendAsync(server, "http://example.com/me/Cookies", transaction2.CookieNameValue);
-            transaction3.SetCookie.ShouldNotBe(null);
-            FindClaimValue(transaction3, ClaimTypes.Name).ShouldBe("Alice");
+            Assert.NotNull(transaction3.SetCookie);
+            Assert.Equal("Alice", FindClaimValue(transaction3, ClaimTypes.Name));
 
             clock.Add(TimeSpan.FromMinutes(6));
 
             var transaction4 = await SendAsync(server, "http://example.com/me/Cookies", transaction1.CookieNameValue);
-            transaction4.SetCookie.ShouldBe(null);
-            FindClaimValue(transaction4, ClaimTypes.Name).ShouldBe(null);
+            Assert.Null(transaction4.SetCookie);
+            Assert.Null(FindClaimValue(transaction4, ClaimTypes.Name));
 
             clock.Add(TimeSpan.FromMinutes(5));
 
             var transaction5 = await SendAsync(server, "http://example.com/me/Cookies", transaction2.CookieNameValue);
-            transaction5.SetCookie.ShouldBe(null);
-            FindClaimValue(transaction5, ClaimTypes.Name).ShouldBe(null);
+            Assert.Null(transaction5.SetCookie);
+            Assert.Null(FindClaimValue(transaction5, ClaimTypes.Name));
         }
 
         [Fact]
@@ -463,26 +461,26 @@ namespace Microsoft.AspNet.Authentication.Cookies
             var transaction1 = await SendAsync(server, "http://example.com/testpath");
 
             var transaction2 = await SendAsync(server, "http://example.com/me/Cookies", transaction1.CookieNameValue);
-            transaction2.SetCookie.ShouldNotBe(null);
-            FindClaimValue(transaction2, ClaimTypes.Name).ShouldBe("Alice");
+            Assert.NotNull(transaction2.SetCookie);
+            Assert.Equal("Alice", FindClaimValue(transaction2, ClaimTypes.Name));
 
             clock.Add(TimeSpan.FromMinutes(5));
 
             var transaction3 = await SendAsync(server, "http://example.com/me/Cookies", transaction2.CookieNameValue);
-            transaction3.SetCookie.ShouldNotBe(null);
-            FindClaimValue(transaction3, ClaimTypes.Name).ShouldBe("Alice");
+            Assert.NotNull(transaction3.SetCookie);
+            Assert.Equal("Alice", FindClaimValue(transaction3, ClaimTypes.Name));
 
             clock.Add(TimeSpan.FromMinutes(6));
 
             var transaction4 = await SendAsync(server, "http://example.com/me/Cookies", transaction3.CookieNameValue);
-            transaction4.SetCookie.ShouldNotBe(null);
-            FindClaimValue(transaction4, ClaimTypes.Name).ShouldBe("Alice");
+            Assert.NotNull(transaction4.SetCookie);
+            Assert.Equal("Alice", FindClaimValue(transaction4, ClaimTypes.Name));
 
             clock.Add(TimeSpan.FromMinutes(11));
 
             var transaction5 = await SendAsync(server, "http://example.com/me/Cookies", transaction4.CookieNameValue);
-            transaction5.SetCookie.ShouldBe(null);
-            FindClaimValue(transaction5, ClaimTypes.Name).ShouldBe(null);
+            Assert.Null(transaction5.SetCookie);
+            Assert.Null(FindClaimValue(transaction5, ClaimTypes.Name));
         }
 
         [Fact]
@@ -507,20 +505,20 @@ namespace Microsoft.AspNet.Authentication.Cookies
             var transaction1 = await SendAsync(server, "http://example.com/testpath");
 
             var transaction2 = await SendAsync(server, "http://example.com/me/Cookies", transaction1.CookieNameValue);
-            transaction2.SetCookie.ShouldBe(null);
-            FindClaimValue(transaction2, ClaimTypes.Name).ShouldBe("Alice");
+            Assert.Null(transaction2.SetCookie);
+            Assert.Equal("Alice", FindClaimValue(transaction2, ClaimTypes.Name));
 
             clock.Add(TimeSpan.FromMinutes(3));
 
             var transaction3 = await SendAsync(server, "http://example.com/me/Cookies", transaction1.CookieNameValue);
-            transaction3.SetCookie.ShouldBe(null);
-            FindClaimValue(transaction3, ClaimTypes.Name).ShouldBe("Alice");
+            Assert.Null(transaction3.SetCookie);
+            Assert.Equal("Alice", FindClaimValue(transaction3, ClaimTypes.Name));
 
             clock.Add(TimeSpan.FromMinutes(3));
 
             var transaction4 = await SendAsync(server, "http://example.com/me/Cookies", transaction1.CookieNameValue);
-            transaction4.SetCookie.ShouldBe(null);
-            FindClaimValue(transaction4, ClaimTypes.Name).ShouldBe(null);
+            Assert.Null(transaction4.SetCookie);
+            Assert.Null(FindClaimValue(transaction4, ClaimTypes.Name));
         }
 
         [Fact]
@@ -537,27 +535,27 @@ namespace Microsoft.AspNet.Authentication.Cookies
             var transaction1 = await SendAsync(server, "http://example.com/testpath");
 
             var transaction2 = await SendAsync(server, "http://example.com/me/Cookies", transaction1.CookieNameValue);
-            transaction2.SetCookie.ShouldBe(null);
-            FindClaimValue(transaction2, ClaimTypes.Name).ShouldBe("Alice");
+            Assert.Null(transaction2.SetCookie);
+            Assert.Equal("Alice", FindClaimValue(transaction2, ClaimTypes.Name));
 
             clock.Add(TimeSpan.FromMinutes(4));
 
             var transaction3 = await SendAsync(server, "http://example.com/me/Cookies", transaction1.CookieNameValue);
-            transaction3.SetCookie.ShouldBe(null);
-            FindClaimValue(transaction3, ClaimTypes.Name).ShouldBe("Alice");
+            Assert.Null(transaction3.SetCookie);
+            Assert.Equal("Alice", FindClaimValue(transaction3, ClaimTypes.Name));
 
             clock.Add(TimeSpan.FromMinutes(4));
 
             // transaction4 should arrive with a new SetCookie value
             var transaction4 = await SendAsync(server, "http://example.com/me/Cookies", transaction1.CookieNameValue);
-            transaction4.SetCookie.ShouldNotBe(null);
-            FindClaimValue(transaction4, ClaimTypes.Name).ShouldBe("Alice");
+            Assert.NotNull(transaction4.SetCookie);
+            Assert.Equal("Alice", FindClaimValue(transaction4, ClaimTypes.Name));
 
             clock.Add(TimeSpan.FromMinutes(4));
 
             var transaction5 = await SendAsync(server, "http://example.com/me/Cookies", transaction4.CookieNameValue);
-            transaction5.SetCookie.ShouldBe(null);
-            FindClaimValue(transaction5, ClaimTypes.Name).ShouldBe("Alice");
+            Assert.Null(transaction5.SetCookie);
+            Assert.Equal("Alice", FindClaimValue(transaction5, ClaimTypes.Name));
         }
 
         [Fact]
@@ -595,9 +593,9 @@ namespace Microsoft.AspNet.Authentication.Cookies
             var url = "http://example.com/challenge";
             var transaction2 = await SendAsync(server, url, transaction1.CookieNameValue);
 
-            transaction2.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction2.Response.StatusCode);
             var location = transaction2.Response.Headers.Location;
-            location.LocalPath.ShouldBe("/Account/AccessDenied");
+            Assert.Equal("/Account/AccessDenied", location.LocalPath);
         }
 
         [Theory]
@@ -616,9 +614,9 @@ namespace Microsoft.AspNet.Authentication.Cookies
             var url = "http://example.com/challenge";
             var transaction = await SendAsync(server, url);
 
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var location = transaction.Response.Headers.Location;
-            location.LocalPath.ShouldBe("/Account/Login");
+            Assert.Equal("/Account/Login", location.LocalPath);
         }
 
         [Theory]
@@ -637,9 +635,9 @@ namespace Microsoft.AspNet.Authentication.Cookies
             var url = "http://example.com/forbid";
             var transaction = await SendAsync(server, url);
 
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var location = transaction.Response.Headers.Location;
-            location.LocalPath.ShouldBe("/Account/AccessDenied");
+            Assert.Equal("/Account/AccessDenied", location.LocalPath);
         }
 
         [Fact]
@@ -657,10 +655,10 @@ namespace Microsoft.AspNet.Authentication.Cookies
 
             var transaction2 = await SendAsync(server, "http://example.com/challenge", transaction1.CookieNameValue);
 
-            transaction2.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction2.Response.StatusCode);
 
             var location = transaction2.Response.Headers.Location;
-            location.LocalPath.ShouldBe("/accessdenied");
+            Assert.Equal("/accessdenied", location.LocalPath);
         }
 
         [Fact]
@@ -677,7 +675,7 @@ namespace Microsoft.AspNet.Authentication.Cookies
 
             var transaction2 = await SendAsync(server, "http://example.com/challenge", transaction1.CookieNameValue);
 
-            transaction2.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction2.Response.StatusCode);
         }
 
         [Fact]
@@ -694,7 +692,7 @@ namespace Microsoft.AspNet.Authentication.Cookies
 
             var transaction2 = await SendAsync(server, "http://example.com/unauthorized", transaction1.CookieNameValue);
 
-            transaction2.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction2.Response.StatusCode);
         }
 
         [Fact]
@@ -709,11 +707,11 @@ namespace Microsoft.AspNet.Authentication.Cookies
 
             var transaction = await server.SendAsync("http://example.com/login");
 
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
 
             var location = transaction.Response.Headers.Location;
-            location.LocalPath.ShouldBe("/page");
-            location.Query.ShouldBe("?ReturnUrl=%2F");
+            Assert.Equal("/page", location.LocalPath);
+            Assert.Equal("?ReturnUrl=%2F", location.Query);
         }
 
         [Fact]
@@ -728,7 +726,7 @@ namespace Microsoft.AspNet.Authentication.Cookies
             }, services => services.AddAuthentication());
 
             var transaction = await server.SendAsync("http://example.com");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, transaction.Response.StatusCode);
         }
 
 /*        [Fact]
@@ -743,7 +741,7 @@ namespace Microsoft.AspNet.Authentication.Cookies
 
             var transaction = await server.SendAsync("http://example.com");
 
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, transaction.Response.StatusCode);
             Assert.True(transaction.SetCookie[0].StartsWith(".AspNet.Cookies="));
         }
 
@@ -759,7 +757,7 @@ namespace Microsoft.AspNet.Authentication.Cookies
 
             var transaction = await server.SendAsync("http://example.com");
 
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, transaction.Response.StatusCode);
             Assert.True(transaction.SetCookie[0].StartsWith("One="));
         }*/
 
@@ -775,8 +773,8 @@ namespace Microsoft.AspNet.Authentication.Cookies
                 services => services.AddAuthentication());
 
             var transaction = await server.SendAsync("http://example.com/notlogin?ReturnUrl=%2Fpage");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
-            transaction.SetCookie.ShouldNotBe(null);
+            Assert.Equal(HttpStatusCode.OK, transaction.Response.StatusCode);
+            Assert.NotNull(transaction.SetCookie);
         }
 
         [Fact]
@@ -792,11 +790,11 @@ namespace Microsoft.AspNet.Authentication.Cookies
 
             var transaction = await server.SendAsync("http://example.com/login?ReturnUrl=%2Fpage");
 
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            transaction.SetCookie.ShouldNotBe(null);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
+            Assert.NotNull(transaction.SetCookie);
 
             var location = transaction.Response.Headers.Location;
-            location.OriginalString.ShouldBe("/page");
+            Assert.Equal("/page", location.OriginalString);
         }
 
         [Fact]
@@ -810,8 +808,8 @@ namespace Microsoft.AspNet.Authentication.Cookies
             services => services.AddAuthentication());
 
             var transaction = await server.SendAsync("http://example.com/notlogout?ReturnUrl=%2Fpage");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
-            transaction.SetCookie[0].ShouldContain(".AspNet.Cookies=; expires=");
+            Assert.Equal(HttpStatusCode.OK, transaction.Response.StatusCode);
+            Assert.Contains(".AspNet.Cookies=; expires=", transaction.SetCookie[0]);
         }
 
         [Fact]
@@ -826,11 +824,11 @@ namespace Microsoft.AspNet.Authentication.Cookies
 
             var transaction = await server.SendAsync("http://example.com/logout?ReturnUrl=%2Fpage");
 
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            transaction.SetCookie[0].ShouldContain(".AspNet.Cookies=; expires=");
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
+            Assert.Contains(".AspNet.Cookies=; expires=", transaction.SetCookie[0]);
 
             var location = transaction.Response.Headers.Location;
-            location.OriginalString.ShouldBe("/page");
+            Assert.Equal("/page", location.OriginalString);
         }
 
         [Fact]
@@ -844,10 +842,10 @@ namespace Microsoft.AspNet.Authentication.Cookies
                 services => services.AddAuthentication());
             var transaction = await server.SendAsync("http://example.com/forbid");
 
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
 
             var location = transaction.Response.Headers.Location;
-            location.LocalPath.ShouldBe("/denied");
+            Assert.Equal("/denied", location.LocalPath);
         }
 
         [Fact]
@@ -862,11 +860,11 @@ namespace Microsoft.AspNet.Authentication.Cookies
                 services => services.AddAuthentication());
             var transaction = await server.SendAsync("http://example.com/base/login");
 
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
 
             var location = transaction.Response.Headers.Location;
-            location.LocalPath.ShouldBe("/base/page");
-            location.Query.ShouldBe("?ReturnUrl=%2F");
+            Assert.Equal("/base/page", location.LocalPath);
+            Assert.Equal("?ReturnUrl=%2F", location.Query);
         }
 
         [Fact]
@@ -881,10 +879,10 @@ namespace Microsoft.AspNet.Authentication.Cookies
                 services => services.AddAuthentication());
             var transaction = await server.SendAsync("http://example.com/base/forbid");
 
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
 
             var location = transaction.Response.Headers.Location;
-            location.LocalPath.ShouldBe("/base/denied");
+            Assert.Equal("/base/denied", location.LocalPath);
         }
 
         [Fact]
@@ -907,7 +905,7 @@ namespace Microsoft.AspNet.Authentication.Cookies
             services => services.AddAuthentication());
 
             var transaction = await SendAsync(server1, "http://example.com/stuff");
-            transaction.SetCookie.ShouldNotBe(null);
+            Assert.NotNull(transaction.SetCookie);
 
             var server2 = TestServer.Create(app =>
             {
@@ -926,7 +924,7 @@ namespace Microsoft.AspNet.Authentication.Cookies
             },
             services => services.AddAuthentication());
             var transaction2 = await SendAsync(server2, "http://example.com/stuff", transaction.CookieNameValue);
-            FindClaimValue(transaction2, ClaimTypes.Name).ShouldBe("Alice");
+            Assert.Equal("Alice", FindClaimValue(transaction2, ClaimTypes.Name));
         }
 
         private class NoOpDataProtector : IDataProtector

--- a/test/Microsoft.AspNet.Authentication.Test/DataHandler/Base64UrlTextEncoderTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/DataHandler/Base64UrlTextEncoderTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Shouldly;
 using Xunit;
 
 namespace Microsoft.AspNet.Authentication
@@ -24,7 +23,7 @@ namespace Microsoft.AspNet.Authentication
 
                 for (int index = 0; index != length; ++index)
                 {
-                    result[index].ShouldBe(data[index]);
+                    Assert.Equal(data[index], result[index]);
                 }
             }
         }

--- a/test/Microsoft.AspNet.Authentication.Test/Facebook/FacebookMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Facebook/FacebookMiddlewareTests.cs
@@ -16,7 +16,6 @@ using Microsoft.AspNet.Http.Authentication;
 using Microsoft.AspNet.TestHost;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.WebEncoders;
-using Shouldly;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -65,9 +64,9 @@ namespace Microsoft.AspNet.Authentication.Facebook
                     return true;
                 });
             var transaction = await server.SendAsync("http://example.com/challenge");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var query = transaction.Response.Headers.Location.Query;
-            query.ShouldContain("custom=test");
+            Assert.Contains("custom=test", query);
         }
 
         [Fact]
@@ -90,14 +89,14 @@ namespace Microsoft.AspNet.Authentication.Facebook
                 },
                 handler: null);
             var transaction = await server.SendAsync("http://example.com/base/login");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var location = transaction.Response.Headers.Location.AbsoluteUri;
-            location.ShouldContain("https://www.facebook.com/v2.2/dialog/oauth");
-            location.ShouldContain("response_type=code");
-            location.ShouldContain("client_id=");
-            location.ShouldContain("redirect_uri=" + UrlEncoder.Default.UrlEncode("http://example.com/base/signin-facebook"));
-            location.ShouldContain("scope=");
-            location.ShouldContain("state=");
+            Assert.Contains("https://www.facebook.com/v2.2/dialog/oauth", location);
+            Assert.Contains("response_type=code", location);
+            Assert.Contains("client_id=", location);
+            Assert.Contains("redirect_uri=" + UrlEncoder.Default.UrlEncode("http://example.com/base/signin-facebook"), location);
+            Assert.Contains("scope=", location);
+            Assert.Contains("state=", location);
         }
 
         [Fact]
@@ -121,14 +120,14 @@ namespace Microsoft.AspNet.Authentication.Facebook
                 },
                 handler: null);
             var transaction = await server.SendAsync("http://example.com/login");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var location = transaction.Response.Headers.Location.AbsoluteUri;
-            location.ShouldContain("https://www.facebook.com/v2.2/dialog/oauth");
-            location.ShouldContain("response_type=code");
-            location.ShouldContain("client_id=");
-            location.ShouldContain("redirect_uri="+ UrlEncoder.Default.UrlEncode("http://example.com/signin-facebook"));
-            location.ShouldContain("scope=");
-            location.ShouldContain("state=");
+            Assert.Contains("https://www.facebook.com/v2.2/dialog/oauth", location);
+            Assert.Contains("response_type=code", location);
+            Assert.Contains("client_id=", location);
+            Assert.Contains("redirect_uri="+ UrlEncoder.Default.UrlEncode("http://example.com/signin-facebook"), location);
+            Assert.Contains("scope=", location);
+            Assert.Contains("state=", location);
         }
 
         [Fact]
@@ -163,14 +162,14 @@ namespace Microsoft.AspNet.Authentication.Facebook
                     return true;
                 });
             var transaction = await server.SendAsync("http://example.com/challenge");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var location = transaction.Response.Headers.Location.AbsoluteUri;
-            location.ShouldContain("https://www.facebook.com/v2.2/dialog/oauth");
-            location.ShouldContain("response_type=code");
-            location.ShouldContain("client_id=");
-            location.ShouldContain("redirect_uri=");
-            location.ShouldContain("scope=");
-            location.ShouldContain("state=");
+            Assert.Contains("https://www.facebook.com/v2.2/dialog/oauth", location);
+            Assert.Contains("response_type=code", location);
+            Assert.Contains("client_id=", location);
+            Assert.Contains("redirect_uri=", location);
+            Assert.Contains("scope=", location);
+            Assert.Contains("state=", location);
         }
 
         [Fact]
@@ -236,11 +235,11 @@ namespace Microsoft.AspNet.Authentication.Facebook
             var transaction = await server.SendAsync(
                 "https://example.com/signin-facebook?code=TestCode&state=" + UrlEncoder.Default.UrlEncode(state),
                 correlationKey + "=" + correlationValue);
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            transaction.Response.Headers.GetValues("Location").First().ShouldBe("/me");
-            finalUserInfoEndpoint.Count(c => c == '?').ShouldBe(1);
-            finalUserInfoEndpoint.ShouldContain("fields=email,timezone,picture");
-            finalUserInfoEndpoint.ShouldContain("&access_token=");
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
+            Assert.Equal("/me", transaction.Response.Headers.GetValues("Location").First());
+            Assert.Equal(1, finalUserInfoEndpoint.Count(c => c == '?'));
+            Assert.Contains("fields=email,timezone,picture", finalUserInfoEndpoint);
+            Assert.Contains("&access_token=", finalUserInfoEndpoint);
         }
 
         private static TestServer CreateServer(Action<IApplicationBuilder> configure, Action<IServiceCollection> configureServices, Func<HttpContext, bool> handler)

--- a/test/Microsoft.AspNet.Authentication.Test/Google/GoogleMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Google/GoogleMiddlewareTests.cs
@@ -17,7 +17,6 @@ using Microsoft.AspNet.TestHost;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.WebEncoders;
 using Newtonsoft.Json;
-using Shouldly;
 using Xunit;
 
 namespace Microsoft.AspNet.Authentication.Google
@@ -33,17 +32,17 @@ namespace Microsoft.AspNet.Authentication.Google
                 options.ClientSecret = "Test Secret";
             });
             var transaction = await server.SendAsync("https://example.com/challenge");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var location = transaction.Response.Headers.Location.ToString();
-            location.ShouldContain("https://accounts.google.com/o/oauth2/auth?response_type=code");
-            location.ShouldContain("&client_id=");
-            location.ShouldContain("&redirect_uri=");
-            location.ShouldContain("&scope=");
-            location.ShouldContain("&state=");
+            Assert.Contains("https://accounts.google.com/o/oauth2/auth?response_type=code", location);
+            Assert.Contains("&client_id=", location);
+            Assert.Contains("&redirect_uri=", location);
+            Assert.Contains("&scope=", location);
+            Assert.Contains("&state=", location);
 
-            location.ShouldNotContain("access_type=");
-            location.ShouldNotContain("approval_prompt=");
-            location.ShouldNotContain("login_hint=");
+            Assert.DoesNotContain("access_type=", location);
+            Assert.DoesNotContain("approval_prompt=", location);
+            Assert.DoesNotContain("login_hint=", location);
         }
 
         [Fact]
@@ -55,7 +54,7 @@ namespace Microsoft.AspNet.Authentication.Google
                 options.ClientSecret = "Test Secret";
             });
             var transaction = await server.SendAsync("https://example.com/signIn");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, transaction.Response.StatusCode);
         }
 
         [Fact]
@@ -67,7 +66,7 @@ namespace Microsoft.AspNet.Authentication.Google
                 options.ClientSecret = "Test Secret";
             });
             var transaction = await server.SendAsync("https://example.com/signOut");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, transaction.Response.StatusCode);
         }
 
         [Fact]
@@ -79,7 +78,7 @@ namespace Microsoft.AspNet.Authentication.Google
                 options.ClientSecret = "Test Secret";
             });
             var transaction = await server.SendAsync("https://example.com/signOut");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, transaction.Response.StatusCode);
         }
 
         [Fact]
@@ -92,13 +91,13 @@ namespace Microsoft.AspNet.Authentication.Google
                 options.AutomaticAuthentication = true;
             });
             var transaction = await server.SendAsync("https://example.com/401");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var location = transaction.Response.Headers.Location.ToString();
-            location.ShouldContain("https://accounts.google.com/o/oauth2/auth?response_type=code");
-            location.ShouldContain("&client_id=");
-            location.ShouldContain("&redirect_uri=");
-            location.ShouldContain("&scope=");
-            location.ShouldContain("&state=");
+            Assert.Contains("https://accounts.google.com/o/oauth2/auth?response_type=code", location);
+            Assert.Contains("&client_id=", location);
+            Assert.Contains("&redirect_uri=", location);
+            Assert.Contains("&scope=", location);
+            Assert.Contains("&state=", location);
         }
 
         [Fact]
@@ -110,7 +109,7 @@ namespace Microsoft.AspNet.Authentication.Google
                 options.ClientSecret = "Test Secret";
             });
             var transaction = await server.SendAsync("https://example.com/challenge");
-            transaction.SetCookie.Single().ShouldContain(".AspNet.Correlation.Google=");
+            Assert.Contains(".AspNet.Correlation.Google=", transaction.SetCookie.Single());
         }
 
         [Fact]
@@ -123,7 +122,7 @@ namespace Microsoft.AspNet.Authentication.Google
                 options.AutomaticAuthentication = true;
             });
             var transaction = await server.SendAsync("https://example.com/401");
-            transaction.SetCookie.Single().ShouldContain(".AspNet.Correlation.Google=");
+            Assert.Contains(".AspNet.Correlation.Google=", transaction.SetCookie.Single());
         }
 
         [Fact]
@@ -135,9 +134,9 @@ namespace Microsoft.AspNet.Authentication.Google
                 options.ClientSecret = "Test Secret";
             });
             var transaction = await server.SendAsync("https://example.com/challenge");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var query = transaction.Response.Headers.Location.Query;
-            query.ShouldContain("&scope=" + UrlEncoder.Default.UrlEncode("openid profile email"));
+            Assert.Contains("&scope=" + UrlEncoder.Default.UrlEncode("openid profile email"), query);
         }
 
         [Fact]
@@ -150,9 +149,9 @@ namespace Microsoft.AspNet.Authentication.Google
                 options.AutomaticAuthentication = true;
             });
             var transaction = await server.SendAsync("https://example.com/401");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var query = transaction.Response.Headers.Location.Query;
-            query.ShouldContain("&scope=" + UrlEncoder.Default.UrlEncode("openid profile email"));
+            Assert.Contains("&scope=" + UrlEncoder.Default.UrlEncode("openid profile email"), query);
         }
 
         [Fact]
@@ -183,12 +182,12 @@ namespace Microsoft.AspNet.Authentication.Google
                     return Task.FromResult<object>(null);
                 });
             var transaction = await server.SendAsync("https://example.com/challenge2");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var query = transaction.Response.Headers.Location.Query;
-            query.ShouldContain("scope=" + UrlEncoder.Default.UrlEncode("https://www.googleapis.com/auth/plus.login"));
-            query.ShouldContain("access_type=offline");
-            query.ShouldContain("approval_prompt=force");
-            query.ShouldContain("login_hint=" + UrlEncoder.Default.UrlEncode("test@example.com"));
+            Assert.Contains("scope=" + UrlEncoder.Default.UrlEncode("https://www.googleapis.com/auth/plus.login"), query);
+            Assert.Contains("access_type=offline", query);
+            Assert.Contains("approval_prompt=force", query);
+            Assert.Contains("login_hint=" + UrlEncoder.Default.UrlEncode("test@example.com"), query);
         }
 
         [Fact]
@@ -208,9 +207,9 @@ namespace Microsoft.AspNet.Authentication.Google
                 };
             });
             var transaction = await server.SendAsync("https://example.com/challenge");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var query = transaction.Response.Headers.Location.Query;
-            query.ShouldContain("custom=test");
+            Assert.Contains("custom=test", query);
         }
 
         [Fact]
@@ -222,7 +221,7 @@ namespace Microsoft.AspNet.Authentication.Google
                 options.ClientSecret = "Test Secret";
             });
             var transaction = await server.SendAsync("https://example.com/signin-google?code=TestCode");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.InternalServerError);
+            Assert.Equal(HttpStatusCode.InternalServerError, transaction.Response.StatusCode);
         }
 
         [Theory]
@@ -286,24 +285,24 @@ namespace Microsoft.AspNet.Authentication.Google
             var transaction = await server.SendAsync(
                 "https://example.com/signin-google?code=TestCode&state=" + UrlEncoder.Default.UrlEncode(state),
                 correlationKey + "=" + correlationValue);
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            transaction.Response.Headers.GetValues("Location").First().ShouldBe("/me");
-            transaction.SetCookie.Count.ShouldBe(2);
-            transaction.SetCookie[0].ShouldContain(correlationKey);
-            transaction.SetCookie[1].ShouldContain(".AspNet." + TestExtensions.CookieAuthenticationScheme);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
+            Assert.Equal("/me", transaction.Response.Headers.GetValues("Location").First());
+            Assert.Equal(2, transaction.SetCookie.Count);
+            Assert.Contains(correlationKey, transaction.SetCookie[0]);
+            Assert.Contains(".AspNet." + TestExtensions.CookieAuthenticationScheme, transaction.SetCookie[1]);
 
             var authCookie = transaction.AuthenticationCookieValue;
             transaction = await server.SendAsync("https://example.com/me", authCookie);
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, transaction.Response.StatusCode);
             var expectedIssuer = claimsIssuer ?? GoogleDefaults.AuthenticationScheme;
-            transaction.FindClaimValue(ClaimTypes.Name, expectedIssuer).ShouldBe("Test Name");
-            transaction.FindClaimValue(ClaimTypes.NameIdentifier, expectedIssuer).ShouldBe("Test User ID");
-            transaction.FindClaimValue(ClaimTypes.GivenName, expectedIssuer).ShouldBe("Test Given Name");
-            transaction.FindClaimValue(ClaimTypes.Surname, expectedIssuer).ShouldBe("Test Family Name");
-            transaction.FindClaimValue(ClaimTypes.Email, expectedIssuer).ShouldBe("Test email");
+            Assert.Equal("Test Name", transaction.FindClaimValue(ClaimTypes.Name, expectedIssuer));
+            Assert.Equal("Test User ID", transaction.FindClaimValue(ClaimTypes.NameIdentifier, expectedIssuer));
+            Assert.Equal("Test Given Name", transaction.FindClaimValue(ClaimTypes.GivenName, expectedIssuer));
+            Assert.Equal("Test Family Name", transaction.FindClaimValue(ClaimTypes.Surname, expectedIssuer));
+            Assert.Equal("Test email", transaction.FindClaimValue(ClaimTypes.Email, expectedIssuer));
 
             // Ensure claims transformation 
-            transaction.FindClaimValue("xform").ShouldBe("yup");
+            Assert.Equal("yup", transaction.FindClaimValue("xform"));
         }
 
         [Fact]
@@ -332,8 +331,8 @@ namespace Microsoft.AspNet.Authentication.Google
             var transaction = await server.SendAsync(
                 "https://example.com/signin-google?code=TestCode&state=" + UrlEncoder.Default.UrlEncode(state),
                 correlationKey + "=" + correlationValue);
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            transaction.Response.Headers.Location.ToString().ShouldContain("error=access_denied");
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
+            Assert.Contains("error=access_denied", transaction.Response.Headers.Location.ToString());
         }
 
         [Fact]
@@ -362,8 +361,8 @@ namespace Microsoft.AspNet.Authentication.Google
             var transaction = await server.SendAsync(
                 "https://example.com/signin-google?code=TestCode&state=" + UrlEncoder.Default.UrlEncode(state),
                 correlationKey + "=" + correlationValue);
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            transaction.Response.Headers.Location.ToString().ShouldContain("error=access_denied");
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
+            Assert.Contains("error=access_denied", transaction.Response.Headers.Location.ToString());
         }
 
         [Fact]
@@ -434,16 +433,16 @@ namespace Microsoft.AspNet.Authentication.Google
             var transaction = await server.SendAsync(
                 "https://example.com/signin-google?code=TestCode&state=" + UrlEncoder.Default.UrlEncode(state),
                 correlationKey + "=" + correlationValue);
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            transaction.Response.Headers.GetValues("Location").First().ShouldBe("/me");
-            transaction.SetCookie.Count.ShouldBe(2);
-            transaction.SetCookie[0].ShouldContain(correlationKey);
-            transaction.SetCookie[1].ShouldContain(".AspNet." + TestExtensions.CookieAuthenticationScheme);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
+            Assert.Equal("/me", transaction.Response.Headers.GetValues("Location").First());
+            Assert.Equal(2, transaction.SetCookie.Count);
+            Assert.Contains(correlationKey, transaction.SetCookie[0]);
+            Assert.Contains(".AspNet." + TestExtensions.CookieAuthenticationScheme, transaction.SetCookie[1]);
 
             var authCookie = transaction.AuthenticationCookieValue;
             transaction = await server.SendAsync("https://example.com/me", authCookie);
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
-            transaction.FindClaimValue("RefreshToken").ShouldBe("Test Refresh Token");
+            Assert.Equal(HttpStatusCode.OK, transaction.Response.StatusCode);
+            Assert.Equal("Test Refresh Token", transaction.FindClaimValue("RefreshToken"));
         }
 
         [Fact]
@@ -526,8 +525,8 @@ namespace Microsoft.AspNet.Authentication.Google
                 "https://example.com/signin-google?code=TestCode&state=" + UrlEncoder.Default.UrlEncode(state),
                 correlationKey + "=" + correlationValue);
 
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            transaction.Response.Headers.GetValues("Location").First().ShouldBe("/foo");
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
+            Assert.Equal("/foo", transaction.Response.Headers.GetValues("Location").First());
         }
 
 

--- a/test/Microsoft.AspNet.Authentication.Test/JwtBearer/JwtBearerMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/JwtBearer/JwtBearerMiddlewareTests.cs
@@ -13,7 +13,6 @@ using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Authentication;
 using Microsoft.AspNet.TestHost;
 using Microsoft.Framework.DependencyInjection;
-using Shouldly;
 using Xunit;
 
 namespace Microsoft.AspNet.Authentication.JwtBearer
@@ -34,7 +33,7 @@ namespace Microsoft.AspNet.Authentication.JwtBearer
 
             var newBearerToken = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6ImtyaU1QZG1Cdng2OHNrVDgtbVBBQjNCc2VlQSJ9.eyJhdWQiOiJodHRwczovL1R1c2hhclRlc3Qub25taWNyb3NvZnQuY29tL1RvZG9MaXN0U2VydmljZS1NYW51YWxKd3QiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hZmJlY2UwMy1hZWFhLTRmM2YtODVlNy1jZTA4ZGQyMGNlNTAvIiwiaWF0IjoxNDE4MzMwNjE0LCJuYmYiOjE0MTgzMzA2MTQsImV4cCI6MTQxODMzNDUxNCwidmVyIjoiMS4wIiwidGlkIjoiYWZiZWNlMDMtYWVhYS00ZjNmLTg1ZTctY2UwOGRkMjBjZTUwIiwiYW1yIjpbInB3ZCJdLCJvaWQiOiI1Mzk3OTdjMi00MDE5LTQ2NTktOWRiNS03MmM0Yzc3NzhhMzMiLCJ1cG4iOiJWaWN0b3JAVHVzaGFyVGVzdC5vbm1pY3Jvc29mdC5jb20iLCJ1bmlxdWVfbmFtZSI6IlZpY3RvckBUdXNoYXJUZXN0Lm9ubWljcm9zb2Z0LmNvbSIsInN1YiI6IkQyMm9aMW9VTzEzTUFiQXZrdnFyd2REVE80WXZJdjlzMV9GNWlVOVUwYnciLCJmYW1pbHlfbmFtZSI6Ikd1cHRhIiwiZ2l2ZW5fbmFtZSI6IlZpY3RvciIsImFwcGlkIjoiNjEzYjVhZjgtZjJjMy00MWI2LWExZGMtNDE2Yzk3ODAzMGI3IiwiYXBwaWRhY3IiOiIwIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwiYWNyIjoiMSJ9.N_Kw1EhoVGrHbE6hOcm7ERdZ7paBQiNdObvp2c6T6n5CE8p0fZqmUd-ya_EqwElcD6SiKSiP7gj0gpNUnOJcBl_H2X8GseaeeMxBrZdsnDL8qecc6_ygHruwlPltnLTdka67s1Ow4fDSHaqhVTEk6lzGmNEcbNAyb0CxQxU6o7Fh0yHRiWoLsT8yqYk8nKzsHXfZBNby4aRo3_hXaa4i0SZLYfDGGYPdttG4vT_u54QGGd4Wzbonv2gjDlllOVGOwoJS6kfl1h8mk0qxdiIaT_ChbDWgkWvTB7bTvBE-EgHgV0XmAo0WtJeSxgjsG3KhhEPsONmqrSjhIUV4IVnF2w";
             var response = await SendAsync(server, "http://example.com/oauth", newBearerToken);
-            response.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.Response.StatusCode);
         }
 
         [Fact]
@@ -45,7 +44,7 @@ namespace Microsoft.AspNet.Authentication.JwtBearer
                 options.AutomaticAuthentication = true;
             });
             var transaction = await server.SendAsync("https://example.com/signIn");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, transaction.Response.StatusCode);
         }
 
         [Fact]
@@ -56,7 +55,7 @@ namespace Microsoft.AspNet.Authentication.JwtBearer
                 options.AutomaticAuthentication = true;
             });
             var transaction = await server.SendAsync("https://example.com/signOut");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, transaction.Response.StatusCode);
         }
 
 
@@ -90,8 +89,8 @@ namespace Microsoft.AspNet.Authentication.JwtBearer
             });
 
             var response = await SendAsync(server, "http://example.com/oauth", "someHeader someblob");
-            response.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
-            response.ResponseText.ShouldBe("Bob le Magnifique");
+            Assert.Equal(HttpStatusCode.OK, response.Response.StatusCode);
+            Assert.Equal("Bob le Magnifique", response.ResponseText);
         }
 
         [Fact]
@@ -99,7 +98,7 @@ namespace Microsoft.AspNet.Authentication.JwtBearer
         {
             var server = CreateServer(options => { });
             var response = await SendAsync(server, "http://example.com/oauth");
-            response.Response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+            Assert.Equal(HttpStatusCode.Unauthorized, response.Response.StatusCode);
         }
 
         [Fact]
@@ -107,7 +106,7 @@ namespace Microsoft.AspNet.Authentication.JwtBearer
         {
             var server = CreateServer(options => { });
             var response = await SendAsync(server, "http://example.com/oauth","Token");
-            response.Response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+            Assert.Equal(HttpStatusCode.Unauthorized, response.Response.StatusCode);
         }
 
         [Fact]
@@ -140,8 +139,8 @@ namespace Microsoft.AspNet.Authentication.JwtBearer
             });
 
             var response = await SendAsync(server, "http://example.com/oauth", "Bearer someblob");
-            response.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
-            response.ResponseText.ShouldBe("Bob le Magnifique");
+            Assert.Equal(HttpStatusCode.OK, response.Response.StatusCode);
+            Assert.Equal("Bob le Magnifique", response.ResponseText);
         }
 
         [Fact]
@@ -160,7 +159,7 @@ namespace Microsoft.AspNet.Authentication.JwtBearer
                         var identity = (ClaimsIdentity)context.AuthenticationTicket.Principal.Identity;
                         var identifier = identity.FindFirst(ClaimTypes.NameIdentifier);
 
-                        identifier.Value.ShouldBe("Bob le Tout Puissant");
+                        Assert.Equal("Bob le Tout Puissant", identifier.Value);
 
                         // Remove the existing NameIdentifier claim and replace it
                         // with a new one containing a different value.
@@ -177,8 +176,8 @@ namespace Microsoft.AspNet.Authentication.JwtBearer
             });
 
             var response = await SendAsync(server, "http://example.com/oauth", "Bearer someblob");
-            response.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
-            response.ResponseText.ShouldBe("Bob le Magnifique");
+            Assert.Equal(HttpStatusCode.OK, response.Response.StatusCode);
+            Assert.Equal("Bob le Magnifique", response.ResponseText);
         }
 
         [Fact]
@@ -216,8 +215,8 @@ namespace Microsoft.AspNet.Authentication.JwtBearer
             });
 
             var response = await SendAsync(server, "http://example.com/oauth", "Bearer Token");
-            response.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
-            response.ResponseText.ShouldBe("Bob le Magnifique");
+            Assert.Equal(HttpStatusCode.OK, response.Response.StatusCode);
+            Assert.Equal("Bob le Magnifique", response.ResponseText);
         }
 
         [Fact]
@@ -248,7 +247,7 @@ namespace Microsoft.AspNet.Authentication.JwtBearer
             });
 
             var response = await SendAsync(server, "http://example.com/unauthorized", "Bearer Token");
-            response.Response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+            Assert.Equal(HttpStatusCode.Forbidden, response.Response.StatusCode);
         }
         
         [Fact]
@@ -279,7 +278,7 @@ namespace Microsoft.AspNet.Authentication.JwtBearer
             });
 
             var response = await SendAsync(server, "http://example.com/unauthorized");
-            response.Response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+            Assert.Equal(HttpStatusCode.Unauthorized, response.Response.StatusCode);
         }
 
         class BlobTokenValidator : ISecurityTokenValidator

--- a/test/Microsoft.AspNet.Authentication.Test/MicrosoftAccount/MicrosoftAccountMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/MicrosoftAccount/MicrosoftAccountMiddlewareTests.cs
@@ -17,7 +17,6 @@ using Microsoft.AspNet.TestHost;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.WebEncoders;
 using Newtonsoft.Json;
-using Shouldly;
 using Xunit;
 
 namespace Microsoft.AspNet.Authentication.Tests.MicrosoftAccount
@@ -42,9 +41,9 @@ namespace Microsoft.AspNet.Authentication.Tests.MicrosoftAccount
                     };
                 });
             var transaction = await server.SendAsync("http://example.com/challenge");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var query = transaction.Response.Headers.Location.Query;
-            query.ShouldContain("custom=test");
+            Assert.Contains("custom=test", query);
         }
 
         [Fact]
@@ -56,7 +55,7 @@ namespace Microsoft.AspNet.Authentication.Tests.MicrosoftAccount
                 options.ClientSecret = "Test Secret";
             });
             var transaction = await server.SendAsync("https://example.com/signIn");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, transaction.Response.StatusCode);
         }
 
         [Fact]
@@ -68,7 +67,7 @@ namespace Microsoft.AspNet.Authentication.Tests.MicrosoftAccount
                 options.ClientSecret = "Test Secret";
             });
             var transaction = await server.SendAsync("https://example.com/signOut");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, transaction.Response.StatusCode);
         }
 
         [Fact]
@@ -80,7 +79,7 @@ namespace Microsoft.AspNet.Authentication.Tests.MicrosoftAccount
                 options.ClientSecret = "Test Secret";
             });
             var transaction = await server.SendAsync("https://example.com/signOut");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, transaction.Response.StatusCode);
         }
 
         [Fact]
@@ -93,14 +92,14 @@ namespace Microsoft.AspNet.Authentication.Tests.MicrosoftAccount
                     options.ClientSecret = "Test Client Secret";
                 });
             var transaction = await server.SendAsync("http://example.com/challenge");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var location = transaction.Response.Headers.Location.AbsoluteUri;
-            location.ShouldContain("https://login.live.com/oauth20_authorize.srf");
-            location.ShouldContain("response_type=code");
-            location.ShouldContain("client_id=");
-            location.ShouldContain("redirect_uri=");
-            location.ShouldContain("scope=");
-            location.ShouldContain("state=");
+            Assert.Contains("https://login.live.com/oauth20_authorize.srf", location);
+            Assert.Contains("response_type=code", location);
+            Assert.Contains("client_id=", location);
+            Assert.Contains("redirect_uri=", location);
+            Assert.Contains("scope=", location);
+            Assert.Contains("state=", location);
         }
 
         [Fact]
@@ -164,16 +163,16 @@ namespace Microsoft.AspNet.Authentication.Tests.MicrosoftAccount
             var transaction = await server.SendAsync(
                 "https://example.com/signin-microsoft?code=TestCode&state=" + UrlEncoder.Default.UrlEncode(state),
                 correlationKey + "=" + correlationValue);
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            transaction.Response.Headers.GetValues("Location").First().ShouldBe("/me");
-            transaction.SetCookie.Count.ShouldBe(2);
-            transaction.SetCookie[0].ShouldContain(correlationKey);
-            transaction.SetCookie[1].ShouldContain(".AspNet." + TestExtensions.CookieAuthenticationScheme);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
+            Assert.Equal("/me", transaction.Response.Headers.GetValues("Location").First());
+            Assert.Equal(2, transaction.SetCookie.Count);
+            Assert.Contains(correlationKey, transaction.SetCookie[0]);
+            Assert.Contains(".AspNet." + TestExtensions.CookieAuthenticationScheme, transaction.SetCookie[1]);
 
             var authCookie = transaction.AuthenticationCookieValue;
             transaction = await server.SendAsync("https://example.com/me", authCookie);
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
-            transaction.FindClaimValue("RefreshToken").ShouldBe("Test Refresh Token");
+            Assert.Equal(HttpStatusCode.OK, transaction.Response.StatusCode);
+            Assert.Equal("Test Refresh Token", transaction.FindClaimValue("RefreshToken"));
         }
 
         private static TestServer CreateServer(Action<MicrosoftAccountOptions> configureOptions)

--- a/test/Microsoft.AspNet.Authentication.Test/OpenIdConnect/OpenIdConnectHandlerTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/OpenIdConnect/OpenIdConnectHandlerTests.cs
@@ -20,7 +20,6 @@ using Microsoft.Framework.OptionsModel;
 using Microsoft.Framework.WebEncoders;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Moq;
-using Shouldly;
 using Xunit;
 
 namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
@@ -41,20 +40,20 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
         public void LoggingLevel()
         {
             var logger = new InMemoryLogger(LogLevel.Debug);
-            logger.IsEnabled(LogLevel.Critical).ShouldBe<bool>(true);
-            logger.IsEnabled(LogLevel.Debug).ShouldBe<bool>(true);
-            logger.IsEnabled(LogLevel.Error).ShouldBe<bool>(true);
-            logger.IsEnabled(LogLevel.Information).ShouldBe<bool>(true);
-            logger.IsEnabled(LogLevel.Verbose).ShouldBe<bool>(true);
-            logger.IsEnabled(LogLevel.Warning).ShouldBe<bool>(true);
+            Assert.True(logger.IsEnabled(LogLevel.Critical));
+            Assert.True(logger.IsEnabled(LogLevel.Debug));
+            Assert.True(logger.IsEnabled(LogLevel.Error));
+            Assert.True(logger.IsEnabled(LogLevel.Information));
+            Assert.True(logger.IsEnabled(LogLevel.Verbose));
+            Assert.True(logger.IsEnabled(LogLevel.Warning));
 
             logger = new InMemoryLogger(LogLevel.Critical);
-            logger.IsEnabled(LogLevel.Critical).ShouldBe<bool>(true);
-            logger.IsEnabled(LogLevel.Debug).ShouldBe<bool>(false);
-            logger.IsEnabled(LogLevel.Error).ShouldBe<bool>(false);
-            logger.IsEnabled(LogLevel.Information).ShouldBe<bool>(false);
-            logger.IsEnabled(LogLevel.Verbose).ShouldBe<bool>(false);
-            logger.IsEnabled(LogLevel.Warning).ShouldBe<bool>(false);
+            Assert.True(logger.IsEnabled(LogLevel.Critical));
+            Assert.False(logger.IsEnabled(LogLevel.Debug));
+            Assert.False(logger.IsEnabled(LogLevel.Error));
+            Assert.False(logger.IsEnabled(LogLevel.Information));
+            Assert.False(logger.IsEnabled(LogLevel.Verbose));
+            Assert.False(logger.IsEnabled(LogLevel.Warning));
         }
 
         [Theory, MemberData("AuthenticateCoreStateDataSet")]

--- a/test/Microsoft.AspNet.Authentication.Test/OpenIdConnect/OpenIdConnectMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/OpenIdConnect/OpenIdConnectMiddlewareTests.cs
@@ -20,7 +20,6 @@ using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.WebEncoders;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Moq;
-using Shouldly;
 using Xunit;
 
 namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
@@ -51,9 +50,9 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
                 options.AuthenticationMethod = OpenIdConnectRedirectBehavior.FormPost;
             });
             var transaction = await SendAsync(server, DefaultHost + Challenge);
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
-            transaction.Response.Content.Headers.ContentType.MediaType.ShouldBe("text/html");
-            transaction.ResponseText.ShouldContain("form");
+            Assert.Equal(HttpStatusCode.OK, transaction.Response.StatusCode);
+            Assert.Equal("text/html", transaction.Response.Content.Headers.ContentType.MediaType);
+            Assert.Contains("form", transaction.ResponseText);
         }
 
         [Fact]
@@ -68,7 +67,7 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
             });
 
             var transaction = await SendAsync(server, DefaultHost + Challenge);
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             queryValues.CheckValues(transaction.Response.Headers.Location.AbsoluteUri, DefaultParameters());
         }
 
@@ -84,12 +83,12 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
             var transaction = await SendAsync(server, DefaultHost + Challenge);
 
             var firstCookie = transaction.SetCookie.First();
-            firstCookie.ShouldContain(OpenIdConnectDefaults.CookieNoncePrefix);
-            firstCookie.ShouldContain("Expires");
+            Assert.Contains(OpenIdConnectDefaults.CookieNoncePrefix, firstCookie);
+            Assert.Contains("expires", firstCookie);
 
             var secondCookie = transaction.SetCookie.Skip(1).First();
-            secondCookie.ShouldContain(OpenIdConnectDefaults.CookieStatePrefix);
-            secondCookie.ShouldContain("Expires");
+            Assert.Contains(OpenIdConnectDefaults.CookieStatePrefix, secondCookie);
+            Assert.Contains("expires", secondCookie);
         }
 
         [Fact]
@@ -102,7 +101,7 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
             });
 
             var transaction = await SendAsync(server, DefaultHost + Challenge);
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             queryValues.CheckValues(transaction.Response.Headers.Location.AbsoluteUri, DefaultParameters());
         }
 
@@ -127,7 +126,7 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
             };
             var server = CreateServer(SetProtocolMessageOptions);
             var transaction = await SendAsync(server, DefaultHost + challenge);
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             queryValues.CheckValues(transaction.Response.Headers.Location.AbsoluteUri, new string[] {});
         }
 
@@ -181,7 +180,7 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
             }, null, properties);
 
             var transaction = await SendAsync(server, DefaultHost + challenge);
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
 
             if (challenge != ChallengeWithProperties)
             {
@@ -234,7 +233,7 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
             });
 
             var transaction = await SendAsync(server, DefaultHost + Challenge);
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             queryValuesSetInEvent.CheckValues(transaction.Response.Headers.Location.AbsoluteUri, DefaultParameters());
         }
 
@@ -301,8 +300,8 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
             });
 
             var transaction = await SendAsync(server, DefaultHost + Signout);
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            transaction.Response.Headers.Location.AbsoluteUri.ShouldBe(configuration.EndSessionEndpoint);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
+            Assert.Equal(configuration.EndSessionEndpoint, transaction.Response.Headers.Location.AbsoluteUri);
         }
 
         [Fact]
@@ -318,8 +317,8 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
             });
 
             var transaction = await SendAsync(server, DefaultHost + Signout);
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            transaction.Response.Headers.Location.AbsoluteUri.ShouldContain(UrlEncoder.Default.UrlEncode("https://example.com/logout"));
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
+            Assert.Contains(UrlEncoder.Default.UrlEncode("https://example.com/logout"), transaction.Response.Headers.Location.AbsoluteUri);
         }
 
         [Fact]
@@ -335,8 +334,8 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
             });
 
             var transaction = await SendAsync(server, "https://example.com/signout_with_specific_redirect_uri");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            transaction.Response.Headers.Location.AbsoluteUri.ShouldContain(UrlEncoder.Default.UrlEncode("http://www.example.com/specific_redirect_uri"));
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
+            Assert.Contains(UrlEncoder.Default.UrlEncode("http://www.example.com/specific_redirect_uri"), transaction.Response.Headers.Location.AbsoluteUri);
         }
 
         private static TestServer CreateServer(Action<OpenIdConnectOptions> configureOptions, Func<HttpContext, Task> handler = null, AuthenticationProperties properties = null)
@@ -466,21 +465,21 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
         {
             DateTime utcNow = DateTime.UtcNow;
 
-            GetNonceExpirationTime(noncePrefix + DateTime.MaxValue.Ticks.ToString(CultureInfo.InvariantCulture) + nonceDelimiter, TimeSpan.FromHours(1)).ShouldBe(DateTime.MaxValue);
+            Assert.Equal(DateTime.MaxValue, GetNonceExpirationTime(noncePrefix + DateTime.MaxValue.Ticks.ToString(CultureInfo.InvariantCulture) + nonceDelimiter, TimeSpan.FromHours(1)));
 
-            GetNonceExpirationTime(noncePrefix + DateTime.MinValue.Ticks.ToString(CultureInfo.InvariantCulture) + nonceDelimiter, TimeSpan.FromHours(1)).ShouldBe(DateTime.MinValue + TimeSpan.FromHours(1));
+            Assert.Equal(DateTime.MinValue + TimeSpan.FromHours(1), GetNonceExpirationTime(noncePrefix + DateTime.MinValue.Ticks.ToString(CultureInfo.InvariantCulture) + nonceDelimiter, TimeSpan.FromHours(1)));
 
-            GetNonceExpirationTime(noncePrefix + utcNow.Ticks.ToString(CultureInfo.InvariantCulture) + nonceDelimiter, TimeSpan.FromHours(1)).ShouldBe(utcNow + TimeSpan.FromHours(1));
+            Assert.Equal(utcNow + TimeSpan.FromHours(1), GetNonceExpirationTime(noncePrefix + utcNow.Ticks.ToString(CultureInfo.InvariantCulture) + nonceDelimiter, TimeSpan.FromHours(1)));
 
-            GetNonceExpirationTime(noncePrefix, TimeSpan.FromHours(1)).ShouldBe(DateTime.MinValue);
+            Assert.Equal(DateTime.MinValue, GetNonceExpirationTime(noncePrefix, TimeSpan.FromHours(1)));
 
-            GetNonceExpirationTime("", TimeSpan.FromHours(1)).ShouldBe(DateTime.MinValue);
+            Assert.Equal(DateTime.MinValue, GetNonceExpirationTime("", TimeSpan.FromHours(1)));
 
-            GetNonceExpirationTime(noncePrefix + noncePrefix, TimeSpan.FromHours(1)).ShouldBe(DateTime.MinValue);
+            Assert.Equal(DateTime.MinValue, GetNonceExpirationTime(noncePrefix + noncePrefix, TimeSpan.FromHours(1)));
 
-            GetNonceExpirationTime(noncePrefix + utcNow.Ticks.ToString(CultureInfo.InvariantCulture) + nonceDelimiter + utcNow.Ticks.ToString(CultureInfo.InvariantCulture) + nonceDelimiter, TimeSpan.FromHours(1)).ShouldBe(utcNow + TimeSpan.FromHours(1));
+            Assert.Equal(utcNow + TimeSpan.FromHours(1), GetNonceExpirationTime(noncePrefix + utcNow.Ticks.ToString(CultureInfo.InvariantCulture) + nonceDelimiter + utcNow.Ticks.ToString(CultureInfo.InvariantCulture) + nonceDelimiter, TimeSpan.FromHours(1)));
 
-            GetNonceExpirationTime(utcNow.Ticks.ToString(CultureInfo.InvariantCulture) + nonceDelimiter + utcNow.Ticks.ToString(CultureInfo.InvariantCulture) + nonceDelimiter, TimeSpan.FromHours(1)).ShouldBe(DateTime.MinValue);
+            Assert.Equal(DateTime.MinValue, GetNonceExpirationTime(utcNow.Ticks.ToString(CultureInfo.InvariantCulture) + nonceDelimiter + utcNow.Ticks.ToString(CultureInfo.InvariantCulture) + nonceDelimiter, TimeSpan.FromHours(1)));
         }
 
         private static DateTime GetNonceExpirationTime(string keyname, TimeSpan nonceLifetime)

--- a/test/Microsoft.AspNet.Authentication.Test/Twitter/TwitterMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Twitter/TwitterMiddlewareTests.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.TestHost;
 using Microsoft.Framework.DependencyInjection;
-using Shouldly;
 using Xunit;
 
 namespace Microsoft.AspNet.Authentication.Twitter
@@ -57,9 +56,9 @@ namespace Microsoft.AspNet.Authentication.Twitter
                     return true;
                 });
             var transaction = await server.SendAsync("http://example.com/challenge");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var query = transaction.Response.Headers.Location.Query;
-            query.ShouldContain("custom=test");
+            Assert.Contains("custom=test", query);
         }
 
         [Fact]
@@ -71,7 +70,7 @@ namespace Microsoft.AspNet.Authentication.Twitter
                 options.ConsumerSecret = "Test Consumer Secret";
             });
             var transaction = await server.SendAsync("https://example.com/signIn");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, transaction.Response.StatusCode);
         }
 
         [Fact]
@@ -83,7 +82,7 @@ namespace Microsoft.AspNet.Authentication.Twitter
                 options.ConsumerSecret = "Test Consumer Secret";
             });
             var transaction = await server.SendAsync("https://example.com/signOut");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, transaction.Response.StatusCode);
         }
 
         [Fact]
@@ -95,7 +94,7 @@ namespace Microsoft.AspNet.Authentication.Twitter
                 options.ConsumerSecret = "Test Consumer Secret";
             });
             var transaction = await server.SendAsync("https://example.com/signOut");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, transaction.Response.StatusCode);
         }
 
 
@@ -131,9 +130,9 @@ namespace Microsoft.AspNet.Authentication.Twitter
                     return true;
                 });
             var transaction = await server.SendAsync("http://example.com/challenge");
-            transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var location = transaction.Response.Headers.Location.AbsoluteUri;
-            location.ShouldContain("https://twitter.com/oauth/authenticate?oauth_token=");
+            Assert.Contains("https://twitter.com/oauth/authenticate?oauth_token=", location);
         }
 
         private static TestServer CreateServer(Action<TwitterOptions> configure, Func<HttpContext, bool> handler = null)

--- a/test/Microsoft.AspNet.Authentication.Test/project.json
+++ b/test/Microsoft.AspNet.Authentication.Test/project.json
@@ -1,28 +1,25 @@
 {
-    "compilationOptions": {
-        "warningsAsErrors": true
-    },
-    "dependencies": {
-        "Microsoft.AspNet.Authentication.Cookies": "1.0.0-*",
-        "Microsoft.AspNet.Authentication.Facebook": "1.0.0-*",
-        "Microsoft.AspNet.Authentication.Google": "1.0.0-*",
-        "Microsoft.AspNet.Authentication.JwtBearer": "1.0.0-*",
-        "Microsoft.AspNet.Authentication.MicrosoftAccount": "1.0.0-*",
-        "Microsoft.AspNet.Authentication.OpenIdConnect": "1.0.0-*",
-        "Microsoft.AspNet.Authentication.Twitter": "1.0.0-*",
-        "Microsoft.AspNet.DataProtection": "1.0.0-*",
-        "Microsoft.AspNet.TestHost": "1.0.0-*",
-        "Moq": "4.2.1312.1622",
-        "xunit.runner.aspnet": "2.0.0-aspnet-*"
-    },
-    "commands": {
-        "test": "xunit.runner.aspnet"
-    },
-    "frameworks": {
-        "dnx451": {
-            "dependencies": {
-                "Shouldly": "1.1.1.1"
-            }
-        }
+  "compilationOptions": {
+    "warningsAsErrors": true
+  },
+  "dependencies": {
+    "Microsoft.AspNet.Authentication.Cookies": "1.0.0-*",
+    "Microsoft.AspNet.Authentication.Facebook": "1.0.0-*",
+    "Microsoft.AspNet.Authentication.Google": "1.0.0-*",
+    "Microsoft.AspNet.Authentication.JwtBearer": "1.0.0-*",
+    "Microsoft.AspNet.Authentication.MicrosoftAccount": "1.0.0-*",
+    "Microsoft.AspNet.Authentication.OpenIdConnect": "1.0.0-*",
+    "Microsoft.AspNet.Authentication.Twitter": "1.0.0-*",
+    "Microsoft.AspNet.DataProtection": "1.0.0-*",
+    "Microsoft.AspNet.TestHost": "1.0.0-*",
+    "Moq": "4.2.1312.1622",
+    "xunit.runner.aspnet": "2.0.0-aspnet-*"
+  },
+  "commands": {
+    "test": "xunit.runner.aspnet"
+  },
+  "frameworks": {
+    "dnx451": {
     }
+  }
 }

--- a/test/Microsoft.AspNet.Authorization.Test/project.json
+++ b/test/Microsoft.AspNet.Authorization.Test/project.json
@@ -1,21 +1,19 @@
 {
-    "compilationOptions": {
-        "warningsAsErrors": true
+  "compilationOptions": {
+    "warningsAsErrors": true
+  },
+  "dependencies": {
+    "Microsoft.AspNet.Authorization": "1.0.0-*",
+    "Microsoft.Framework.DependencyInjection": "1.0.0-*",
+    "xunit.runner.aspnet": "2.0.0-aspnet-*"
+  },
+  "commands": {
+    "test": "xunit.runner.aspnet"
+  },
+  "frameworks": {
+    "dnx451": {
     },
-    "dependencies": {
-        "Microsoft.AspNet.Authorization": "1.0.0-*",
-        "Microsoft.Framework.DependencyInjection": "1.0.0-*",
-        "Moq": "4.2.1312.1622",
-        "xunit.runner.aspnet": "2.0.0-aspnet-*"
-    },
-    "commands": {
-        "test": "xunit.runner.aspnet"
-    },
-    "frameworks": {
-        "dnx451": {
-            "dependencies": {
-                "Shouldly": "1.1.1.1"
-            }
-        }
+    "dnxcore50": {
     }
+  }
 }


### PR DESCRIPTION
* removed Shouldy as a dependency from all tests
* could not enable coreclr50 due to remaining incompatibility with moq, Uri.GetLeftPart(...), UriPartial, et al

#420