### PR TITLE
Update facebook APIs to v2.5.

### DIFF
--- a/src/Microsoft.AspNet.Authentication.Facebook/FacebookDefaults.cs
+++ b/src/Microsoft.AspNet.Authentication.Facebook/FacebookDefaults.cs
@@ -7,10 +7,10 @@ namespace Microsoft.AspNet.Authentication.Facebook
     {
         public const string AuthenticationScheme = "Facebook";
 
-        public static readonly string AuthorizationEndpoint = "https://www.facebook.com/v2.2/dialog/oauth";
+        public static readonly string AuthorizationEndpoint = "https://www.facebook.com/v2.5/dialog/oauth";
 
-        public static readonly string TokenEndpoint = "https://graph.facebook.com/v2.2/oauth/access_token";
+        public static readonly string TokenEndpoint = "https://graph.facebook.com/v2.5/oauth/access_token";
 
-        public static readonly string UserInformationEndpoint = "https://graph.facebook.com/v2.2/me";
+        public static readonly string UserInformationEndpoint = "https://graph.facebook.com/v2.5/me";
     }
 }

--- a/src/Microsoft.AspNet.Authentication.Facebook/FacebookOptions.cs
+++ b/src/Microsoft.AspNet.Authentication.Facebook/FacebookOptions.cs
@@ -1,8 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNet.Http;
+using System.Collections.Generic;
 using Microsoft.AspNet.Authentication.OAuth;
+using Microsoft.AspNet.Http;
 
 namespace Microsoft.AspNet.Authentication.Facebook
 {
@@ -24,6 +25,7 @@ namespace Microsoft.AspNet.Authentication.Facebook
             TokenEndpoint = FacebookDefaults.TokenEndpoint;
             UserInformationEndpoint = FacebookDefaults.UserInformationEndpoint;
             SaveTokensAsClaims = false;
+            Fields = new List<string>();
         }
 
         // Facebook uses a non-standard term for this field.
@@ -51,5 +53,11 @@ namespace Microsoft.AspNet.Authentication.Facebook
         /// This is enabled by default.
         /// </summary>
         public bool SendAppSecretProof { get; set; }
+
+        /// <summary>
+        /// The list of fields to retrieve from the UserInformationEndpoint.
+        /// https://developers.facebook.com/docs/graph-api/reference/user
+        /// </summary>
+        public IList<string> Fields { get; }
     }
 }

--- a/test/Microsoft.AspNet.Authentication.Test/Facebook/FacebookMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.Authentication.Test/Facebook/FacebookMiddlewareTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNet.Authentication.Facebook
             var transaction = await server.SendAsync("http://example.com/base/login");
             Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var location = transaction.Response.Headers.Location.AbsoluteUri;
-            Assert.Contains("https://www.facebook.com/v2.2/dialog/oauth", location);
+            Assert.Contains("https://www.facebook.com/v2.5/dialog/oauth", location);
             Assert.Contains("response_type=code", location);
             Assert.Contains("client_id=", location);
             Assert.Contains("redirect_uri=" + UrlEncoder.Default.Encode("http://example.com/base/signin-facebook"), location);
@@ -113,7 +113,7 @@ namespace Microsoft.AspNet.Authentication.Facebook
             var transaction = await server.SendAsync("http://example.com/login");
             Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var location = transaction.Response.Headers.Location.AbsoluteUri;
-            Assert.Contains("https://www.facebook.com/v2.2/dialog/oauth", location);
+            Assert.Contains("https://www.facebook.com/v2.5/dialog/oauth", location);
             Assert.Contains("response_type=code", location);
             Assert.Contains("client_id=", location);
             Assert.Contains("redirect_uri="+ UrlEncoder.Default.Encode("http://example.com/signin-facebook"), location);
@@ -147,7 +147,7 @@ namespace Microsoft.AspNet.Authentication.Facebook
             var transaction = await server.SendAsync("http://example.com/challenge");
             Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var location = transaction.Response.Headers.Location.AbsoluteUri;
-            Assert.Contains("https://www.facebook.com/v2.2/dialog/oauth", location);
+            Assert.Contains("https://www.facebook.com/v2.5/dialog/oauth", location);
             Assert.Contains("response_type=code", location);
             Assert.Contains("client_id=", location);
             Assert.Contains("redirect_uri=", location);
@@ -178,11 +178,11 @@ namespace Microsoft.AspNet.Authentication.Facebook
                                 if (req.RequestUri.GetComponents(UriComponents.SchemeAndServer | UriComponents.Path, UriFormat.UriEscaped) == FacebookDefaults.TokenEndpoint)
                                 {
                                     var res = new HttpResponseMessage(HttpStatusCode.OK);
-                                    var tokenResponse = new Dictionary<string, string>
+                                    var graphResponse = JsonConvert.SerializeObject(new
                                     {
-                                        { "access_token", "TestAuthToken" },
-                                    };
-                                    res.Content = new FormUrlEncodedContent(tokenResponse);
+                                        access_token = "TestAuthToken"
+                                    });
+                                    res.Content = new StringContent(graphResponse, Encoding.UTF8);
                                     return res;
                                 }
                                 if (req.RequestUri.GetComponents(UriComponents.SchemeAndServer | UriComponents.Path, UriFormat.UriEscaped) ==


### PR DESCRIPTION
#565, #435
1. They now use a standard JSON instead of a custom Form response from the TokenEndpoint.
2. Added support for requesting non-default Fields like e-mail.
@HaoK
/cc: @MikeWasson @AlexTo @hajjat @Jayman1305 @chris02031 @dotnetshadow 