### PR TITLE
Remote auth expiration fix

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationOptions.cs
@@ -139,12 +139,6 @@ namespace Microsoft.AspNetCore.Builder
         public ISecureDataFormat<AuthenticationTicket> TicketDataFormat { get; set; }
 
         /// <summary>
-        /// For testing purposes only.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public ISystemClock SystemClock { get; set; }
-
-        /// <summary>
         /// The component used to get cookies from the request or set them on the response.
         ///
         /// ChunkingCookieManager will be used by default.

--- a/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerOptions.cs
@@ -96,12 +96,6 @@ namespace Microsoft.AspNetCore.Builder
         public bool RefreshOnIssuerKeyNotFound { get; set; } = true;
 
         /// <summary>
-        /// For testing purposes only.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public ISystemClock SystemClock { get; set; } = new SystemClock();
-
-        /// <summary>
         /// Gets the ordered list of <see cref="ISecurityTokenValidator"/> used to validate access tokens.
         /// </summary>
         public IList<ISecurityTokenValidator> SecurityTokenValidators { get; } = new List<ISecurityTokenValidator> { new JwtSecurityTokenHandler() };

--- a/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthHandler.cs
@@ -175,10 +175,7 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var properties = new AuthenticationProperties(context.Properties)
-            {
-                ExpiresUtc = Options.SystemClock.UtcNow.Add(Options.RemoteAuthenticationTimeout)
-            };
+            var properties = new AuthenticationProperties(context.Properties);
 
             if (string.IsNullOrEmpty(properties.RedirectUri))
             {

--- a/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthOptions.cs
@@ -64,11 +64,5 @@ namespace Microsoft.AspNetCore.Builder
         /// Gets or sets the type used to secure data handled by the middleware.
         /// </summary>
         public ISecureDataFormat<AuthenticationProperties> StateDataFormat { get; set; }
-
-        /// <summary>
-        /// For testing purposes only.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public ISystemClock SystemClock { get; set; } = new SystemClock();
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
@@ -259,10 +259,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
             // order for local RedirectUri
             // 1. challenge.Properties.RedirectUri
             // 2. CurrentUri if RedirectUri is not set)
-            var properties = new AuthenticationProperties(context.Properties)
-            {
-                ExpiresUtc = Options.SystemClock.UtcNow.Add(Options.RemoteAuthenticationTimeout)
-            };
+            var properties = new AuthenticationProperties(context.Properties);
 
             if (string.IsNullOrEmpty(properties.RedirectUri))
             {

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectOptions.cs
@@ -202,11 +202,5 @@ namespace Microsoft.AspNetCore.Builder
         /// This is disabled by default.
         /// </summary>
         public bool SkipUnrecognizedRequests { get; set; } = false;
-
-        /// <summary>
-        /// For testing purposes only.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public ISystemClock SystemClock { get; set; } = new SystemClock();
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterHandler.cs
@@ -131,10 +131,7 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var properties = new AuthenticationProperties(context.Properties)
-            {
-                ExpiresUtc = Options.SystemClock.UtcNow.Add(Options.RemoteAuthenticationTimeout)
-            };
+            var properties = new AuthenticationProperties(context.Properties);
 
             if (string.IsNullOrEmpty(properties.RedirectUri))
             {

--- a/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterHandler.cs
@@ -145,7 +145,8 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
             var cookieOptions = new CookieOptions
             {
                 HttpOnly = true,
-                Secure = Request.IsHttps
+                Secure = Request.IsHttps,
+                Expires = Options.SystemClock.UtcNow.Add(Options.RemoteAuthenticationTimeout),
             };
 
             Response.Cookies.Append(StateCookie, Options.StateDataFormat.Protect(requestToken), cookieOptions);

--- a/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterOptions.cs
@@ -59,11 +59,5 @@ namespace Microsoft.AspNetCore.Builder
             get { return (ITwitterEvents)base.Events; }
             set { base.Events = value; }
         }
-
-        /// <summary>
-        /// For testing purposes only.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public ISystemClock SystemClock { get; set; } = new SystemClock();
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication/AuthenticationOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication/AuthenticationOptions.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http.Authentication;
+using System.ComponentModel;
 
 namespace Microsoft.AspNetCore.Builder
 {
@@ -47,5 +49,11 @@ namespace Microsoft.AspNetCore.Builder
         /// Additional information about the authentication type which is made available to the application.
         /// </summary>
         public AuthenticationDescription Description { get; set; } = new AuthenticationDescription();
+
+        /// <summary>
+        /// For testing purposes only.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ISystemClock SystemClock { get; set; } = new SystemClock();
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication/RemoteAuthenticationHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication/RemoteAuthenticationHandler.cs
@@ -149,7 +149,7 @@ namespace Microsoft.AspNetCore.Authentication
             {
                 HttpOnly = true,
                 Secure = Request.IsHttps,
-                Expires = properties.ExpiresUtc
+                Expires = Options.SystemClock.UtcNow.Add(Options.RemoteAuthenticationTimeout),
             };
 
             properties.Items[CorrelationProperty] = correlationId;


### PR DESCRIPTION
Fixes #855, which documents a bug where the `RemoteAuthenticationTimeout` (intended to be used for a correlation cookie) also ends up getting used for the `ExpiresUtc` value of the `AuthenticationProperties` of the actual authentication ticket that gets issued. 

I did not see a generic set of tests for `RemoteAuthenticationHandler` so I refrained from adding a test for now.