### PR TITLE
DefaultAuthorizationServiceTests Improvements

### DIFF
--- a/test/Microsoft.AspNet.Authorization.Test/DefaultAuthorizationServiceTests.cs
+++ b/test/Microsoft.AspNet.Authorization.Test/DefaultAuthorizationServiceTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNet.Authorization.Test
                     options.AddPolicy("Basic", policy => policy.RequireClaim("Permission", "CanViewPage"));
                 });
             });
-            var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { new Claim("Permission", "CanViewPage") }, "Basic"));
+            var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { new Claim("Permission", "CanViewPage") }));
 
             // Act
             var allowed = await authorizationService.AuthorizeAsync(user, "Basic");
@@ -62,7 +62,10 @@ namespace Microsoft.AspNet.Authorization.Test
             {
                 services.AddAuthorization(options =>
                 {
-                    options.AddPolicy("Basic", policy => policy.RequireClaim("Permission", "CanViewPage"));
+                    options.AddPolicy("Basic", policy => {
+                        policy.AddAuthenticationSchemes("Basic");
+                        policy.RequireClaim("Permission", "CanViewPage");
+                    });
                 });
             });
             var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { new Claim("Permission", "CanViewPage") }, "Basic"));


### PR DESCRIPTION
Summary of the changes
 - No need to set the authenticationType in the Authorize_ShouldAllowIfClaimIsPresent unit test, since we already have another unit test for these functionality.
 - Specified the authentication scheme of the authorization policy  in the Authorize_ShouldAllowIfClaimIsPresentWithSpecifiedAuthType unit test