### PR TITLE
Remove usage of IOptions

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAppBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAppBuilderExtensions.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Builder
                 throw new ArgumentNullException(nameof(options));
             }
 
-            return app.UseMiddleware<CookieAuthenticationMiddleware>(Options.Create(options));
+            return app.UseMiddleware<CookieAuthenticationMiddleware>(options);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationMiddleware.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
             IDataProtectionProvider dataProtectionProvider,
             ILoggerFactory loggerFactory,
             UrlEncoder urlEncoder,
-            IOptions<CookieAuthenticationOptions> options)
+            CookieAuthenticationOptions options)
             : base(next, options, loggerFactory, urlEncoder)
         {
             if (dataProtectionProvider == null)

--- a/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Authentication;
@@ -15,15 +16,23 @@ namespace Microsoft.AspNetCore.Builder
     /// <summary>
     /// Contains the options used by the CookiesAuthenticationMiddleware
     /// </summary>
-    public class CookieAuthenticationOptions : AuthenticationOptions, IOptions<CookieAuthenticationOptions>
+    public class CookieAuthenticationOptions : AuthenticationOptions
     {
         private string _cookieName;
 
         /// <summary>
         /// Create an instance of the options initialized with the default values
         /// </summary>
-        public CookieAuthenticationOptions()
+        public CookieAuthenticationOptions(IEnumerable<IConfigureOptions<CookieAuthenticationOptions>> configureOptions = null)
         {
+            if (configureOptions != null)
+            {
+                foreach (var configure in configureOptions)
+                {
+                    configure.Configure(this);
+                }
+            }
+
             AuthenticationScheme = CookieAuthenticationDefaults.AuthenticationScheme;
             AutomaticAuthenticate = true;
             ReturnUrlParameter = CookieAuthenticationDefaults.ReturnUrlParameter;
@@ -160,13 +169,5 @@ namespace Microsoft.AspNetCore.Builder
         /// to the client. This can be used to mitigate potential problems with very large identities.
         /// </summary>
         public ITicketStore SessionStore { get; set; }
-
-        CookieAuthenticationOptions IOptions<CookieAuthenticationOptions>.Value
-        {
-            get
-            {
-                return this;
-            }
-        }
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookMiddleware.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Authentication.Facebook
 {
@@ -33,8 +32,8 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             IDataProtectionProvider dataProtectionProvider,
             ILoggerFactory loggerFactory,
             UrlEncoder encoder,
-            IOptions<SharedAuthenticationOptions> sharedOptions,
-            IOptions<FacebookOptions> options)
+            SharedAuthenticationOptions sharedOptions,
+            FacebookOptions options)
             : base(next, dataProtectionProvider, loggerFactory, encoder, sharedOptions, options)
         {
             if (next == null)

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookOptions.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Authentication.Facebook;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Builder
 {
@@ -15,8 +16,16 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// Initializes a new <see cref="FacebookOptions"/>.
         /// </summary>
-        public FacebookOptions()
+        public FacebookOptions(IEnumerable<IConfigureOptions<FacebookOptions>> configureOptions = null)
         {
+            if (configureOptions != null)
+            {
+                foreach (var configure in configureOptions)
+                {
+                    configure.Configure(this);
+                }
+            }
+
             AuthenticationScheme = FacebookDefaults.AuthenticationScheme;
             DisplayName = AuthenticationScheme;
             CallbackPath = new PathString("/signin-facebook");

--- a/src/Microsoft.AspNetCore.Authentication.Google/GoogleMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Google/GoogleMiddleware.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Authentication.Google
 {
@@ -34,8 +33,8 @@ namespace Microsoft.AspNetCore.Authentication.Google
             IDataProtectionProvider dataProtectionProvider,
             ILoggerFactory loggerFactory,
             UrlEncoder encoder,
-            IOptions<SharedAuthenticationOptions> sharedOptions,
-            IOptions<GoogleOptions> options)
+            SharedAuthenticationOptions sharedOptions,
+            GoogleOptions options)
             : base(next, dataProtectionProvider, loggerFactory, encoder, sharedOptions, options)
         {
             if (next == null)

--- a/src/Microsoft.AspNetCore.Authentication.Google/GoogleOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Google/GoogleOptions.cs
@@ -1,8 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Authentication.Google;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Builder
 {
@@ -14,8 +16,16 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// Initializes a new <see cref="GoogleOptions"/>.
         /// </summary>
-        public GoogleOptions()
+        public GoogleOptions(IEnumerable<IConfigureOptions<GoogleOptions>> configureOptions = null)
         {
+            if (configureOptions != null)
+            {
+                foreach (var configure in configureOptions)
+                {
+                    configure.Configure(this);
+                }
+            }
+
             AuthenticationScheme = GoogleDefaults.AuthenticationScheme;
             DisplayName = AuthenticationScheme;
             CallbackPath = new PathString("/signin-google");

--- a/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerMiddleware.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
             RequestDelegate next,
             ILoggerFactory loggerFactory,
             UrlEncoder encoder,
-            IOptions<JwtBearerOptions> options)
+            JwtBearerOptions options)
             : base(next, options, loggerFactory, encoder)
         {
             if (next == null)

--- a/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerOptions.cs
@@ -8,6 +8,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
@@ -22,8 +23,15 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// Creates an instance of bearer authentication options with default values.
         /// </summary>
-        public JwtBearerOptions() : base()
+        public JwtBearerOptions(IEnumerable<IConfigureOptions<JwtBearerOptions>> configureOptions = null)
         {
+            if (configureOptions != null)
+            {
+                foreach (var configure in configureOptions)
+                {
+                    configure.Configure(this);
+                }
+            }
             AuthenticationScheme = JwtBearerDefaults.AuthenticationScheme;
         }
 

--- a/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountMiddleware.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
 {
@@ -32,8 +31,8 @@ namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
             IDataProtectionProvider dataProtectionProvider,
             ILoggerFactory loggerFactory,
             UrlEncoder encoder,
-            IOptions<SharedAuthenticationOptions> sharedOptions,
-            IOptions<MicrosoftAccountOptions> options)
+            SharedAuthenticationOptions sharedOptions,
+            MicrosoftAccountOptions options)
             : base(next, dataProtectionProvider, loggerFactory, encoder, sharedOptions, options)
         {
             if (next == null)

--- a/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountOptions.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Authentication.MicrosoftAccount;
+using Microsoft.Extensions.Options;
+using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Builder
 {
@@ -14,8 +16,16 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// Initializes a new <see cref="MicrosoftAccountOptions"/>.
         /// </summary>
-        public MicrosoftAccountOptions()
+        public MicrosoftAccountOptions(IEnumerable<IConfigureOptions<MicrosoftAccountOptions>> configureOptions = null)
         {
+            if (configureOptions != null)
+            {
+                foreach (var configure in configureOptions)
+                {
+                    configure.Configure(this);
+                }
+            }
+
             AuthenticationScheme = MicrosoftAccountDefaults.AuthenticationScheme;
             DisplayName = AuthenticationScheme;
             CallbackPath = new PathString("/signin-microsoft");

--- a/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthMiddleware.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Authentication.OAuth
 {
@@ -32,8 +31,8 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
             IDataProtectionProvider dataProtectionProvider,
             ILoggerFactory loggerFactory,
             UrlEncoder encoder,
-            IOptions<SharedAuthenticationOptions> sharedOptions,
-            IOptions<TOptions> options)
+            SharedAuthenticationOptions sharedOptions,
+            TOptions options)
             : base(next, options, loggerFactory, encoder)
         {
             if (next == null)
@@ -116,7 +115,7 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
 
             if (string.IsNullOrEmpty(Options.SignInScheme))
             {
-                Options.SignInScheme = sharedOptions.Value.SignInScheme;
+                Options.SignInScheme = sharedOptions.SignInScheme;
             }
             if (string.IsNullOrEmpty(Options.SignInScheme))
             {

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectMiddleware.cs
@@ -38,8 +38,8 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
             ILoggerFactory loggerFactory,
             UrlEncoder encoder,
             IServiceProvider services,
-            IOptions<SharedAuthenticationOptions> sharedOptions,
-            IOptions<OpenIdConnectOptions> options,
+            SharedAuthenticationOptions sharedOptions,
+            OpenIdConnectOptions options,
             HtmlEncoder htmlEncoder)
             : base(next, options, loggerFactory, encoder)
         {
@@ -90,7 +90,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
 
             if (string.IsNullOrEmpty(Options.SignInScheme))
             {
-                Options.SignInScheme = sharedOptions.Value.SignInScheme;
+                Options.SignInScheme = sharedOptions.SignInScheme;
             }
             if (string.IsNullOrEmpty(Options.SignInScheme))
             {

--- a/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterMiddleware.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Authentication.Twitter
 {
@@ -37,8 +36,8 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
             IDataProtectionProvider dataProtectionProvider,
             ILoggerFactory loggerFactory,
             UrlEncoder encoder,
-            IOptions<SharedAuthenticationOptions> sharedOptions,
-            IOptions<TwitterOptions> options)
+            SharedAuthenticationOptions sharedOptions,
+            TwitterOptions options)
             : base(next, options, loggerFactory, encoder)
         {
             if (next == null)
@@ -99,7 +98,7 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
 
             if (string.IsNullOrEmpty(Options.SignInScheme))
             {
-                Options.SignInScheme = sharedOptions.Value.SignInScheme;
+                Options.SignInScheme = sharedOptions.SignInScheme;
             }
             if (string.IsNullOrEmpty(Options.SignInScheme))
             {

--- a/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterOptions.cs
@@ -2,10 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Twitter;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Builder
 {
@@ -17,8 +19,16 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// Initializes a new instance of the <see cref="TwitterOptions"/> class.
         /// </summary>
-        public TwitterOptions()
+        public TwitterOptions(IEnumerable<IConfigureOptions<TwitterOptions>> configureOptions = null)
         {
+            if (configureOptions != null)
+            {
+                foreach (var configure in configureOptions)
+                {
+                    configure.Configure(this);
+                }
+            }
+
             AuthenticationScheme = TwitterDefaults.AuthenticationScheme;
             DisplayName = AuthenticationScheme;
             CallbackPath = new PathString("/signin-twitter");

--- a/src/Microsoft.AspNetCore.Authentication/AuthenticationMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Authentication/AuthenticationMiddleware.cs
@@ -7,17 +7,16 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Authentication
 {
-    public abstract class AuthenticationMiddleware<TOptions> where TOptions : AuthenticationOptions, new()
+    public abstract class AuthenticationMiddleware<TOptions> where TOptions : AuthenticationOptions
     {
         private readonly RequestDelegate _next;
 
         protected AuthenticationMiddleware(
             RequestDelegate next,
-            IOptions<TOptions> options,
+            TOptions options,
             ILoggerFactory loggerFactory,
             UrlEncoder encoder)
         {
@@ -41,7 +40,7 @@ namespace Microsoft.AspNetCore.Authentication
                 throw new ArgumentNullException(nameof(encoder));
             }
 
-            Options = options.Value;
+            Options = options;
             Logger = loggerFactory.CreateLogger(this.GetType().FullName);
             UrlEncoder = encoder;
 

--- a/src/Microsoft.AspNetCore.Authentication/AuthenticationOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication/AuthenticationOptions.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Http.Authentication;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Builder
 {

--- a/src/Microsoft.AspNetCore.Authentication/AuthenticationServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication/AuthenticationServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(services));
             }
 
+            services.AddSingleton<SharedAuthenticationOptions>();
             services.AddWebEncoders();
             services.AddDataProtection();
             return services;

--- a/src/Microsoft.AspNetCore.Authentication/ClaimsTransformationAppBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication/ClaimsTransformationAppBuilderExtensions.cs
@@ -5,7 +5,6 @@ using System;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
-using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Builder
 {
@@ -69,7 +68,7 @@ namespace Microsoft.AspNetCore.Builder
                 throw new ArgumentNullException(nameof(options));
             }
 
-            return app.UseMiddleware<ClaimsTransformationMiddleware>(Options.Create(options));
+            return app.UseMiddleware<ClaimsTransformationMiddleware>(options);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication/ClaimsTransformationMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Authentication/ClaimsTransformationMiddleware.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Authentication
 {
@@ -15,7 +14,7 @@ namespace Microsoft.AspNetCore.Authentication
 
         public ClaimsTransformationMiddleware(
             RequestDelegate next,
-            IOptions<ClaimsTransformationOptions> options)
+            ClaimsTransformationOptions options)
         {
             if (next == null)
             {
@@ -27,7 +26,7 @@ namespace Microsoft.AspNetCore.Authentication
                 throw new ArgumentNullException(nameof(options));
             }
 
-            Options = options.Value;
+            Options = options;
             _next = next;
         }
 

--- a/src/Microsoft.AspNetCore.Authentication/ClaimsTransformationOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication/ClaimsTransformationOptions.cs
@@ -1,12 +1,25 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Builder
 {
     public class ClaimsTransformationOptions
     {
+        public ClaimsTransformationOptions(IEnumerable<IConfigureOptions<ClaimsTransformationOptions>> configureOptions = null)
+        {
+            if (configureOptions != null)
+            {
+                foreach (var configure in configureOptions)
+                {
+                    configure.Configure(this);
+                }
+            }
+        }
+
         public IClaimsTransformer Transformer { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication/RemoteAuthenticationOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication/RemoteAuthenticationOptions.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Authentication;
 
 namespace Microsoft.AspNetCore.Builder
 {
-    public class RemoteAuthenticationOptions : AuthenticationOptions
+    public abstract class RemoteAuthenticationOptions : AuthenticationOptions
     {
         /// <summary>
         /// Gets or sets timeout value in milliseconds for back channel communications with the remote provider.

--- a/src/Microsoft.AspNetCore.Authentication/SharedAuthenticationOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication/SharedAuthenticationOptions.cs
@@ -1,13 +1,24 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-
-using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Authentication
 {
     public class SharedAuthenticationOptions
     {
+        public SharedAuthenticationOptions(IEnumerable<IConfigureOptions<SharedAuthenticationOptions>> configureOptions = null)
+        {
+            if (configureOptions != null)
+            {
+                foreach (var configure in configureOptions)
+                {
+                    configure.Configure(this);
+                }
+            }
+        }
+
         /// <summary>
         /// Gets or sets the authentication scheme corresponding to the default middleware
         /// responsible of persisting user's identity after a successful authentication.

--- a/src/Microsoft.AspNetCore.Authorization/AuthorizationServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authorization/AuthorizationServiceCollectionExtensions.cs
@@ -24,7 +24,8 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 throw new ArgumentNullException(nameof(services));
             }
-            
+
+            services.TryAddSingleton<AuthorizationOptions>();
             services.TryAdd(ServiceDescriptor.Transient<IAuthorizationService, DefaultAuthorizationService>());
             services.TryAdd(ServiceDescriptor.Transient<IAuthorizationPolicyProvider, DefaultAuthorizationPolicyProvider>());
             services.TryAddEnumerable(ServiceDescriptor.Transient<IAuthorizationHandler, PassThroughAuthorizationHandler>());

--- a/src/Microsoft.AspNetCore.Authorization/DefaultAuthorizationPolicyProvider.cs
+++ b/src/Microsoft.AspNetCore.Authorization/DefaultAuthorizationPolicyProvider.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Authorization
 {
@@ -14,14 +13,14 @@ namespace Microsoft.AspNetCore.Authorization
     {
         private readonly AuthorizationOptions _options;
 
-        public DefaultAuthorizationPolicyProvider(IOptions<AuthorizationOptions> options)
+        public DefaultAuthorizationPolicyProvider(AuthorizationOptions options)
         {
             if (options == null)
             {
                 throw new ArgumentNullException(nameof(options));
             }
 
-            _options = options.Value;
+            _options = options;
         } 
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.CookiePolicy/CookiePolicyAppBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.CookiePolicy/CookiePolicyAppBuilderExtensions.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Builder
                 throw new ArgumentNullException(nameof(options));
             }
 
-            return app.UseMiddleware<CookiePolicyMiddleware>(Options.Create(options));
+            return app.UseMiddleware<CookiePolicyMiddleware>(options);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.CookiePolicy/CookiePolicyMiddleware.cs
+++ b/src/Microsoft.AspNetCore.CookiePolicy/CookiePolicyMiddleware.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features.Internal;
-using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.CookiePolicy
 {
@@ -14,11 +13,9 @@ namespace Microsoft.AspNetCore.CookiePolicy
     {
         private readonly RequestDelegate _next;
 
-        public CookiePolicyMiddleware(
-            RequestDelegate next,
-            IOptions<CookiePolicyOptions> options)
+        public CookiePolicyMiddleware(RequestDelegate next, CookiePolicyOptions options)
         {
-            Options = options.Value;
+            Options = options;
             _next = next;
         }
 

--- a/src/Microsoft.AspNetCore.CookiePolicy/CookiePolicyOptions.cs
+++ b/src/Microsoft.AspNetCore.CookiePolicy/CookiePolicyOptions.cs
@@ -2,12 +2,25 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.CookiePolicy;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Builder
 {
     public class CookiePolicyOptions
     {
+        public CookiePolicyOptions(IEnumerable<IConfigureOptions<CookiePolicyOptions>> configureOptions = null)
+        {
+            if (configureOptions != null)
+            {
+                foreach (var configure in configureOptions)
+                {
+                    configure.Configure(this);
+                }
+            }
+        }
+
         public HttpOnlyPolicy HttpOnly { get; set; } = HttpOnlyPolicy.None;
         public SecurePolicy Secure { get; set; } = SecurePolicy.None;
 


### PR DESCRIPTION
https://github.com/aspnet/Options/issues/122

New behavior now with the UseAuth() that don't take an options instance, they will fail now unless someone registered AuthOptions before using that method unlike before...