### PR TITLE
Ensure redirect uris can be generated

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
@@ -208,6 +208,12 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
 
             message.State = Options.StateDataFormat.Protect(properties);
 
+            if (string.IsNullOrEmpty(message.IssuerAddress))
+            {
+                throw new InvalidOperationException(
+                    "Cannot redirect to the end session endpoint, the configuration may be missing or invalid.");
+            }
+
             if (Options.AuthenticationMethod == OpenIdConnectRedirectBehavior.RedirectGet)
             {
                 var redirectUri = message.CreateLogoutRequestUrl();
@@ -355,6 +361,12 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
             properties.Items.Add(OpenIdConnectDefaults.RedirectUriForCodePropertiesKey, message.RedirectUri);
 
             message.State = Options.StateDataFormat.Protect(properties);
+
+            if (string.IsNullOrEmpty(message.IssuerAddress))
+            {
+                throw new InvalidOperationException(
+                    "Cannot redirect to the authorization endpoint, the configuration may be missing or invalid.");
+            }
 
             if (Options.AuthenticationMethod == OpenIdConnectRedirectBehavior.RedirectGet)
             {

--- a/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectChallengeTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectChallengeTests.cs
@@ -222,6 +222,7 @@ namespace Microsoft.AspNetCore.Authentication.Tests.OpenIdConnect
         {
             var newMessage = new MockOpenIdConnectMessage
             {
+                IssuerAddress = "http://example.com/",
                 TestAuthorizeEndpoint = $"http://example.com/{Guid.NewGuid()}/oauth2/signin"
             };
 
@@ -321,6 +322,17 @@ namespace Microsoft.AspNetCore.Authentication.Tests.OpenIdConnect
             var secondCookie = transaction.SetCookie.Skip(1).First();
             Assert.StartsWith(".AspNetCore.Correlation.OpenIdConnect.", secondCookie);
             Assert.Contains("expires", secondCookie);
+        }
+
+        [Fact]
+        public async Task Challenge_WithEmptyConfig_Fails()
+        {
+            var settings = new TestSettings(
+                opt => opt.Configuration = new OpenIdConnectConfiguration());
+
+            var server = settings.CreateTestServer();
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => server.SendAsync(ChallengeEndpoint));
+            Assert.Equal("Cannot redirect to the authorization endpoint, the configuration may be missing or invalid.", exception.Message);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectMiddlewareTests.cs
@@ -135,6 +135,17 @@ namespace Microsoft.AspNetCore.Authentication.Tests.OpenIdConnect
             Assert.Equal("http://www.example.com/specific_redirect_uri", properties.RedirectUri, true);
         }
 
+        [Fact]
+        public async Task SignOut_WithMissingConfig_Throws()
+        {
+            var setting = new TestSettings(opt => opt.Configuration = new OpenIdConnectConfiguration());
+
+            var server = setting.CreateTestServer();
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => server.SendAsync(DefaultHost + TestServerBuilder.Signout));
+            Assert.Equal("Cannot redirect to the end session endpoint, the configuration may be missing or invalid.", exception.Message);
+        }
+
         // Test Cases for calculating the expiration time of cookie from cookie name
         [Fact]
         public void NonceCookieExpirationTime()


### PR DESCRIPTION
#903 @HaoK @brentschmaltz @PinpointTownes 
This helps users discover middleware configuration errors that may otherwise result in infinite challenge redirects.