### PR TITLE
Ensure scope has no duplicates

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthOptions.cs
@@ -56,9 +56,9 @@ namespace Microsoft.AspNetCore.Builder
         }
 
         /// <summary>
-        /// A list of permissions to request.
+        /// Gets the list of permissions to request.
         /// </summary>
-        public IList<string> Scope { get; } = new List<string>();
+        public ICollection<string> Scope { get; } = new HashSet<string>();
 
         /// <summary>
         /// Gets or sets the type used to secure data handled by the middleware.

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectOptions.cs
@@ -53,6 +53,8 @@ namespace Microsoft.AspNetCore.Builder
             DisplayName = OpenIdConnectDefaults.Caption;
             CallbackPath = new PathString("/signin-oidc");
             Events = new OpenIdConnectEvents();
+            Scope.Add("openid");
+            Scope.Add("profile");
         }
 
         /// <summary>
@@ -155,7 +157,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// Gets the list of permissions to request.
         /// </summary>
-        public IList<string> Scope { get; } = new List<string> { "openid", "profile" };
+        public ICollection<string> Scope { get; } = new HashSet<string>();
 
         /// <summary>
         /// Gets or sets the type used to secure data handled by the middleware.


### PR DESCRIPTION
Make sure scope list only has unique elements.

- Change  OAuthOptions to use Hashset for Scope list
- Change OpenIDConnectOptions to use HashSet for scope list
- Change OpenIDConnectOptions  to new options pattern for scope defaults

No known APIs break with duplicate scope values.
However Facebook breaks for duplicate field values so it seems a good idea to guard against duplicate scope values as well  using the same methodology.
It is quite possible that a future API may not be so accommodating of duplicate values.

PS I cant get tests running but tested used social sample and OpenIDConnect sample (Google authority)

