### PR TITLE
Remove obsolete DateTime conversions

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationHandler.cs
@@ -192,7 +192,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
                 var cookieOptions = BuildCookieOptions();
                 if (ticket.Properties.IsPersistent && _refreshExpiresUtc.HasValue)
                 {
-                    cookieOptions.Expires = _refreshExpiresUtc.Value.ToUniversalTime().DateTime;
+                    cookieOptions.Expires = _refreshExpiresUtc.Value.ToUniversalTime();
                 }
 
                 Options.CookieManager.AppendResponseCookie(
@@ -240,7 +240,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
             if (signInContext.Properties.IsPersistent)
             {
                 var expiresUtc = signInContext.Properties.ExpiresUtc ?? issuedUtc.Add(Options.ExpireTimeSpan);
-                signInContext.CookieOptions.Expires = expiresUtc.ToUniversalTime().DateTime;
+                signInContext.CookieOptions.Expires = expiresUtc.ToUniversalTime();
             }
 
             var ticket = new AuthenticationTicket(signInContext.Principal, signInContext.Properties, signInContext.AuthenticationScheme);


### PR DESCRIPTION
#780 @nickcam @HaoK @muratg @Eilon 

Katana used DateTime for all of its fields/properties. We've since converted everything to use DateTimeOffset as it more accurately preserves things like time zone. However, we forgot to remove a few conversions like the ones in this PR. It wasn't a compiler break because of the implicit conversion from DateTime to DateTimeOffset, but we were loosing information in the downgrade.