### PR TITLE
Catch exception thrown from AuthenticationFailed.

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerHandler.cs
@@ -166,20 +166,30 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
             }
             catch (Exception ex)
             {
-                Logger.ErrorProcessingMessage(ex);
-
-                var authenticationFailedContext = new AuthenticationFailedContext(Context, Options)
+                try
                 {
-                    Exception = ex
-                };
+                    Logger.ErrorProcessingMessage(ex);
 
-                await Options.Events.AuthenticationFailed(authenticationFailedContext);
-                if (authenticationFailedContext.CheckEventResult(out result))
-                {
-                    return result;
+                    var authenticationFailedContext = new AuthenticationFailedContext(Context, Options)
+                    {
+                        Exception = ex
+                    };
+
+                    await Options.Events.AuthenticationFailed(authenticationFailedContext);
+                    if (authenticationFailedContext.CheckEventResult(out result))
+                    {
+                        return result;
+                    }
+                    else
+                    {
+                        return AuthenticateResult.Fail(ex);
+                    }
                 }
-
-                throw;
+                catch (Exception ex2)
+                {
+                    Logger.ErrorProcessingMessage(ex2);
+                    return AuthenticateResult.Fail(ex2);
+                }
             }
         }
 

--- a/test/Microsoft.AspNetCore.Authentication.Test/JwtBearer/JwtBearerMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/JwtBearer/JwtBearerMiddlewareTests.cs
@@ -59,6 +59,44 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
             Assert.Equal(HttpStatusCode.OK, transaction.Response.StatusCode);
         }
 
+        [Fact]
+        public async Task ThrowAtAuthenticationFailedEvent()
+        {
+            var options = new JwtBearerOptions
+            {
+                Events = new JwtBearerEvents
+                {
+                    OnAuthenticationFailed = context =>
+                    {
+                        context.Response.StatusCode = 401;
+                        throw new Exception();
+                    },
+                    OnMessageReceived = context =>
+                    {
+                        context.Token = "something";
+                        return Task.FromResult(0);
+                    }
+                }
+            };
+            options.SecurityTokenValidators.Clear();
+            options.SecurityTokenValidators.Insert(0, new InvalidTokenValidator());
+
+            var server = CreateServer(options, async (context, next) =>
+            {
+                try
+                {
+                    await next();
+                }
+                catch (Exception)
+                {
+                    Assert.False(true, "Exception shouldn't be thrown from middleware");
+                }
+            });
+
+            var transaction = await server.SendAsync("https://example.com/signIn");
+
+            Assert.Equal(HttpStatusCode.Unauthorized, transaction.Response.StatusCode);
+        }
 
         [Fact]
         public async Task CustomHeaderReceived()
@@ -104,7 +142,7 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
         public async Task HeaderWithoutBearerReceived()
         {
             var server = CreateServer(new JwtBearerOptions());
-            var response = await SendAsync(server, "http://example.com/oauth","Token");
+            var response = await SendAsync(server, "http://example.com/oauth", "Token");
             Assert.Equal(HttpStatusCode.Unauthorized, response.Response.StatusCode);
         }
 
@@ -347,7 +385,7 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
             var response = await SendAsync(server, "http://example.com/unauthorized", "Bearer Token");
             Assert.Equal(HttpStatusCode.Forbidden, response.Response.StatusCode);
         }
-        
+
         [Fact]
         public async Task BearerDoesNothingTo401IfNotAuthenticated()
         {
@@ -522,7 +560,7 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
             public string AuthenticationScheme { get; }
 
             public bool CanValidateToken => true;
-            
+
             public int MaximumTokenSizeInBytes
             {
                 get
@@ -558,11 +596,21 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
             }
         }
 
-        private static TestServer CreateServer(JwtBearerOptions options, Func<HttpContext, bool> handler = null)
+        private static TestServer CreateServer(JwtBearerOptions options)
+        {
+            return CreateServer(options, handleBeforeAuth: null);
+        }
+
+        private static TestServer CreateServer(JwtBearerOptions options, Func<HttpContext, Func<Task>, Task> handleBeforeAuth)
         {
             var builder = new WebHostBuilder()
                 .Configure(app =>
                 {
+                    if (handleBeforeAuth != null)
+                    {
+                        app.Use(handleBeforeAuth);
+                    }
+
                     if (options != null)
                     {
                         app.UseJwtBearerAuthentication(options);


### PR DESCRIPTION
Address issue #927 

Take two.

This is a smaller fix. Avoid re-thrown in the `catch` clause in JwtBearerHandler's authenticate method. 