### PR TITLE
Rework CookieAuth for compat with CookiePolicy.

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationMiddleware.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
             }
             if (Options.CookieManager == null)
             {
-                Options.CookieManager = new ChunkingCookieManager(urlEncoder);
+                Options.CookieManager = new ChunkingCookieManager();
             }
             if (!Options.LoginPath.HasValue)
             {

--- a/src/Microsoft.Owin.Security.Interop/Constants.cs
+++ b/src/Microsoft.Owin.Security.Interop/Constants.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Owin.Security.Interop
+{
+    internal static class Constants
+    {
+        internal static class Headers
+        {
+            internal const string SetCookie = "Set-Cookie";
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.CookiePolicy.Test/project.json
+++ b/test/Microsoft.AspNetCore.CookiePolicy.Test/project.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "dotnet-test-xunit": "1.0.0-*",
     "Microsoft.NETCore.Platforms": "1.0.1-*",
+    "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0-*",
     "Microsoft.AspNetCore.CookiePolicy": "1.0.0-*",
     "Microsoft.AspNetCore.TestHost": "1.0.0-*",
     "Microsoft.Extensions.DependencyInjection": "1.0.0-*",


### PR DESCRIPTION
#814 @anurse @HaoK @muratg 
Change ChunkingCookieManager from appending raw headers to appending via the response cookies API. Here are a few side effects:
- Removed the key & value encoding. The lower level will handle this and most of the time no encoding is required. Worst case we loose a little bit of length precision and devs need to lower ChunkSize accordingly.
- Removed the quote handling. Cookie auth never uses quotes.
- Change the format of the first cookie from `key=chunks:2` to `key=chunks-2`. `:` would be escaped by the response cookies API.