### PR TITLE
Replace SaveTokensAsClaims with ITokenStore

### DIFF
--- a/samples/SocialSample/MemoryTokenStore.cs
+++ b/samples/SocialSample/MemoryTokenStore.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace SocialSample
+{
+    public class MemoryTokenStore : ITokenStore
+    {
+        private IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
+
+        public string Get(string key)
+        {
+            return _cache.Get<string>(key);
+        }
+
+        public void Set(string key, string value)
+        {
+            _cache.Set(key, value);
+        }
+    }
+}

--- a/samples/SocialSample/project.json
+++ b/samples/SocialSample/project.json
@@ -9,6 +9,7 @@
     "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.Extensions.Configuration.UserSecrets": "1.0.0-*",
+    "Microsoft.Extensions.Caching.Memory": "1.0.0-*",
     "Microsoft.Extensions.Logging.Console": "1.0.0-*",
     "Microsoft.NETCore.Platforms": "1.0.1-*"
   },

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookMiddleware.cs
@@ -22,20 +22,21 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
         /// Initializes a new <see cref="FacebookMiddleware"/>.
         /// </summary>
         /// <param name="next">The next middleware in the HTTP pipeline to invoke.</param>
+        /// <param name="serviceProvider"></param>
         /// <param name="dataProtectionProvider"></param>
         /// <param name="loggerFactory"></param>
         /// <param name="encoder"></param>
         /// <param name="sharedOptions"></param>
         /// <param name="options">Configuration options for the middleware.</param>
-        /// <param name="configureOptions"></param>
         public FacebookMiddleware(
             RequestDelegate next,
+            IServiceProvider serviceProvider,
             IDataProtectionProvider dataProtectionProvider,
             ILoggerFactory loggerFactory,
             UrlEncoder encoder,
             IOptions<SharedAuthenticationOptions> sharedOptions,
             IOptions<FacebookOptions> options)
-            : base(next, dataProtectionProvider, loggerFactory, encoder, sharedOptions, options)
+            : base(next, serviceProvider, dataProtectionProvider, loggerFactory, encoder, sharedOptions, options)
         {
             if (next == null)
             {

--- a/src/Microsoft.AspNetCore.Authentication.Google/GoogleMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Google/GoogleMiddleware.cs
@@ -23,20 +23,21 @@ namespace Microsoft.AspNetCore.Authentication.Google
         /// Initializes a new <see cref="GoogleMiddleware"/>.
         /// </summary>
         /// <param name="next">The next middleware in the HTTP pipeline to invoke.</param>
+        /// <param name="serviceProvider"></param>
         /// <param name="dataProtectionProvider"></param>
         /// <param name="loggerFactory"></param>
         /// <param name="encoder"></param>
         /// <param name="sharedOptions"></param>
         /// <param name="options">Configuration options for the middleware.</param>
-        /// <param name="configureOptions"></param>
         public GoogleMiddleware(
             RequestDelegate next,
+            IServiceProvider serviceProvider,
             IDataProtectionProvider dataProtectionProvider,
             ILoggerFactory loggerFactory,
             UrlEncoder encoder,
             IOptions<SharedAuthenticationOptions> sharedOptions,
             IOptions<GoogleOptions> options)
-            : base(next, dataProtectionProvider, loggerFactory, encoder, sharedOptions, options)
+            : base(next, serviceProvider, dataProtectionProvider, loggerFactory, encoder, sharedOptions, options)
         {
             if (next == null)
             {

--- a/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountMiddleware.cs
@@ -21,20 +21,21 @@ namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
         /// Initializes a new <see cref="MicrosoftAccountMiddleware"/>.
         /// </summary>
         /// <param name="next">The next middleware in the HTTP pipeline to invoke.</param>
+        /// <param name="serviceProvider"></param>
         /// <param name="dataProtectionProvider"></param>
         /// <param name="loggerFactory"></param>
         /// <param name="encoder"></param>
         /// <param name="sharedOptions"></param>
         /// <param name="options">Configuration options for the middleware.</param>
-        /// <param name="configureOptions"></param>
         public MicrosoftAccountMiddleware(
             RequestDelegate next,
+            IServiceProvider serviceProvider,
             IDataProtectionProvider dataProtectionProvider,
             ILoggerFactory loggerFactory,
             UrlEncoder encoder,
             IOptions<SharedAuthenticationOptions> sharedOptions,
             IOptions<MicrosoftAccountOptions> options)
-            : base(next, dataProtectionProvider, loggerFactory, encoder, sharedOptions, options)
+            : base(next, serviceProvider, dataProtectionProvider, loggerFactory, encoder, sharedOptions, options)
         {
             if (next == null)
             {

--- a/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthMiddleware.cs
@@ -9,6 +9,7 @@ using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -24,11 +25,15 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
         /// Initializes a new <see cref="OAuthAuthenticationMiddleware"/>.
         /// </summary>
         /// <param name="next">The next middleware in the HTTP pipeline to invoke.</param>
+        /// <param name="serviceProvider"></param>
         /// <param name="dataProtectionProvider"></param>
         /// <param name="loggerFactory"></param>
+        /// <param name="encoder"></param>
+        /// <param name="sharedOptions"></param>
         /// <param name="options">Configuration options for the middleware.</param>
         public OAuthMiddleware(
             RequestDelegate next,
+            IServiceProvider serviceProvider,
             IDataProtectionProvider dataProtectionProvider,
             ILoggerFactory loggerFactory,
             UrlEncoder encoder,
@@ -39,6 +44,11 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
             if (next == null)
             {
                 throw new ArgumentNullException(nameof(next));
+            }
+
+            if (serviceProvider == null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider));
             }
 
             if (dataProtectionProvider == null)
@@ -121,6 +131,12 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
             if (string.IsNullOrEmpty(Options.SignInScheme))
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Exception_OptionMustBeProvided, nameof(Options.SignInScheme)));
+            }
+
+            if (Options.TokenStore == null)
+            {
+                // Optional
+                Options.TokenStore = serviceProvider.GetService<ITokenStore>();
             }
         }
 

--- a/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterHandler.cs
@@ -88,10 +88,10 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
             },
             Options.ClaimsIssuer);
 
-            if (Options.SaveTokensAsClaims)
+            if (Options.TokenStore != null)
             {
-                identity.AddClaim(new Claim("access_token", accessToken.Token, ClaimValueTypes.String, Options.ClaimsIssuer));
-                identity.AddClaim(new Claim("access_token_secret", accessToken.TokenSecret, ClaimValueTypes.String, Options.ClaimsIssuer));
+                Options.TokenStore.Set(Options.AuthenticationScheme, accessToken.UserId, "access_token", accessToken.Token);
+                Options.TokenStore.Set(Options.AuthenticationScheme, accessToken.UserId, "access_token_secret", accessToken.TokenSecret);
             }
 
             return AuthenticateResult.Success(await CreateTicketAsync(identity, properties, accessToken));

--- a/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterMiddleware.cs
@@ -9,6 +9,7 @@ using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -26,14 +27,15 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
         /// Initializes a <see cref="TwitterMiddleware"/>
         /// </summary>
         /// <param name="next">The next middleware in the HTTP pipeline to invoke</param>
+        /// <param name="serviceProvider"></param>
         /// <param name="dataProtectionProvider"></param>
         /// <param name="loggerFactory"></param>
         /// <param name="encoder"></param>
         /// <param name="sharedOptions"></param>
         /// <param name="options">Configuration options for the middleware</param>
-        /// <param name="configureOptions"></param>
         public TwitterMiddleware(
             RequestDelegate next,
+            IServiceProvider serviceProvider,
             IDataProtectionProvider dataProtectionProvider,
             ILoggerFactory loggerFactory,
             UrlEncoder encoder,
@@ -44,6 +46,11 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
             if (next == null)
             {
                 throw new ArgumentNullException(nameof(next));
+            }
+
+            if (serviceProvider == null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider));
             }
 
             if (dataProtectionProvider == null)
@@ -104,6 +111,12 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
             if (string.IsNullOrEmpty(Options.SignInScheme))
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Exception_OptionMustBeProvided, "SignInScheme"));
+            }
+
+            if (Options.TokenStore == null)
+            {
+                // Optional
+                Options.TokenStore = serviceProvider.GetService<ITokenStore>();
             }
 
             _httpClient = new HttpClient(Options.BackchannelHttpHandler ?? new HttpClientHandler());

--- a/src/Microsoft.AspNetCore.Authentication/ITokenStore.cs
+++ b/src/Microsoft.AspNetCore.Authentication/ITokenStore.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Authentication
+{
+    public interface ITokenStore
+    {
+        string Get(string key);
+
+        void Set(string key, string value);
+    }
+}

--- a/src/Microsoft.AspNetCore.Authentication/RemoteAuthenticationOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication/RemoteAuthenticationOptions.cs
@@ -49,17 +49,15 @@ namespace Microsoft.AspNetCore.Builder
         }
 
         /// <summary>
-        /// Defines whether access and refresh tokens should be stored in the
-        /// <see cref="ClaimsPrincipal"/> after a successful authorization with the remote provider.
-        /// This property is set to <c>false</c> by default to reduce
-        /// the size of the final authentication cookie.
-        /// </summary>
-        public bool SaveTokensAsClaims { get; set; }
-
-        /// <summary>
         /// Gets or sets the time limit for completing the authentication flow (15 minutes by default).
         /// </summary>
         public TimeSpan RemoteAuthenticationTimeout { get; set; } = TimeSpan.FromMinutes(15);
+
+        /// <summary>
+        /// An optional location to store access and refresh tokens after a successful authorization with the remote provider.
+        /// This can also be provided via dependency injection.
+        /// </summary>
+        public ITokenStore TokenStore { get; set; }
 
         public IRemoteAuthenticationEvents Events = new RemoteAuthenticationEvents();
     }

--- a/src/Microsoft.AspNetCore.Authentication/TokenExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication/TokenExtensions.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Authentication
+{
+    public static class TokenExtensions
+    {
+        public static string Get(this ITokenStore store, string authenticationScheme, string userId, string tokenType)
+        {
+            return store?.Get($"{authenticationScheme};{userId};{tokenType}");
+        }
+
+        public static void Set(this ITokenStore store, string authenticationScheme, string userId, string tokenType, string value)
+        {
+            if (store == null)
+            {
+                throw new ArgumentNullException(nameof(store));
+            }
+            if (string.IsNullOrEmpty(authenticationScheme))
+            {
+                throw new ArgumentException("", nameof(authenticationScheme));
+            }
+            if (string.IsNullOrEmpty(userId))
+            {
+                throw new ArgumentException("", nameof(userId));
+            }
+            if (string.IsNullOrEmpty(tokenType))
+            {
+                throw new ArgumentException("", nameof(tokenType));
+            }
+            store.Set($"{authenticationScheme};{userId};{tokenType}", value);
+        }
+
+        public static string Get(this ITokenStore store, string authenticationScheme, ClaimsPrincipal user, string tokenType)
+        {
+            var userId = user?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (string.IsNullOrEmpty(userId))
+            {
+                return null;
+            }
+            return store.Get(authenticationScheme, userId, tokenType);
+        }
+
+        public static void Set(this ITokenStore store, string authenticationScheme, ClaimsPrincipal user, string tokenType, string value)
+        {
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+            var claim = user.FindFirst(ClaimTypes.NameIdentifier);
+            if (claim == null)
+            {
+                throw new ArgumentException("The user does not have the expected claim: " + ClaimTypes.NameIdentifier, nameof(user));
+            }
+            var userId = claim.Value;
+            if (string.IsNullOrEmpty(userId))
+            {
+                throw new ArgumentException("The id claim does not have a value.", nameof(user));
+            }
+            store.Set(authenticationScheme, userId, tokenType, value);
+        }
+
+        public static string GetToken(this AuthenticationManager authManager, string authenticationScheme, string tokenType)
+        {
+            var store = authManager.HttpContext.RequestServices.GetService<ITokenStore>();
+            return store.Get(authenticationScheme, authManager.HttpContext.User, tokenType);
+        }
+
+        public static void SetToken(this AuthenticationManager authManager, string authenticationScheme, string tokenType, string value)
+        {
+            var store = authManager.HttpContext.RequestServices.GetRequiredService<ITokenStore>();
+            store.Set(authenticationScheme, authManager.HttpContext.User, tokenType, value);
+        }
+
+        public static string GetAccessToken(this AuthenticationManager authManager, string authenticationScheme)
+        {
+            return authManager.GetToken(authenticationScheme, "access_token");
+        }
+
+        public static void SetAccessToken(this AuthenticationManager authManager, string authenticationScheme, string value)
+        {
+            authManager.SetToken(authenticationScheme, "access_token", value);
+        }
+
+        public static string GetRefreshToken(this AuthenticationManager authManager, string authenticationScheme)
+        {
+            return authManager.GetToken(authenticationScheme, "refresh_token");
+        }
+
+        public static DateTimeOffset? GetExpiresAt(this AuthenticationManager authManager, string authenticationScheme)
+        {
+            DateTimeOffset result;
+            return DateTimeOffset.TryParse(authManager.GetToken(authenticationScheme, "expires_at"),
+                CultureInfo.InvariantCulture, DateTimeStyles.None, out result) ? result : (DateTimeOffset?)null;
+        }
+    }
+}


### PR DESCRIPTION
#639 
@PinpointTownes @leastprivilege @HaoK @Eilon @vibronet @brentschmaltz 
Here is an initial design on how we might replace SaveTokensAsClaims with something more versatile but not more difficult to use.

Design points:
- Tokens are stored and retrieved per provider, per user.
- Tokens must be updateable, e.g. for when you use a refresh token to update the access token.
- Tokens should be available even with indirection in place. E.g. looking up a local user's associated google tokens.
- We do NOT manage lifetimes, refresh, etc.. The only sure way to know if a token is expired is to try to use it. If it fails you must attempt to refresh it or re-sign-in to get new tokens.
- The store is shared via DI across the various auth middleware and the user code.
- Sugar for common scenarios.

Unaddressed so far:
- JwtBearer, though it could use the same model.
- What store implementations should we provide? At least IMemoryCache, IDistributedCache, and something for Identity.
- How this interfaces with ADAL's storage.