### PR TITLE
Standardize the pattern for scope defaults.

### DIFF
--- a/samples/SocialSample/Startup.cs
+++ b/samples/SocialSample/Startup.cs
@@ -133,18 +133,18 @@ namespace CookieSample
             The MicrosoftAccount service has restrictions that prevent the use of http://localhost:54540/ for test applications.
             As such, here is how to change this sample to uses http://mssecsample.localhost.this:54540/ instead.
 
-            Edit the Project.json file and replace http://localhost:54540/ with http://mssecsample.localhost.this:54540/.
+            Edit the hosting.json file and add "server.urls": "http://mssecsample.localhost.this:54540/".
 
             From an admin command console first enter:
              notepad C:\Windows\System32\drivers\etc\hosts
             and add this to the file, save, and exit (and reboot?):
              127.0.0.1 MsSecSample.localhost.this
 
-            Then you can choose to run the app as admin (see below) or add the following ACL as admin:
+            [WebListener] Then you can choose to run the app as admin (see below) or add the following ACL as admin:
              netsh http add urlacl url=http://mssecsample.localhost.this:54540/ user=[domain\user]
 
             The sample app can then be run via:
-             dnx . web
+             dnx web
             */
             app.UseOAuthAuthentication(new OAuthOptions
             {

--- a/src/Microsoft.AspNetCore.Authentication.Google/GoogleMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Google/GoogleMiddleware.cs
@@ -67,16 +67,6 @@ namespace Microsoft.AspNetCore.Authentication.Google
             {
                 throw new ArgumentNullException(nameof(options));
             }
-
-            if (Options.Scope.Count == 0)
-            {
-                // Google OAuth 2.0 asks for non-empty scope. If user didn't set it, set default scope to 
-                // "openid profile email" to get basic user information.
-                // TODO: Should we just add these by default when we create the Options?
-                Options.Scope.Add("openid");
-                Options.Scope.Add("profile");
-                Options.Scope.Add("email");
-            }
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Authentication.Google/GoogleOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Google/GoogleOptions.cs
@@ -22,6 +22,9 @@ namespace Microsoft.AspNetCore.Builder
             AuthorizationEndpoint = GoogleDefaults.AuthorizationEndpoint;
             TokenEndpoint = GoogleDefaults.TokenEndpoint;
             UserInformationEndpoint = GoogleDefaults.UserInformationEndpoint;
+            Scope.Add("openid");
+            Scope.Add("profile");
+            Scope.Add("email");
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountMiddleware.cs
@@ -65,13 +65,6 @@ namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
             {
                 throw new ArgumentNullException(nameof(options));
             }
-
-            if (Options.Scope.Count == 0)
-            {
-                // LiveID requires a scope string, so if the user didn't set one we go for the least possible.
-                // TODO: Should we just add these by default when we create the Options?
-                Options.Scope.Add("wl.basic");
-            }
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountOptions.cs
@@ -22,6 +22,7 @@ namespace Microsoft.AspNetCore.Builder
             AuthorizationEndpoint = MicrosoftAccountDefaults.AuthorizationEndpoint;
             TokenEndpoint = MicrosoftAccountDefaults.TokenEndpoint;
             UserInformationEndpoint = MicrosoftAccountDefaults.UserInformationEndpoint;
+            Scope.Add("wl.basic");
         }
     }
 }


### PR DESCRIPTION
#614 @PinpointTownes @brockallen @HaoK @Eilon 

Google and MSA require scopes by default so we provide a few. However they also send an ok error message if you clear the default scopes so we're not checking for missing scopes in the constructor.

OIDC already works like this.