### PR TITLE
Handle  the remote authentication failure gracefully

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Globalization;
 using System.Net.Http;
 using System.Security.Claims;
@@ -35,7 +36,11 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             }
 
             var response = await Backchannel.GetAsync(endpoint, Context.RequestAborted);
-            response.EnsureSuccessStatusCode();
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorMessage = $"Failed to retrived Facebook user information ({response.StatusCode}) Please check if the authentication information is correct and the corresponding Google API is enabled.";
+                throw new InvalidOperationException(errorMessage);
+            }
 
             var payload = JObject.Parse(await response.Content.ReadAsStringAsync());
 
@@ -119,7 +124,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             {
                 identity.AddClaim(new Claim(ClaimTypes.Name, name, ClaimValueTypes.String, Options.ClaimsIssuer));
             }
- 
+
             var timeZone = FacebookHelper.GetTimeZone(payload);
             if (!string.IsNullOrEmpty(timeZone))
             {

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
@@ -38,8 +38,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             var response = await Backchannel.GetAsync(endpoint, Context.RequestAborted);
             if (!response.IsSuccessStatusCode)
             {
-                var errorMessage = $"Failed to retrived Facebook user information ({response.StatusCode}) Please check if the authentication information is correct and the corresponding Google API is enabled.";
-                throw new InvalidOperationException(errorMessage);
+                throw new HttpRequestException($"Failed to retrived Facebook user information ({response.StatusCode}) Please check if the authentication information is correct and the corresponding Facebook API is enabled.");
             }
 
             var payload = JObject.Parse(await response.Content.ReadAsStringAsync());

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             var response = await Backchannel.GetAsync(endpoint, Context.RequestAborted);
             if (!response.IsSuccessStatusCode)
             {
-                throw new HttpRequestException($"Failed to retrived Facebook user information ({response.StatusCode}) Please check if the authentication information is correct and the corresponding Facebook API is enabled.");
+                throw new HttpRequestException($"Failed to retrived Facebook user information ({response.StatusCode}) Please check if the authentication information is correct and the corresponding Facebook Graph API is enabled.");
             }
 
             var payload = JObject.Parse(await response.Content.ReadAsStringAsync());

--- a/src/Microsoft.AspNetCore.Authentication.Google/GoogleHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Google/GoogleHandler.cs
@@ -34,8 +34,7 @@ namespace Microsoft.AspNetCore.Authentication.Google
             var response = await Backchannel.SendAsync(request, Context.RequestAborted);
             if (!response.IsSuccessStatusCode)
             {
-                var errorMessage = $"Failed to retrived Google user information ({response.StatusCode}) Please check if the authentication information is correct and the corresponding Google API is enabled.";
-                throw new InvalidOperationException(errorMessage);
+                throw new HttpRequestException($"An error occurred when retrieving user information ({response.StatusCode}). Please check if the authentication information is correct and the corresponding Google API is enabled.");
             }
 
             var payload = JObject.Parse(await response.Content.ReadAsStringAsync());

--- a/src/Microsoft.AspNetCore.Authentication.Google/GoogleHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Google/GoogleHandler.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Authentication.Google
             var response = await Backchannel.SendAsync(request, Context.RequestAborted);
             if (!response.IsSuccessStatusCode)
             {
-                throw new HttpRequestException($"An error occurred when retrieving user information ({response.StatusCode}). Please check if the authentication information is correct and the corresponding Google API is enabled.");
+                throw new HttpRequestException($"An error occurred when retrieving user information ({response.StatusCode}). Please check if the authentication information is correct and the corresponding Google+ API is enabled.");
             }
 
             var payload = JObject.Parse(await response.Content.ReadAsStringAsync());

--- a/src/Microsoft.AspNetCore.Authentication.Google/GoogleHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Google/GoogleHandler.cs
@@ -32,7 +32,11 @@ namespace Microsoft.AspNetCore.Authentication.Google
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", tokens.AccessToken);
 
             var response = await Backchannel.SendAsync(request, Context.RequestAborted);
-            response.EnsureSuccessStatusCode();
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorMessage = $"Failed to retrived Google user information ({response.StatusCode}) Please check if the authentication information is correct and the corresponding Google API is enabled.";
+                throw new InvalidOperationException(errorMessage);
+            }
 
             var payload = JObject.Parse(await response.Content.ReadAsStringAsync());
 

--- a/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountHandler.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
@@ -25,7 +26,11 @@ namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", tokens.AccessToken);
 
             var response = await Backchannel.SendAsync(request, Context.RequestAborted);
-            response.EnsureSuccessStatusCode();
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorMessage = $"Failed to retrived Microsoft user information ({response.StatusCode}) Please check if the authentication information is correct and the corresponding Google API is enabled.";
+                throw new InvalidOperationException(errorMessage);
+            }
 
             var payload = JObject.Parse(await response.Content.ReadAsStringAsync());
 

--- a/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountHandler.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
             var response = await Backchannel.SendAsync(request, Context.RequestAborted);
             if (!response.IsSuccessStatusCode)
             {
-                throw new HttpRequestException($"Failed to retrived Microsoft user information ({response.StatusCode}) Please check if the authentication information is correct and the corresponding Microsoft API is enabled.");
+                throw new HttpRequestException($"Failed to retrived Microsoft user information ({response.StatusCode}) Please check if the authentication information is correct and the corresponding Microsoft Account API is enabled.");
             }
 
             var payload = JObject.Parse(await response.Content.ReadAsStringAsync());

--- a/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountHandler.cs
@@ -28,8 +28,7 @@ namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
             var response = await Backchannel.SendAsync(request, Context.RequestAborted);
             if (!response.IsSuccessStatusCode)
             {
-                var errorMessage = $"Failed to retrived Microsoft user information ({response.StatusCode}) Please check if the authentication information is correct and the corresponding Google API is enabled.";
-                throw new InvalidOperationException(errorMessage);
+                throw new HttpRequestException($"Failed to retrived Microsoft user information ({response.StatusCode}) Please check if the authentication information is correct and the corresponding Microsoft API is enabled.");
             }
 
             var payload = JObject.Parse(await response.Content.ReadAsStringAsync());

--- a/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthHandler.cs
@@ -119,7 +119,15 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
                 properties.StoreTokens(authTokens);
             }
 
-            return AuthenticateResult.Success(await CreateTicketAsync(identity, properties, tokens));
+            try
+            {
+                var ticket = await CreateTicketAsync(identity, properties, tokens);
+                return AuthenticateResult.Success(ticket);
+            }
+            catch (Exception ex)
+            {
+                return AuthenticateResult.Fail(ex);
+            }
         }
 
         protected virtual async Task<OAuthTokenResponse> ExchangeCodeAsync(string code, string redirectUri)

--- a/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthHandler.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Authentication;
@@ -15,7 +16,6 @@ using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Http.Features.Authentication;
 using Microsoft.Extensions.Primitives;
 using Newtonsoft.Json.Linq;
-using System.Threading;
 
 namespace Microsoft.AspNetCore.Authentication.OAuth
 {

--- a/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthHandler.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Http.Features.Authentication;
 using Microsoft.Extensions.Primitives;
 using Newtonsoft.Json.Linq;
+using System.Threading;
 
 namespace Microsoft.AspNetCore.Authentication.OAuth
 {
@@ -119,14 +120,14 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
                 properties.StoreTokens(authTokens);
             }
 
-            try
+            var ticket = await CreateTicketAsync(identity, properties, tokens);
+            if (ticket != null)
             {
-                var ticket = await CreateTicketAsync(identity, properties, tokens);
                 return AuthenticateResult.Success(ticket);
             }
-            catch (Exception ex)
+            else
             {
-                return AuthenticateResult.Fail(ex);
+                return AuthenticateResult.Fail("Failed to retrieve user information from remote server.");
             }
         }
 

--- a/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthHandler.cs
@@ -8,7 +8,6 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Authentication;

--- a/src/Microsoft.AspNetCore.Authentication/RemoteAuthenticationHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication/RemoteAuthenticationHandler.cs
@@ -87,6 +87,12 @@ namespace Microsoft.AspNetCore.Authentication
             return true;
         }
 
+        /// <summary>
+        /// Authenticate the user identity with the identity provider. 
+        ///
+        /// This could be done through a back channel communication with the identity provider. Exception thrown during
+        /// the authenticating should be saved to the AuthenticateResult.
+        /// </summary>
         protected abstract Task<AuthenticateResult> HandleRemoteAuthenticateAsync();
 
         protected override async Task<AuthenticateResult> HandleAuthenticateAsync()

--- a/src/Microsoft.AspNetCore.Authentication/RemoteAuthenticationHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication/RemoteAuthenticationHandler.cs
@@ -44,12 +44,12 @@ namespace Microsoft.AspNetCore.Authentication
                 }
                 else if (authResult == null)
                 {
-                    exception = new InvalidOperationException("Invalide return state, unable to redirect.");
+                    exception = new InvalidOperationException("Invalid return state, unable to redirect.");
                 }
                 else if (!authResult.Succeeded)
                 {
                     exception = authResult?.Failure ??
-                                new InvalidOperationException("Invalide return state, unable to redirect.");
+                                new InvalidOperationException("Invalid return state, unable to redirect.");
                 }
             }
             catch (Exception ex)

--- a/src/Microsoft.AspNetCore.Authentication/RemoteAuthenticationHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication/RemoteAuthenticationHandler.cs
@@ -114,8 +114,7 @@ namespace Microsoft.AspNetCore.Authentication
         /// <summary>
         /// Authenticate the user identity with the identity provider. 
         ///
-        /// This could be done through a back channel communication with the identity provider. Exception thrown during
-        /// the authenticating should be saved to the AuthenticateResult.
+        /// This could be done through a back channel communication with the identity provider. 
         /// </summary>
         protected abstract Task<AuthenticateResult> HandleRemoteAuthenticateAsync();
 

--- a/src/Microsoft.AspNetCore.Authentication/RemoteAuthenticationHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication/RemoteAuthenticationHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Net.Http;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
@@ -9,7 +10,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features.Authentication;
 using Microsoft.AspNetCore.Http.Authentication;
 using Microsoft.Extensions.Logging;
-using System.Net.Http;
 
 namespace Microsoft.AspNetCore.Authentication
 {

--- a/src/Microsoft.AspNetCore.Authentication/RemoteAuthenticationHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication/RemoteAuthenticationHandler.cs
@@ -37,18 +37,17 @@ namespace Microsoft.AspNetCore.Authentication
             try
             {
                 var authResult = await HandleRemoteAuthenticateAsync();
-                if (authResult != null && authResult.Skipped)
-                {
-                    return false;
-                }
-
                 if (authResult == null)
                 {
                     exception = new InvalidOperationException("Invalid return state, unable to redirect.");
                 }
+                else if (authResult.Skipped)
+                {
+                    return false;
+                }
                 else if (!authResult.Succeeded)
                 {
-                    exception = authResult?.Failure ??
+                    exception = authResult.Failure ??
                                 new InvalidOperationException("Invalid return state, unable to redirect.");
                 }
 

--- a/src/Microsoft.AspNetCore.Authentication/RemoteAuthenticationHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication/RemoteAuthenticationHandler.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Authentication
             try
             {
                 var authResult = await HandleRemoteAuthenticateAsync();
-                if (authResult != null && authResult.Skipped == true)
+                if (authResult != null && authResult.Skipped)
                 {
                     return false;
                 }

--- a/src/Microsoft.AspNetCore.Authentication/RemoteAuthenticationHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication/RemoteAuthenticationHandler.cs
@@ -112,9 +112,9 @@ namespace Microsoft.AspNetCore.Authentication
         }
 
         /// <summary>
-        /// Authenticate the user identity with the identity provider. 
+        /// Authenticate the user identity with the identity provider.
         ///
-        /// This could be done through a back channel communication with the identity provider. 
+        /// The method process the request on the endpoint defined by CallbackPath.
         /// </summary>
         protected abstract Task<AuthenticateResult> HandleRemoteAuthenticateAsync();
 


### PR DESCRIPTION
Address issue #53 

Error message now:
![image](https://cloud.githubusercontent.com/assets/1329240/16966868/5c65a62e-4dbb-11e6-8d3b-ef17069e7f58.png)

The `GoogleHandler` throws when the response from back channel is out of 2XX range. The exception neither provides sufficient information for user to correct the error or is handled gracefully in `OAuthHandler`

The PR contains two commit. The first one is purely for refactoring and readability improvement. For the actual logic change you can focus on the [second commit](https://github.com/aspnet/Security/commit/967c7cdeb6838368ac775a526b84abd164dd6fae)