### PR TITLE
Add core fields to Facebook

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
@@ -60,6 +60,18 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
                 identity.AddClaim(new Claim(ClaimTypes.Name, name, ClaimValueTypes.String, Options.ClaimsIssuer));
             }
 
+            var givenName = FacebookHelper.GetGivenName(payload);
+            if (!string.IsNullOrEmpty(givenName))
+            {
+                identity.AddClaim(new Claim(ClaimTypes.GivenName, givenName, ClaimValueTypes.String, Options.ClaimsIssuer));
+            }
+
+            var surname = FacebookHelper.GetFamilyName(payload);
+            if (!string.IsNullOrEmpty(surname))
+            {
+                identity.AddClaim(new Claim(ClaimTypes.Surname, surname, ClaimValueTypes.String, Options.ClaimsIssuer));
+            }
+
             var link = FacebookHelper.GetLink(payload);
             if (!string.IsNullOrEmpty(link))
             {

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Authentication;
 using Microsoft.AspNetCore.WebUtilities;
 using Newtonsoft.Json.Linq;
+using System.Linq;
 
 namespace Microsoft.AspNetCore.Authentication.Facebook
 {
@@ -31,7 +32,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             }
             if (Options.Fields.Count > 0)
             {
-                endpoint = QueryHelpers.AddQueryString(endpoint, "fields", string.Join(",", Options.Fields));
+                endpoint = QueryHelpers.AddQueryString(endpoint, "fields", string.Join(",", Options.Fields.Distinct()));
             }
 
             var response = await Backchannel.GetAsync(endpoint, Context.RequestAborted);

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
@@ -48,12 +48,6 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
                 identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, identifier, ClaimValueTypes.String, Options.ClaimsIssuer));
             }
 
-            var userName = FacebookHelper.GetUserName(payload);
-            if (!string.IsNullOrEmpty(userName))
-            {
-                identity.AddClaim(new Claim(ClaimsIdentity.DefaultNameClaimType, userName, ClaimValueTypes.String, Options.ClaimsIssuer));
-            }
-
             var email = FacebookHelper.GetEmail(payload);
             if (!string.IsNullOrEmpty(email))
             {
@@ -63,13 +57,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             var name = FacebookHelper.GetName(payload);
             if (!string.IsNullOrEmpty(name))
             {
-                identity.AddClaim(new Claim("urn:facebook:name", name, ClaimValueTypes.String, Options.ClaimsIssuer));
-
-                // Many Facebook accounts do not set the UserName field.  Fall back to the Name field instead.
-                if (string.IsNullOrEmpty(userName))
-                {
-                    identity.AddClaim(new Claim(identity.NameClaimType, name, ClaimValueTypes.String, Options.ClaimsIssuer));
-                }
+                identity.AddClaim(new Claim(ClaimTypes.Name, name, ClaimValueTypes.String, Options.ClaimsIssuer));
             }
 
             var link = FacebookHelper.GetLink(payload);

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
@@ -49,10 +49,70 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
                 identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, identifier, ClaimValueTypes.String, Options.ClaimsIssuer));
             }
 
+            var ageRangeMin = FacebookHelper.GetAgeRangeMin(payload);
+            if (!string.IsNullOrEmpty(ageRangeMin))
+            {
+                identity.AddClaim(new Claim("urn:facebook:age_range_min", ageRangeMin, ClaimValueTypes.String, Options.ClaimsIssuer));
+            }
+
+            var ageRangeMax = FacebookHelper.GetAgeRangeMax(payload);
+            if (!string.IsNullOrEmpty(ageRangeMax))
+            {
+                identity.AddClaim(new Claim("urn:facebook:age_range_max", ageRangeMax, ClaimValueTypes.String, Options.ClaimsIssuer));
+            }
+
+            var birthday = FacebookHelper.GetBirthday(payload);
+            if (!string.IsNullOrEmpty(birthday))
+            {
+                identity.AddClaim(new Claim(ClaimTypes.DateOfBirth, birthday, ClaimValueTypes.String, Options.ClaimsIssuer));
+            }
+
             var email = FacebookHelper.GetEmail(payload);
             if (!string.IsNullOrEmpty(email))
             {
                 identity.AddClaim(new Claim(ClaimTypes.Email, email, ClaimValueTypes.String, Options.ClaimsIssuer));
+            }
+
+            var firstName = FacebookHelper.GetFirstName(payload);
+            if (!string.IsNullOrEmpty(firstName))
+            {
+                identity.AddClaim(new Claim(ClaimTypes.GivenName, firstName, ClaimValueTypes.String, Options.ClaimsIssuer));
+            }
+
+            var gender = FacebookHelper.GetGender(payload);
+            if (!string.IsNullOrEmpty(gender))
+            {
+                identity.AddClaim(new Claim(ClaimTypes.Gender, gender, ClaimValueTypes.String, Options.ClaimsIssuer));
+            }
+
+            var lastName = FacebookHelper.GetLastName(payload);
+            if (!string.IsNullOrEmpty(lastName))
+            {
+                identity.AddClaim(new Claim(ClaimTypes.Surname, lastName, ClaimValueTypes.String, Options.ClaimsIssuer));
+            }
+
+            var link = FacebookHelper.GetLink(payload);
+            if (!string.IsNullOrEmpty(link))
+            {
+                identity.AddClaim(new Claim("urn:facebook:link", link, ClaimValueTypes.String, Options.ClaimsIssuer));
+            }
+
+            var location = FacebookHelper.GetLocation(payload);
+            if (!string.IsNullOrEmpty(location))
+            {
+                identity.AddClaim(new Claim(ClaimTypes.StateOrProvince, location, ClaimValueTypes.String, Options.ClaimsIssuer));
+            }
+
+            var locale = FacebookHelper.GetLocale(payload);
+            if (!string.IsNullOrEmpty(locale))
+            {
+                identity.AddClaim(new Claim(ClaimTypes.Locality, locale, ClaimValueTypes.String, Options.ClaimsIssuer));
+            }
+
+            var middleName = FacebookHelper.GetMiddleName(payload);
+            if (!string.IsNullOrEmpty(middleName))
+            {
+                identity.AddClaim(new Claim("urn:facebook:middle_name", middleName, ClaimValueTypes.String, Options.ClaimsIssuer));
             }
 
             var name = FacebookHelper.GetName(payload);
@@ -60,23 +120,11 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             {
                 identity.AddClaim(new Claim(ClaimTypes.Name, name, ClaimValueTypes.String, Options.ClaimsIssuer));
             }
-
-            var givenName = FacebookHelper.GetGivenName(payload);
-            if (!string.IsNullOrEmpty(givenName))
+ 
+            var timeZone = FacebookHelper.GetTimeZone(payload);
+            if (!string.IsNullOrEmpty(timeZone))
             {
-                identity.AddClaim(new Claim(ClaimTypes.GivenName, givenName, ClaimValueTypes.String, Options.ClaimsIssuer));
-            }
-
-            var surname = FacebookHelper.GetFamilyName(payload);
-            if (!string.IsNullOrEmpty(surname))
-            {
-                identity.AddClaim(new Claim(ClaimTypes.Surname, surname, ClaimValueTypes.String, Options.ClaimsIssuer));
-            }
-
-            var link = FacebookHelper.GetLink(payload);
-            if (!string.IsNullOrEmpty(link))
-            {
-                identity.AddClaim(new Claim("urn:facebook:link", link, ClaimValueTypes.String, Options.ClaimsIssuer));
+                identity.AddClaim(new Claim("urn:facebook:timezone", timeZone, ClaimValueTypes.String, Options.ClaimsIssuer));
             }
 
             await Options.Events.CreatingTicket(context);

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
@@ -12,7 +12,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Authentication;
 using Microsoft.AspNetCore.WebUtilities;
 using Newtonsoft.Json.Linq;
-using System.Linq;
 
 namespace Microsoft.AspNetCore.Authentication.Facebook
 {
@@ -32,7 +31,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             }
             if (Options.Fields.Count > 0)
             {
-                endpoint = QueryHelpers.AddQueryString(endpoint, "fields", string.Join(",", Options.Fields.Distinct()));
+                endpoint = QueryHelpers.AddQueryString(endpoint, "fields", string.Join(",", Options.Fields));
             }
 
             var response = await Backchannel.GetAsync(endpoint, Context.RequestAborted);
@@ -100,7 +99,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             var location = FacebookHelper.GetLocation(payload);
             if (!string.IsNullOrEmpty(location))
             {
-                identity.AddClaim(new Claim(ClaimTypes.StateOrProvince, location, ClaimValueTypes.String, Options.ClaimsIssuer));
+                identity.AddClaim(new Claim("urn:facebook:location", location, ClaimValueTypes.String, Options.ClaimsIssuer));
             }
 
             var locale = FacebookHelper.GetLocale(payload);

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHelper.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHelper.cs
@@ -51,20 +51,6 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
         }
 
         /// <summary>
-        /// Gets the Facebook username.
-        /// </summary>
-        public static string GetUserName(JObject user)
-        {
-            if (user == null)
-            {
-                throw new ArgumentNullException(nameof(user));
-            }
-
-            return user.Value<string>("username");
-        }
-
-
-        /// <summary>
         /// Gets the Facebook email.
         /// </summary>
         public static string GetEmail(JObject user)

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHelper.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHelper.cs
@@ -37,6 +37,32 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
 
             return user.Value<string>("name");
         }
+        
+        /// <summary>
+        /// Gets the user's given name.
+        /// </summary>
+        public static string GetGivenName(JObject user)
+        {
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
+            return user.Value<string>("first_name");
+        }
+
+        /// <summary>
+        /// Gets the user's family name.
+        /// </summary>
+        public static string GetFamilyName(JObject user)
+        {
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
+            return user.Value<string>("last_name");
+        }
 
         /// <summary>
         /// Gets the user's link.

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHelper.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHelper.cs
@@ -26,22 +26,59 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
         }
 
         /// <summary>
-        /// Gets the user's name.
+        /// Gets the user's min age.
         /// </summary>
-        public static string GetName(JObject user)
+        public static string GetAgeRangeMin(JObject user)
+        {
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+            return TryGetValue(user, "age_range", "min");
+        }
+
+        /// <summary>
+        /// Gets the user's max age.
+        /// </summary>
+        public static string GetAgeRangeMax(JObject user)
         {
             if (user == null)
             {
                 throw new ArgumentNullException(nameof(user));
             }
 
-            return user.Value<string>("name");
+            return TryGetValue(user, "age_range", "max");
         }
-        
+
         /// <summary>
-        /// Gets the user's given name.
+        /// Gets the user's birthday.
         /// </summary>
-        public static string GetGivenName(JObject user)
+        public static string GetBirthday(JObject user)
+        {
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+            return user.Value<string>("birthday");
+        }
+
+        /// <summary>
+        /// Gets the Facebook email.
+        /// </summary>
+        public static string GetEmail(JObject user)
+        {
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
+            return user.Value<string>("email");
+        }
+
+        /// <summary>
+        /// Gets the user's first name.
+        /// </summary>
+        public static string GetFirstName(JObject user)
         {
             if (user == null)
             {
@@ -52,9 +89,21 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
         }
 
         /// <summary>
+        /// Gets the user's gender.
+        /// </summary>
+        public static string GetGender(JObject user)
+        {
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+            return user.Value<string>("gender");
+        }
+
+        /// <summary>
         /// Gets the user's family name.
         /// </summary>
-        public static string GetFamilyName(JObject user)
+        public static string GetLastName(JObject user)
         {
             if (user == null)
             {
@@ -77,16 +126,81 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
         }
 
         /// <summary>
-        /// Gets the Facebook email.
+        /// Gets the user's location.
         /// </summary>
-        public static string GetEmail(JObject user)
+        public static string GetLocation(JObject user)
+        {
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+            return TryGetValue(user, "location", "name");
+        }
+
+        /// <summary>
+        /// Gets the user's locale.
+        /// </summary>
+        public static string GetLocale(JObject user)
+        {
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+            return user.Value<string>("locale");
+        }
+
+        /// <summary>
+        /// Gets the user's middle name.
+        /// </summary>
+        public static string GetMiddleName(JObject user)
         {
             if (user == null)
             {
                 throw new ArgumentNullException(nameof(user));
             }
 
-            return user.Value<string>("email");
+            return user.Value<string>("middle_name");
         }
+
+        /// <summary>
+        /// Gets the user's name.
+        /// </summary>
+        public static string GetName(JObject user)
+        {
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
+            return user.Value<string>("name");
+        }
+
+        /// <summary>
+        /// Gets the user's timezone.
+        /// </summary>
+        public static string GetTimeZone(JObject user)
+        {
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+            return user.Value<string>("timezone");
+        }
+
+        // Get the given subProperty from a property.
+        private static string TryGetValue(JObject user, string propertyName, string subProperty)
+        {
+            JToken value;
+            if (user.TryGetValue(propertyName, out value))
+            {
+                var subObject = JObject.Parse(value.ToString());
+                if (subObject != null && subObject.TryGetValue(subProperty, out value))
+                {
+                    return value.ToString();
+                }
+            }
+            return null;
+        }
+
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookMiddleware.cs
@@ -76,25 +76,6 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Exception_OptionMustBeProvided, nameof(Options.AppSecret)));
             }
-
-            if (Options.Scope.Count == 0)
-            {
-                // Add default scopes.  These scopes are always permitted.
-                // TODO: Should we just add these by default when we create the Options?
-                Options.Scope.Add("public_profile");
-                Options.Scope.Add("email");
-            }
-
-            if (Options.Fields.Count == 0)
-            {
-                // Add default fields
-                // TODO: Should we just add these by default when we create the Options?
-                Options.Fields.Add("name");
-                Options.Fields.Add("first_name");
-                Options.Fields.Add("last_name");
-                Options.Fields.Add("link");
-                Options.Fields.Add("email");
-            }
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookMiddleware.cs
@@ -71,9 +71,29 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Exception_OptionMustBeProvided, nameof(Options.AppId)));
             }
+
             if (string.IsNullOrEmpty(Options.AppSecret))
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Exception_OptionMustBeProvided, nameof(Options.AppSecret)));
+            }
+
+            if (Options.Scope.Count == 0)
+            {
+                // Add default scopes.  These scopes are always permitted.
+                // TODO: Should we just add these by default when we create the Options?
+                Options.Scope.Add("public_profile");
+                Options.Scope.Add("email");
+            }
+
+            if (Options.Fields.Count == 0)
+            {
+                // Add default fields
+                // TODO: Should we just add these by default when we create the Options?
+                Options.Fields.Add("name");
+                Options.Fields.Add("first_name");
+                Options.Fields.Add("last_name");
+                Options.Fields.Add("link");
+                Options.Fields.Add("email");
             }
         }
 

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookOptions.cs
@@ -24,7 +24,13 @@ namespace Microsoft.AspNetCore.Builder
             AuthorizationEndpoint = FacebookDefaults.AuthorizationEndpoint;
             TokenEndpoint = FacebookDefaults.TokenEndpoint;
             UserInformationEndpoint = FacebookDefaults.UserInformationEndpoint;
-            Fields = new List<string>();
+            Scope.Add("public_profile");
+            Scope.Add("email");
+            Fields.Add("name");
+            Fields.Add("first_name");
+            Fields.Add("last_name");
+            Fields.Add("link");
+            Fields.Add("email");
         }
 
         // Facebook uses a non-standard term for this field.
@@ -57,6 +63,6 @@ namespace Microsoft.AspNetCore.Builder
         /// The list of fields to retrieve from the UserInformationEndpoint.
         /// https://developers.facebook.com/docs/graph-api/reference/user
         /// </summary>
-        public IList<string> Fields { get; }
+        public IList<string> Fields { get; } = new List<string>();
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookOptions.cs
@@ -60,6 +60,6 @@ namespace Microsoft.AspNetCore.Builder
         /// The list of fields to retrieve from the UserInformationEndpoint.
         /// https://developers.facebook.com/docs/graph-api/reference/user
         /// </summary>
-        public IList<string> Fields { get; } = new List<string>();
+        public ICollection<string> Fields { get; } = new HashSet<string>();
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookOptions.cs
@@ -27,9 +27,6 @@ namespace Microsoft.AspNetCore.Builder
             Scope.Add("public_profile");
             Scope.Add("email");
             Fields.Add("name");
-            Fields.Add("first_name");
-            Fields.Add("last_name");
-            Fields.Add("link");
             Fields.Add("email");
         }
 


### PR DESCRIPTION
- Remove username field  from helper and handler.

This field is no longer returned by the Facebook API as of v 2.0 onwards.
see https://developers.facebook.com/docs/apps/changelog#v2_0_graph_api

- Add a set of default fields to the request if none are supplied. 

This gives parity with Microsoft.AspNetCore.Authentication.Google.
It allows the most common scenario with minimal configuration which will greatly benefit new users.
The change also has no impact on existing code.

Using the following minimal configuration
```
    app.UseFacebookAuthentication(new FacebookOptions
            {
                AppId = "122334455666";
                AppSecret = "9876543";
            });
```

Gives the following results from the Social Sample
```
Hello Joe Blogs
http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier: 999999999999
http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress: joe@blogs.co.uk
http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name: Joe Blogs
http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname: Joe
http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname: Blogs
urn:facebook:link: https://www.facebook.com/app_scoped_user_id/1234567678/
Logout
```

cc @Tratcher @HaoK 
