### PR TITLE
Update launchSettings for new VS 2017 rules

### DIFF
--- a/samples/CookieSample/Properties/launchSettings.json
+++ b/samples/CookieSample/Properties/launchSettings.json
@@ -18,10 +18,9 @@
     "CookieSample": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "http://localhost:12345",
+      "applicationUrl": "http://localhost:12345",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_URLS": "http://localhost:12345"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
   }

--- a/samples/CookieSessionSample/Properties/launchSettings.json
+++ b/samples/CookieSessionSample/Properties/launchSettings.json
@@ -18,10 +18,9 @@
     "CookieSessionSample": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "http://localhost:12345",
+      "applicationUrl": "http://localhost:12345",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_URLS": "http://localhost:12345"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
   }

--- a/samples/JwtBearerSample/Properties/launchSettings.json
+++ b/samples/JwtBearerSample/Properties/launchSettings.json
@@ -18,10 +18,9 @@
     "JwtBearer": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "http://localhost:42023",
+      "applicationUrl": "http://localhost:42023",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_URLS": "http://localhost:42023"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
   }

--- a/samples/OpenIdConnect.AzureAdSample/Properties/launchSettings.json
+++ b/samples/OpenIdConnect.AzureAdSample/Properties/launchSettings.json
@@ -18,10 +18,9 @@
     "OpenIdConnect": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "http://localhost:42023",
+      "applicationUrl": "http://localhost:42023",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_URLS": "http://localhost:42023"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
   }

--- a/samples/OpenIdConnectSample/Properties/launchSettings.json
+++ b/samples/OpenIdConnectSample/Properties/launchSettings.json
@@ -19,9 +19,8 @@
     "OpenIdConnectSample": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "https://localhost:44318/",
+      "applicationUrl": "https://localhost:44318/",
       "environmentVariables": {
-        "ASPNETCORE_URLS": "https://localhost:44318/",
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }

--- a/samples/SocialSample/Properties/launchSettings.json
+++ b/samples/SocialSample/Properties/launchSettings.json
@@ -19,10 +19,9 @@
     "SocialSample": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "https://localhost:44318/",
+      "applicationUrl": "https://localhost:44318/",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_URLS": "https://localhost:44318/"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
   }


### PR DESCRIPTION
VS 2017 changes the launch url mechanics for self-host. Before we set launchUrl and ASPNETCORE_URLS, but now we only need to set applicationUrl and VS will set the other two from that value.

Note most of these projects need a specific port because that's what's registered with the 3rd party providers like Facebook.