### PR TITLE
Add a new IncludeErrorDetails option to prevent the JWT middleware from returning error/error_description

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.JwtBearer/Events/JwtBearerChallengeContext.cs
+++ b/src/Microsoft.AspNetCore.Authentication.JwtBearer/Events/JwtBearerChallengeContext.cs
@@ -22,5 +22,25 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
         /// Any failures encountered during the authentication process.
         /// </summary>
         public Exception AuthenticateFailure { get; set; }
+
+        /// <summary>
+        /// Gets or sets the "error" value returned to the caller as part
+        /// of the WWW-Authenticate header. This property may be null when
+        /// <see cref="JwtBearerOptions.IncludeErrorDetails"/> is set to <c>false</c>.
+        /// </summary>
+        public string Error { get; set; }
+
+        /// <summary>
+        /// Gets or sets the "error_description" value returned to the caller as part
+        /// of the WWW-Authenticate header. This property may be null when
+        /// <see cref="JwtBearerOptions.IncludeErrorDetails"/> is set to <c>false</c>.
+        /// </summary>
+        public string ErrorDescription { get; set; }
+
+        /// <summary>
+        /// Gets or sets the "error_uri" value returned to the caller as part of the
+        /// WWW-Authenticate header. This property is always null unless explicitly set.
+        /// </summary>
+        public string ErrorUri { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerOptions.cs
@@ -118,5 +118,12 @@ namespace Microsoft.AspNetCore.Builder
         /// <see cref="Http.Authentication.AuthenticationProperties"/> after a successful authorization.
         /// </summary>
         public bool SaveToken { get; set; } = true;
+
+        /// <summary>
+        /// Defines whether the token validation errors should be returned to the caller.
+        /// Enabled by default, this option can be disabled to prevent the JWT middleware
+        /// from returning an error and an error_description in the WWW-Authenticate header.
+        /// </summary>
+        public bool IncludeErrorDetails { get; set; } = true;
     }
 }


### PR DESCRIPTION
We had agreed on the fact an option allowing to remove the error details from the WWW-Authenticate header was important, but it looks like it was not added by @Tratcher in his PR.

https://github.com/aspnet/Security/issues/776#issuecomment-210263382

/cc @Eilon @HaoK @Tratcher 