### PR TITLE
Add IAuthorizationEvaluator/IAuthorizationHandlerContextFactory

### DIFF
--- a/src/Microsoft.AspNetCore.Authorization/AuthorizationHandlerContext.cs
+++ b/src/Microsoft.AspNetCore.Authorization/AuthorizationHandlerContext.cs
@@ -42,32 +42,32 @@ namespace Microsoft.AspNetCore.Authorization
         /// <summary>
         /// The collection of all the <see cref="IAuthorizationRequirement"/> for the current authorization action.
         /// </summary>
-        public IEnumerable<IAuthorizationRequirement> Requirements { get; }
+        public virtual IEnumerable<IAuthorizationRequirement> Requirements { get; }
 
         /// <summary>
         /// The <see cref="ClaimsPrincipal"/> representing the current user.
         /// </summary>
-        public ClaimsPrincipal User { get; }
+        public virtual ClaimsPrincipal User { get; }
 
         /// <summary>
         /// The optional resource to evaluate the <see cref="AuthorizationHandlerContext.Requirements"/> against.
         /// </summary>
-        public object Resource { get; }
+        public virtual object Resource { get; }
 
         /// <summary>
         /// Gets the requirements that have not yet been marked as succeeded.
         /// </summary>
-        public IEnumerable<IAuthorizationRequirement> PendingRequirements { get { return _pendingRequirements; } }
+        public virtual IEnumerable<IAuthorizationRequirement> PendingRequirements { get { return _pendingRequirements; } }
 
         /// <summary>
         /// Flag indicating whether the current authorization processing has failed.
         /// </summary>
-        public bool HasFailed { get { return _failCalled; } }
+        public virtual bool HasFailed { get { return _failCalled; } }
 
         /// <summary>
         /// Flag indicating whether the current authorization processing has succeeded.
         /// </summary>
-        public bool HasSucceeded
+        public virtual bool HasSucceeded
         {
             get
             {
@@ -79,7 +79,7 @@ namespace Microsoft.AspNetCore.Authorization
         /// Called to indicate <see cref="AuthorizationHandlerContext.HasSucceeded"/> will
         /// never return true, even if all requirements are met.
         /// </summary>
-        public void Fail()
+        public virtual void Fail()
         {
             _failCalled = true;
         }
@@ -89,7 +89,7 @@ namespace Microsoft.AspNetCore.Authorization
         /// successfully evaluated.
         /// </summary>
         /// <param name="requirement">The requirement whose evaluation has succeeded.</param>
-        public void Succeed(IAuthorizationRequirement requirement)
+        public virtual void Succeed(IAuthorizationRequirement requirement)
         {
             _succeedCalled = true;
             _pendingRequirements.Remove(requirement);

--- a/src/Microsoft.AspNetCore.Authorization/AuthorizationServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authorization/AuthorizationServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Extensions.DependencyInjection
             
             services.TryAdd(ServiceDescriptor.Transient<IAuthorizationService, DefaultAuthorizationService>());
             services.TryAdd(ServiceDescriptor.Transient<IAuthorizationPolicyProvider, DefaultAuthorizationPolicyProvider>());
+            services.TryAdd(ServiceDescriptor.Transient<IAuthorizationEvaluator, DefaultAuthorizationEvaluator>());
             services.TryAddEnumerable(ServiceDescriptor.Transient<IAuthorizationHandler, PassThroughAuthorizationHandler>());
             return services;
         }

--- a/src/Microsoft.AspNetCore.Authorization/AuthorizationServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authorization/AuthorizationServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAdd(ServiceDescriptor.Transient<IAuthorizationService, DefaultAuthorizationService>());
             services.TryAdd(ServiceDescriptor.Transient<IAuthorizationPolicyProvider, DefaultAuthorizationPolicyProvider>());
             services.TryAdd(ServiceDescriptor.Transient<IAuthorizationEvaluator, DefaultAuthorizationEvaluator>());
+            services.TryAdd(ServiceDescriptor.Transient<IAuthorizationHandlerContextFactory, DefaultAuthorizationHandlerContextFactory>());
             services.TryAddEnumerable(ServiceDescriptor.Transient<IAuthorizationHandler, PassThroughAuthorizationHandler>());
             return services;
         }

--- a/src/Microsoft.AspNetCore.Authorization/DefaultAuthorizationEvaluator.cs
+++ b/src/Microsoft.AspNetCore.Authorization/DefaultAuthorizationEvaluator.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Authorization
+{
+    /// <summary>
+    /// Determines whether an authorization request was successful or not.
+    /// </summary>
+    public class DefaultAuthorizationEvaluator : IAuthorizationEvaluator
+    {
+        /// <summary>
+        /// Returns true, if authorization has failed.
+        /// </summary>
+        /// <param name="context">The authorization information.</param>
+        /// <returns>True if authorization has failed.</returns>
+        public virtual bool HasFailed(AuthorizationHandlerContext context)
+        {
+            return context.HasFailed;
+        }
+
+        /// <summary>
+        /// Returns true, if authorization has succeeded.
+        /// </summary>
+        /// <param name="context">The authorization information.</param>
+        /// <returns>True if authorization has succeeded.</returns>
+        public virtual bool HasSucceeded(AuthorizationHandlerContext context)
+        {
+            return context.HasSucceeded;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Authorization/DefaultAuthorizationHandlerContextFactory.cs
+++ b/src/Microsoft.AspNetCore.Authorization/DefaultAuthorizationHandlerContextFactory.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Security.Claims;
+
+namespace Microsoft.AspNetCore.Authorization
+{
+    /// <summary>
+    /// A type used to provide a <see cref="AuthorizationHandlerContext"/> used for authorization.
+    /// </summary>
+    public class DefaultAuthorizationHandlerContextFactory : IAuthorizationHandlerContextFactory
+    {
+        /// <summary>
+        /// Creates a <see cref="AuthorizationHandlerContext"/> used for authorization.
+        /// </summary>
+        /// <param name="requirements">The requirements to evaluate.</param>
+        /// <param name="user">The user to evaluate the requirements against.</param>
+        /// <param name="resource">
+        /// An optional resource the policy should be checked with.
+        /// If a resource is not required for policy evaluation you may pass null as the value.
+        /// </param>
+        /// <returns>The <see cref="AuthorizationHandlerContext"/>.</returns>
+        public virtual AuthorizationHandlerContext CreateContext(IEnumerable<IAuthorizationRequirement> requirements, ClaimsPrincipal user, object resource)
+        {
+            return new AuthorizationHandlerContext(requirements, user, resource);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Authorization/IAuthorizationEvaluator.cs
+++ b/src/Microsoft.AspNetCore.Authorization/IAuthorizationEvaluator.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Authorization
+{
+    /// <summary>
+    /// Determines whether an authorization request was successful or not.
+    /// </summary>
+    public interface IAuthorizationEvaluator
+    {
+        /// <summary>
+        /// Returns true, if authorization has failed.
+        /// </summary>
+        /// <param name="context">The authorization information.</param>
+        /// <returns>True if authorization has failed.</returns>
+        bool HasFailed(AuthorizationHandlerContext context);
+
+        /// <summary>
+        /// Returns true, if authorization has succeeded.
+        /// </summary>
+        /// <param name="context">The authorization information.</param>
+        /// <returns>True if authorization has succeeded.</returns>
+        bool HasSucceeded(AuthorizationHandlerContext context);
+    }
+}

--- a/src/Microsoft.AspNetCore.Authorization/IAuthorizationHandlerContextFactory.cs
+++ b/src/Microsoft.AspNetCore.Authorization/IAuthorizationHandlerContextFactory.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Security.Claims;
+
+namespace Microsoft.AspNetCore.Authorization
+{
+    /// <summary>
+    /// A type used to provide a <see cref="AuthorizationHandlerContext"/> used for authorization.
+    /// </summary>
+    public interface IAuthorizationHandlerContextFactory
+    {
+        /// <summary>
+        /// Creates a <see cref="AuthorizationHandlerContext"/> used for authorization.
+        /// </summary>
+        /// <param name="requirements">The requirements to evaluate.</param>
+        /// <param name="user">The user to evaluate the requirements against.</param>
+        /// <param name="resource">
+        /// An optional resource the policy should be checked with.
+        /// If a resource is not required for policy evaluation you may pass null as the value.
+        /// </param>
+        /// <returns>The <see cref="AuthorizationHandlerContext"/>.</returns>
+        AuthorizationHandlerContext CreateContext(IEnumerable<IAuthorizationRequirement> requirements, ClaimsPrincipal user, object resource);
+    }
+}

--- a/test/Microsoft.AspNetCore.Authorization.Test/DefaultAuthorizationServiceTests.cs
+++ b/test/Microsoft.AspNetCore.Authorization.Test/DefaultAuthorizationServiceTests.cs
@@ -1019,5 +1019,30 @@ namespace Microsoft.AspNetCore.Authorization.Test
             Assert.True(await authorizationService.AuthorizeAsync(user, "2"));
             Assert.False(await authorizationService.AuthorizeAsync(user, "3"));
         }
+
+        public class SuccessEvaluator : IAuthorizationEvaluator
+        {
+            public bool HasFailed(AuthorizationHandlerContext context)
+            {
+                return false;
+            }
+
+            public bool HasSucceeded(AuthorizationHandlerContext context)
+            {
+                return true;
+            }
+        }
+
+        [Fact]
+        public async Task CanUseCustomEvaluatorThatOverridesRequirement()
+        {
+            var authorizationService = BuildAuthorizationService(services =>
+            {
+                // This will ignore the policy options
+                services.AddSingleton<IAuthorizationEvaluator, SuccessEvaluator>();
+                services.AddAuthorization(options => options.AddPolicy("Fail", p => p.RequireAssertion(c => false)));
+            });
+            Assert.True(await authorizationService.AuthorizeAsync(null, "Fail"));
+        }
     }
 }


### PR DESCRIPTION
@blowdart @divega 

Add a powerful new extensibility point, which enables plugging in different semantics for whether Authorize returns true or not.  

Not sure if we have to preserve old ctor parameters as well or not, just to be safe I added an additional ctor for back compat (but I'd prefer just to modify the original if possible)