### PR TITLE
Add default fields to Facebook

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
@@ -48,28 +48,10 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
                 identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, identifier, ClaimValueTypes.String, Options.ClaimsIssuer));
             }
 
-            var userName = FacebookHelper.GetUserName(payload);
-            if (!string.IsNullOrEmpty(userName))
-            {
-                identity.AddClaim(new Claim(ClaimsIdentity.DefaultNameClaimType, userName, ClaimValueTypes.String, Options.ClaimsIssuer));
-            }
-
-            var email = FacebookHelper.GetEmail(payload);
-            if (!string.IsNullOrEmpty(email))
-            {
-                identity.AddClaim(new Claim(ClaimTypes.Email, email, ClaimValueTypes.String, Options.ClaimsIssuer));
-            }
-
             var name = FacebookHelper.GetName(payload);
             if (!string.IsNullOrEmpty(name))
-            {
-                identity.AddClaim(new Claim("urn:facebook:name", name, ClaimValueTypes.String, Options.ClaimsIssuer));
-
-                // Many Facebook accounts do not set the UserName field.  Fall back to the Name field instead.
-                if (string.IsNullOrEmpty(userName))
-                {
-                    identity.AddClaim(new Claim(identity.NameClaimType, name, ClaimValueTypes.String, Options.ClaimsIssuer));
-                }
+            {           
+                identity.AddClaim(new Claim(ClaimTypes.Name, name, ClaimValueTypes.String, Options.ClaimsIssuer));
             }
 
             var link = FacebookHelper.GetLink(payload);

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
@@ -54,6 +54,18 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
                 identity.AddClaim(new Claim(ClaimTypes.Name, name, ClaimValueTypes.String, Options.ClaimsIssuer));
             }
 
+            var givenName = FacebookHelper.GetGivenName(payload);
+            if (!string.IsNullOrEmpty(givenName))
+            {
+                identity.AddClaim(new Claim(ClaimTypes.GivenName, givenName, ClaimValueTypes.String, Options.ClaimsIssuer));
+            }
+
+            var surname = FacebookHelper.GetFamilyName(payload);
+            if (!string.IsNullOrEmpty(surname))
+            {
+                identity.AddClaim(new Claim(ClaimTypes.Surname, surname, ClaimValueTypes.String, Options.ClaimsIssuer));
+            }
+
             var link = FacebookHelper.GetLink(payload);
             if (!string.IsNullOrEmpty(link))
             {

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHelper.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHelper.cs
@@ -51,20 +51,6 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
         }
 
         /// <summary>
-        /// Gets the Facebook username.
-        /// </summary>
-        public static string GetUserName(JObject user)
-        {
-            if (user == null)
-            {
-                throw new ArgumentNullException(nameof(user));
-            }
-
-            return user.Value<string>("username");
-        }
-
-
-        /// <summary>
         /// Gets the Facebook email.
         /// </summary>
         public static string GetEmail(JObject user)

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHelper.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHelper.cs
@@ -39,6 +39,32 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
         }
 
         /// <summary>
+        /// Gets the user's given name.
+        /// </summary>
+        public static string GetGivenName(JObject user)
+        {
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
+            return user.Value<string>("first_name");
+        }
+
+        /// <summary>
+        /// Gets the user's family name.
+        /// </summary>
+        public static string GetFamilyName(JObject user)
+        {
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
+            return user.Value<string>("last_name");
+        }
+
+        /// <summary>
         /// Gets the user's link.
         /// </summary>
         public static string GetLink(JObject user)

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookMiddleware.cs
@@ -75,6 +75,25 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Exception_OptionMustBeProvided, nameof(Options.AppSecret)));
             }
+
+            if (Options.Scope.Count == 0)
+            {
+                // Add default scopes.  These scopes are always permitted.
+                // TODO: Should we just add these by default when we create the Options?
+                Options.Scope.Add("public_profile");
+                Options.Scope.Add("email");
+            }
+
+            if (Options.Fields.Count == 0)
+            {
+                // Add default fields
+                // TODO: Should we just add these by default when we create the Options?
+                Options.Fields.Add("name");
+                Options.Fields.Add("first_name");
+                Options.Fields.Add("last_name");
+                Options.Fields.Add("link");
+                Options.Fields.Add("email");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
- Remove username field  from helper and handler as this is no longer returned by the Facebook API as of v 2.0 onwards.

see https://developers.facebook.com/docs/apps/changelog#v2_0_graph_api

- Add a set of default fields to the request if none are supplied.  This gives parity with Google.

This means we can simply use
```
    app.UseFacebookAuthentication(new FacebookOptions
            {
                AppId = "122334455666";
                AppSecret = "9876543";
            });
```

And be done.