### PR TITLE
Fix some authentication unit tests failing on Linux and OS X.

### DIFF
--- a/test/Microsoft.AspNet.Authentication.Test/Google/GoogleMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Google/GoogleMiddlewareTests.cs
@@ -245,7 +245,7 @@ namespace Microsoft.AspNet.Authentication.Google
                 options.ClientSecret = "Test Secret";
             });
             var error = await Assert.ThrowsAnyAsync<Exception>(() => server.SendAsync("https://example.com/signin-google?code=TestCode"));
-            Assert.Equal("The oauth state was missing or invalid.", error.Message);
+            Assert.Equal("The oauth state was missing or invalid.", error.GetBaseException().Message);
         }
 
         [Theory]
@@ -279,7 +279,7 @@ namespace Microsoft.AspNet.Authentication.Google
             else
             {
                 var error = await Assert.ThrowsAnyAsync<Exception>(() => server.SendAsync("https://example.com/signin-google?error=OMG"));
-                Assert.Equal("OMG", error.Message);
+                Assert.Equal("OMG", error.GetBaseException().Message);
             }
         }
 
@@ -417,7 +417,7 @@ namespace Microsoft.AspNet.Authentication.Google
             else
             {
                 var error = await Assert.ThrowsAnyAsync<Exception>(() => sendTask);
-                Assert.Equal("OAuth token endpoint failure: Status: BadRequest;Headers: ;Body: {\"Error\":\"Error\"};", error.Message);
+                Assert.Equal("OAuth token endpoint failure: Status: BadRequest;Headers: ;Body: {\"Error\":\"Error\"};", error.GetBaseException().Message);
             }
         }
 
@@ -471,7 +471,7 @@ namespace Microsoft.AspNet.Authentication.Google
             else
             {
                 var error = await Assert.ThrowsAnyAsync<Exception>(() => sendTask);
-                Assert.Equal("Failed to retrieve access token.", error.Message);
+                Assert.Equal("Failed to retrieve access token.", error.GetBaseException().Message);
             }
         }
 
@@ -723,7 +723,7 @@ namespace Microsoft.AspNet.Authentication.Google
 
             //Post a message to the Google middleware
             var error = await Assert.ThrowsAnyAsync<Exception>(() => server.SendAsync("https://example.com/signin-google?code=TestCode"));
-            Assert.Equal("The oauth state was missing or invalid.", error.Message);
+            Assert.Equal("The oauth state was missing or invalid.", error.GetBaseException().Message);
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Authentication.Test/Twitter/TwitterMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Twitter/TwitterMiddlewareTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.AspNet.Authentication.Twitter
 
             // Send a bogus sign in
             var error = await Assert.ThrowsAnyAsync<Exception>(() => server.SendAsync("https://example.com/signin-twitter"));
-            Assert.Equal("Invalid state cookie.", error.Message);
+            Assert.Equal("Invalid state cookie.", error.GetBaseException().Message);
         }
 
         [Fact]


### PR DESCRIPTION
It looks like HttpClient on Windows extracts the base exception from an AggregateException in a response, while Mono doesn't. So we need to look at the base exception of whatever exception is returned when an error is expected in a response. This works for non-aggregate exceptions because GetBaseException() returns the exception itself in that case.

cc @Tratcher 