### PR TITLE
Handle authorize and forbid for redirecting handlers.

### DIFF
--- a/samples/SocialSample/Properties/launchSettings.json
+++ b/samples/SocialSample/Properties/launchSettings.json
@@ -19,10 +19,10 @@
     "SocialSample": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "https://localhost:54541/",
+      "launchUrl": "https://localhost:44318/",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_SERVER.URLS": "https://localhost:54541/"
+        "ASPNETCORE_SERVER.URLS": "https://localhost:44318/"
       }
     }
   }


### PR DESCRIPTION
#667 - Authenticated but not authorized infinite loop
#801 - Authenticate remote provider by name

When a user lacks a specific claim the authorization service issues a Challenge. For Bearer or Cookies they accept this challenge, verify that they produced the identity, and switch to Forbid. This isn't happening for the remote providers because they do not maintain the identity, they delegate that to Cookies. As such they end up in an infinite challenge loop. See https://github.com/aspnet/Security/blob/dev/src/Microsoft.AspNetCore.Authentication/AuthenticationHandler.cs#L310-L332 for reference on Challenge behaviors.

Similarly, `[Authorize(ActiveAuthenticationSchemes = OpenIdConnectDefaults.AuthenticationScheme)]` doesn't work because the remote auth handler does not store the identity internally so `HttpContext.Authentication.AuthenticateAsync(scheme)` always returns null. `[Authorize]` works because Cookies has AutomaticAuthenticate and OIDC has AutomaticChallenge.

Fix: When a remote handler is 'Authenticating', have it delegate to the handler specified by SignInScheme.

@HaoK @PinpointTownes Thoughts?

@vibronet I think this will break your background refresh sample where you challenge for the current auth type to refresh the identity. I think it can still work if we make an easy way to avoid ChallengeBehavior.Automatic.