### PR TITLE
Add fail fast option for AuthZ

### DIFF
--- a/src/Microsoft.AspNetCore.Authorization/AuthorizationOptions.cs
+++ b/src/Microsoft.AspNetCore.Authorization/AuthorizationOptions.cs
@@ -14,6 +14,12 @@ namespace Microsoft.AspNetCore.Authorization
         private IDictionary<string, AuthorizationPolicy> PolicyMap { get; } = new Dictionary<string, AuthorizationPolicy>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
+        /// Determines whether authentication handlers should be invoked after a failure.
+        /// Defaults to true.
+        /// </summary>
+        public bool InvokeHandlersAfterFailure { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets the default authorization policy.
         /// </summary>
         /// <remarks>

--- a/src/Microsoft.AspNetCore.Authorization/AuthorizationServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authorization/AuthorizationServiceCollectionExtensions.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(services));
             }
 
-            services.AddOptions();
             services.TryAdd(ServiceDescriptor.Transient<IAuthorizationService, DefaultAuthorizationService>());
             services.TryAdd(ServiceDescriptor.Transient<IAuthorizationPolicyProvider, DefaultAuthorizationPolicyProvider>());
             services.TryAdd(ServiceDescriptor.Transient<IAuthorizationEvaluator, DefaultAuthorizationEvaluator>());

--- a/src/Microsoft.AspNetCore.Authorization/AuthorizationServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authorization/AuthorizationServiceCollectionExtensions.cs
@@ -24,7 +24,8 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 throw new ArgumentNullException(nameof(services));
             }
-            
+
+            services.AddOptions();
             services.TryAdd(ServiceDescriptor.Transient<IAuthorizationService, DefaultAuthorizationService>());
             services.TryAdd(ServiceDescriptor.Transient<IAuthorizationPolicyProvider, DefaultAuthorizationPolicyProvider>());
             services.TryAdd(ServiceDescriptor.Transient<IAuthorizationEvaluator, DefaultAuthorizationEvaluator>());


### PR DESCRIPTION
@blowdart happy with the name: InvokeHandlersAfterFailure?

Fixes: https://github.com/aspnet/Security/issues/945