### PR TITLE
Fix SystemClock precision errors

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication/SystemClock.cs
+++ b/src/Microsoft.AspNetCore.Authentication/SystemClock.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Authentication
                 // the clock measures whole seconds only, to have integral expires_in results, and
                 // because milliseconds do not round-trip serialization formats
                 DateTimeOffset utcNow = DateTimeOffset.UtcNow;
-                return utcNow.AddMilliseconds(-utcNow.Millisecond);
+                return utcNow.AddTicks(-(utcNow.Ticks % 10000000));
             }
         }
     }


### PR DESCRIPTION
Substracting milliseconds left nanoseconds part.

Closes #1110.