### PR TITLE
Remove depreciated field username from Facebook

### DIFF
--- a/src/Microsoft.AspNet.Authentication.Facebook/FacebookHandler.cs
+++ b/src/Microsoft.AspNet.Authentication.Facebook/FacebookHandler.cs
@@ -48,28 +48,16 @@ namespace Microsoft.AspNet.Authentication.Facebook
                 identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, identifier, ClaimValueTypes.String, Options.ClaimsIssuer));
             }
 
-            var userName = FacebookHelper.GetUserName(payload);
-            if (!string.IsNullOrEmpty(userName))
+            var name = FacebookHelper.GetName(payload);
+            if (!string.IsNullOrEmpty(name))
             {
-                identity.AddClaim(new Claim(ClaimsIdentity.DefaultNameClaimType, userName, ClaimValueTypes.String, Options.ClaimsIssuer));
+                identity.AddClaim(new Claim(ClaimsIdentity.DefaultNameClaimType, name, ClaimValueTypes.String, Options.ClaimsIssuer));
             }
 
             var email = FacebookHelper.GetEmail(payload);
             if (!string.IsNullOrEmpty(email))
             {
                 identity.AddClaim(new Claim(ClaimTypes.Email, email, ClaimValueTypes.String, Options.ClaimsIssuer));
-            }
-
-            var name = FacebookHelper.GetName(payload);
-            if (!string.IsNullOrEmpty(name))
-            {
-                identity.AddClaim(new Claim("urn:facebook:name", name, ClaimValueTypes.String, Options.ClaimsIssuer));
-
-                // Many Facebook accounts do not set the UserName field.  Fall back to the Name field instead.
-                if (string.IsNullOrEmpty(userName))
-                {
-                    identity.AddClaim(new Claim(identity.NameClaimType, name, ClaimValueTypes.String, Options.ClaimsIssuer));
-                }
             }
 
             var link = FacebookHelper.GetLink(payload);


### PR DESCRIPTION
https://developers.facebook.com/docs/apps/changelog

Endpoints no longer available in v2.0
....
•/me/username is no longer available.

Test output from Social Sample

Hello Joe Blogs
http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier: 931001963123456
http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name: Joe Blogs
Logout