### PR TITLE
Remove unused dependency

### DIFF
--- a/src/Microsoft.AspNetCore.Authorization/project.json
+++ b/src/Microsoft.AspNetCore.Authorization/project.json
@@ -10,12 +10,15 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "Microsoft.AspNetCore.Http.Features": "1.0.0-*",
     "Microsoft.Extensions.Logging.Abstractions": "1.0.0-*",
     "Microsoft.Extensions.Options": "1.0.0-*"
   },
   "frameworks": {
-    "net451": {},
-    "dotnet5.4": {}
+    "net451": { },
+    "dotnet5.4": {
+      "dependencies": {
+        "System.Security.Claims": "4.0.1-*"
+      }
+    }
   }
 }


### PR DESCRIPTION
- The authorization stack doesn't depend on AspNetCore at all really

This brings up an interesting question, why is it tied to ASP.NET at all? Shouldn't the AuthorizationContext flow the HttpContext as well? 

/cc @HaoK @blowdart @Tratcher @lodejard 