### PR TITLE
Show some JwtBearer errors in response headers

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.JwtBearer/Events/JwtBearerChallengeContext.cs
+++ b/src/Microsoft.AspNetCore.Authentication.JwtBearer/Events/JwtBearerChallengeContext.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Authentication;
@@ -16,5 +17,10 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
         }
 
         public AuthenticationProperties Properties { get; }
+
+        /// <summary>
+        /// Any failures encountered during the authentication process.
+        /// </summary>
+        public Exception AuthenticateFailure { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
@@ -575,7 +575,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                 Logger.ExceptionProcessingMessage(exception);
 
                 // Refresh the configuration for exceptions that may be caused by key rollovers. The user can also request a refresh in the event.
-                if (Options.RefreshOnIssuerKeyNotFound && exception.GetType().Equals(typeof(SecurityTokenSignatureKeyNotFoundException)))
+                if (Options.RefreshOnIssuerKeyNotFound && exception is SecurityTokenSignatureKeyNotFoundException)
                 {
                     if (Options.ConfigurationManager != null)
                     {


### PR DESCRIPTION
#776 @vibronet @blowdart @brentschmaltz @HaoK @PinpointTownes @Eilon @muratg 

For a specific set of exceptions, display those exception messages in the response headers to help the consumer report and debug configuration issues. The list of exceptions to report is configurable. Note we're using headers rather than the body because the auth middleware is never in control of the response body.

Example:
```
Content-Length:0
Date:Wed, 25 May 2016 20:54:58 GMT
Server:Kestrel
WWW-Authenticate:Bearer
X-Authentication-Failure:IDX10214: Audience validation failed. Audiences: '63a87a83-64b9-4ac1-b2c5-092126f8474f'. Did not match:  validationParameters.ValidAudience: '63a87a83-64b9-4ac1-b2c5-092126f8474f-wrongaudiance' or validationParameters.ValidAudiences: 'null'
```