### PR TITLE
Remove RedirectUri from OIDC, use CallbackPath.

### DIFF
--- a/samples/OpenIdConnectSample/Startup.cs
+++ b/samples/OpenIdConnectSample/Startup.cs
@@ -33,7 +33,6 @@ namespace OpenIdConnectSample
                 options.ClientId = "63a87a83-64b9-4ac1-b2c5-092126f8474f";
                 options.ClientSecret = "Yse2iP7tO1Azq0iDajNisMaTSnIDv+FXmAsFuXr+Cy8="; // for code flow
                 options.Authority = "https://login.windows.net/tratcheroutlook.onmicrosoft.com";
-                options.RedirectUri = "http://localhost:42023/signin-oidc";
                 options.ResponseType = OpenIdConnectResponseTypes.Code;
                 options.GetClaimsFromUserInfoEndpoint = true;
             });

--- a/src/Microsoft.AspNet.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
@@ -192,7 +192,7 @@ namespace Microsoft.AspNet.Authentication.OpenIdConnect
             {
                 ClientId = Options.ClientId,
                 IssuerAddress = _configuration?.AuthorizationEndpoint ?? string.Empty,
-                RedirectUri = Options.RedirectUri,
+                RedirectUri = BuildRedirectUri(Options.CallbackPath),
                 Resource = Options.Resource,
                 ResponseType = Options.ResponseType,
                 Scope = string.Join(" ", Options.Scope)
@@ -239,18 +239,8 @@ namespace Microsoft.AspNet.Authentication.OpenIdConnect
                 properties.Items[OpenIdConnectDefaults.UserstatePropertiesKey] = message.State;
             }
 
-            var redirectUriForCode = message.RedirectUri;
-            if (string.IsNullOrEmpty(redirectUriForCode))
-            {
-                Logger.LogDebug(8, "Using Options.RedirectUri for 'redirect_uri': '{0}'.", Options.RedirectUri);
-                redirectUriForCode = Options.RedirectUri;
-            }
-
-            if (!string.IsNullOrEmpty(redirectUriForCode))
-            {
-                // When redeeming a 'code' for an AccessToken, this value is needed
-                properties.Items.Add(OpenIdConnectDefaults.RedirectUriForCodePropertiesKey, redirectUriForCode);
-            }
+            // When redeeming a 'code' for an AccessToken, this value is needed
+            properties.Items.Add(OpenIdConnectDefaults.RedirectUriForCodePropertiesKey, message.RedirectUri);
 
             message.State = Options.StateDataFormat.Protect(properties);
 
@@ -957,8 +947,7 @@ namespace Microsoft.AspNet.Authentication.OpenIdConnect
 
         private async Task<AuthorizationCodeReceivedContext> RunAuthorizationCodeReceivedEventAsync(OpenIdConnectMessage message, AuthenticationProperties properties, AuthenticationTicket ticket, JwtSecurityToken jwt)
         {
-            var redirectUri = properties.Items.ContainsKey(OpenIdConnectDefaults.RedirectUriForCodePropertiesKey) ?
-                properties.Items[OpenIdConnectDefaults.RedirectUriForCodePropertiesKey] : Options.RedirectUri;
+            var redirectUri = properties.Items[OpenIdConnectDefaults.RedirectUriForCodePropertiesKey];
 
             Logger.LogDebug(32, "AuthorizationCode received: '{0}'", message.Code);
 

--- a/src/Microsoft.AspNet.Authentication.OpenIdConnect/OpenIdConnectMiddleware.cs
+++ b/src/Microsoft.AspNet.Authentication.OpenIdConnect/OpenIdConnectMiddleware.cs
@@ -121,16 +121,6 @@ namespace Microsoft.AspNet.Authentication.OpenIdConnect
                 Options.StringDataFormat = new SecureDataFormat<string>(new StringSerializer(), dataProtector);
             }
 
-            // if the user has not set the AuthorizeCallback, set it from the redirect_uri
-            if (!Options.CallbackPath.HasValue)
-            {
-                Uri redirectUri;
-                if (!string.IsNullOrEmpty(Options.RedirectUri) && Uri.TryCreate(Options.RedirectUri, UriKind.Absolute, out redirectUri))
-                {
-                    // Redirect_Uri must be a very specific, case sensitive value, so we can't generate it. Instead we generate AuthorizeCallback from it.
-                    Options.CallbackPath = PathString.FromUriComponent(redirectUri);
-                }
-            }
 
             if (Options.Events == null)
             {

--- a/src/Microsoft.AspNet.Authentication.OpenIdConnect/OpenIdConnectOptions.cs
+++ b/src/Microsoft.AspNet.Authentication.OpenIdConnect/OpenIdConnectOptions.cs
@@ -126,12 +126,6 @@ namespace Microsoft.AspNet.Authentication.OpenIdConnect
         public string PostLogoutRedirectUri { get; set; }
 
         /// <summary>
-        /// Gets or sets the 'redirect_uri'.
-        /// </summary>
-        [SuppressMessage("Microsoft.Design", "CA1056:UriPropertiesShouldNotBeStrings", Justification = "By Design")]
-        public string RedirectUri { get; set; }
-
-        /// <summary>
         /// Gets or sets if a metadata refresh should be attempted after a SecurityTokenSignatureKeyNotFoundException. This allows for automatic
         /// recovery in the event of a signature key rollover. This is enabled by default.
         /// </summary>

--- a/test/Microsoft.AspNet.Authentication.Test/OpenIdConnect/OpenIdConnectMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/OpenIdConnect/OpenIdConnectMiddlewareTests.cs
@@ -215,6 +215,7 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
                     OnRedirectToAuthenticationEndpoint = context =>
                     {
                         context.ProtocolMessage.State = userState;
+                        context.ProtocolMessage.RedirectUri = queryValues.RedirectUri;
                         return Task.FromResult<object>(null);
                     }
 
@@ -285,8 +286,6 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
             {
                 if (param.Equals(OpenIdConnectParameterNames.ClientId))
                     options.ClientId = queryValues.ClientId;
-                else if (param.Equals(OpenIdConnectParameterNames.RedirectUri))
-                    options.RedirectUri = queryValues.RedirectUri;
                 else if (param.Equals(OpenIdConnectParameterNames.Resource))
                     options.Resource = queryValues.Resource;
                 else if (param.Equals(OpenIdConnectParameterNames.Scope)) {
@@ -309,7 +308,6 @@ namespace Microsoft.AspNet.Authentication.Tests.OpenIdConnect
                 new List<string>
                 {
                     OpenIdConnectParameterNames.ClientId,
-                    OpenIdConnectParameterNames.RedirectUri,
                     OpenIdConnectParameterNames.Resource,
                     OpenIdConnectParameterNames.ResponseMode,
                     OpenIdConnectParameterNames.Scope,


### PR DESCRIPTION
#455 @HaoK @brentschmaltz @tushargupta51 @PinpointTownes @leastprivilege
From what we can tell RedirectUri can be correctly generated in most scenarios, and if you really need to override it you can do so in the events. This brings OIDC in line with the other middleware and requires less configuration parameter.