### PR TITLE
Modify warning about policy behavior

### DIFF
--- a/src/Microsoft.AspNetCore.Authorization/DefaultAuthorizationPolicyProvider.cs
+++ b/src/Microsoft.AspNetCore.Authorization/DefaultAuthorizationPolicyProvider.cs
@@ -45,7 +45,9 @@ namespace Microsoft.AspNetCore.Authorization
         /// <returns>The named <see cref="AuthorizationPolicy"/>.</returns>
         public virtual Task<AuthorizationPolicy> GetPolicyAsync(string policyName)
         {
-            // MVC relies on DefaultAuthorizationPolicyProvider providing the same policy for the same requests.
+            // MVC caches policies specifically for this class, so this method MUST return the same policy per
+            // policyName for every request or it could allow undesired access. It also must return synchronously.
+            // A change to either of these behaviors would require shipping a patch of MVC as well.
             return Task.FromResult(_options.GetPolicy(policyName));
         }
     }


### PR DESCRIPTION
Make the warning about the behavior dependency MVC has on DefaultAuthorizationPolicyProvider a bit more explicit.

CC @Eilon, @rynowak, @HaoK, and @blowdart for review.