### PR TITLE
Made ChunkingCookieManager's default chunk size public AND Updated Authentication's Base64UrlTextEncoder to use WebUtilities's Base64UrlTextEncoder logic

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication/DataHandler/TextEncoder.cs
+++ b/src/Microsoft.AspNetCore.Authentication/DataHandler/TextEncoder.cs
@@ -1,31 +1,30 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-
 namespace Microsoft.AspNetCore.Authentication
 {
     public static class Base64UrlTextEncoder
     {
+        /// <summary>
+        /// Encodes supplied data into Base64 and replaces any URL encodable characters into non-URL encodable
+        /// characters.
+        /// </summary>
+        /// <param name="data">Data to be encoded.</param>
+        /// <returns>Base64 encoded string modified with non-URL encodable characters</returns>
         public static string Encode(byte[] data)
         {
-            return Convert.ToBase64String(data).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+            return WebUtilities.Base64UrlTextEncoder.Encode(data);
         }
 
+        /// <summary>
+        /// Decodes supplied string by replacing the non-URL encodable characters with URL encodable characters and
+        /// then decodes the Base64 string.
+        /// </summary>
+        /// <param name="text">The string to be decoded.</param>
+        /// <returns>The decoded data.</returns>
         public static byte[] Decode(string text)
         {
-            return Convert.FromBase64String(Pad(text.Replace('-', '+').Replace('_', '/')));
+            return WebUtilities.Base64UrlTextEncoder.Decode(text);
         }
-
-        private static string Pad(string text)
-        {
-            var padding = 3 - ((text.Length + 3) % 4);
-            if (padding == 0)
-            {
-                return text;
-            }
-            return text + new string('=', padding);
-        }
-
     }
 }

--- a/src/Microsoft.AspNetCore.ChunkingCookieManager.Sources/ChunkingCookieManager.cs
+++ b/src/Microsoft.AspNetCore.ChunkingCookieManager.Sources/ChunkingCookieManager.cs
@@ -30,6 +30,11 @@ namespace Microsoft.AspNetCore.Internal
     internal class ChunkingCookieManager
     {
 #endif
+        /// <summary>
+        /// The default maximum size of characters in a cookie to send back to the client.
+        /// </summary>
+        public const int DefaultChunkSize = 4070;
+
         private const string ChunkKeySuffix = "C";
         private const string ChunkCountPrefix = "chunks-";
 
@@ -38,7 +43,7 @@ namespace Microsoft.AspNetCore.Internal
             // Lowest common denominator. Safari has the lowest known limit (4093), and we leave little extra just in case.
             // See http://browsercookielimits.x64.me/.
             // Leave at least 20 in case CookiePolicy tries to add 'secure' and/or 'httponly'.
-            ChunkSize = 4070;
+            ChunkSize = DefaultChunkSize;
             ThrowForPartialCookies = true;
         }
 


### PR DESCRIPTION
@Tratcher Couple of minor changes...I plan to keep these as separate commits when merging...