### PR TITLE
AddXyz() binds to default config section

### DIFF
--- a/samples/OpenIdConnect.AzureAdSample/Startup.cs
+++ b/samples/OpenIdConnect.AzureAdSample/Startup.cs
@@ -72,7 +72,7 @@ namespace OpenIdConnect.AzureAdSample
             });
 
             services.AddAuthentication(sharedOptions =>
-                sharedOptions.DefaultAuthenticationScheme = CookieAuthenticationDefaults.AuthenticationScheme);
+                sharedOptions.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme);
         }
 
         public void Configure(IApplicationBuilder app, ILoggerFactory loggerfactory)

--- a/samples/OpenIdConnectSample/Startup.cs
+++ b/samples/OpenIdConnectSample/Startup.cs
@@ -71,7 +71,7 @@ namespace OpenIdConnectSample
 
             services.AddAuthentication(sharedOptions =>
             {
-                sharedOptions.DefaultAuthenticationScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                sharedOptions.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                 sharedOptions.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
             });
         }

--- a/samples/SocialSample/Startup.cs
+++ b/samples/SocialSample/Startup.cs
@@ -201,7 +201,7 @@ namespace SocialSample
                 };
             });
 
-            services.AddAuthentication(options => options.DefaultAuthenticationScheme = CookieAuthenticationDefaults.AuthenticationScheme);
+            services.AddAuthentication(options => options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme);
         }
 
         public void Configure(IApplicationBuilder app, ILoggerFactory loggerfactory)

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookConfigureOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookConfigureOptions.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Authentication.Facebook
+{
+    internal class FacebookConfigureOptions : ConfigureNamedOptions<FacebookOptions>
+    {
+        // Bind to "Google" section by default
+        public FacebookConfigureOptions(IConfiguration config) :
+            base(FacebookDefaults.AuthenticationScheme,
+                options => config.GetSection(FacebookDefaults.AuthenticationScheme).Bind(options))
+        { }
+    }
+}

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookConfigureOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookConfigureOptions.cs
@@ -8,7 +8,6 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
 {
     internal class FacebookConfigureOptions : ConfigureNamedOptions<FacebookOptions>
     {
-        // Bind to "Google" section by default
         public FacebookConfigureOptions(IConfiguration config) :
             base(FacebookDefaults.AuthenticationScheme,
                 options => config.GetSection(FacebookDefaults.AuthenticationScheme).Bind(options))

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookExtensions.cs
@@ -3,11 +3,24 @@
 
 using System;
 using Microsoft.AspNetCore.Authentication.Facebook;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
     public static class FacebookAuthenticationOptionsExtensions
     {
+        /// <summary>
+        /// Adds facebook authentication with options bound against the "Facebook" section 
+        /// from the IConfiguration in the service container.
+        /// </summary>
+        /// <param name="services"></param>
+        /// <returns></returns>
+        public static IServiceCollection AddFacebookAuthentication(this IServiceCollection services)
+        {
+            services.AddSingleton<IConfigureOptions<FacebookOptions>, FacebookConfigureOptions>();
+            return services.AddFacebookAuthentication(o => { });
+        }
+
         public static IServiceCollection AddFacebookAuthentication(this IServiceCollection services, Action<FacebookOptions> configureOptions) 
             => services.AddFacebookAuthentication(FacebookDefaults.AuthenticationScheme, configureOptions);
 

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookExtensions.cs
@@ -16,15 +16,15 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services"></param>
         /// <returns></returns>
         public static IServiceCollection AddFacebookAuthentication(this IServiceCollection services)
-        {
-            services.AddSingleton<IConfigureOptions<FacebookOptions>, FacebookConfigureOptions>();
-            return services.AddFacebookAuthentication(o => { });
-        }
+            => services.AddFacebookAuthentication(FacebookDefaults.AuthenticationScheme, _ => { });
 
         public static IServiceCollection AddFacebookAuthentication(this IServiceCollection services, Action<FacebookOptions> configureOptions) 
             => services.AddFacebookAuthentication(FacebookDefaults.AuthenticationScheme, configureOptions);
 
-        public static IServiceCollection AddFacebookAuthentication(this IServiceCollection services, string authenticationScheme, Action<FacebookOptions> configureOptions) 
-            => services.AddScheme<FacebookOptions, FacebookHandler>(authenticationScheme, configureOptions);
+        public static IServiceCollection AddFacebookAuthentication(this IServiceCollection services, string authenticationScheme, Action<FacebookOptions> configureOptions)
+        {
+            services.AddSingleton<IConfigureOptions<FacebookOptions>, FacebookConfigureOptions>();
+            return services.AddScheme<FacebookOptions, FacebookHandler>(authenticationScheme, configureOptions);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/Microsoft.AspNetCore.Authentication.Facebook.csproj
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/Microsoft.AspNetCore.Authentication.Facebook.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.AspNetCore.Authentication.OAuth\Microsoft.AspNetCore.Authentication.OAuth.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.AspNetCore.Authentication.Google/GoogleConfigureOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Google/GoogleConfigureOptions.cs
@@ -8,7 +8,6 @@ namespace Microsoft.AspNetCore.Authentication.Google
 {
     internal class GoogleConfigureOptions : ConfigureNamedOptions<GoogleOptions>
     {
-        // Bind to "Google" section by default
         public GoogleConfigureOptions(IConfiguration config) :
             base(GoogleDefaults.AuthenticationScheme,
                 options => config.GetSection(GoogleDefaults.AuthenticationScheme).Bind(options))

--- a/src/Microsoft.AspNetCore.Authentication.Google/GoogleExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Google/GoogleExtensions.cs
@@ -16,15 +16,15 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services"></param>
         /// <returns></returns>
         public static IServiceCollection AddGoogleAuthentication(this IServiceCollection services)
+            => services.AddGoogleAuthentication(GoogleDefaults.AuthenticationScheme, _ => { });
+
+        public static IServiceCollection AddGoogleAuthentication(this IServiceCollection services, Action<GoogleOptions> configureOptions) 
+            => services.AddGoogleAuthentication(GoogleDefaults.AuthenticationScheme, configureOptions);
+
+        public static IServiceCollection AddGoogleAuthentication(this IServiceCollection services, string authenticationScheme, Action<GoogleOptions> configureOptions)
         {
             services.AddSingleton<IConfigureOptions<GoogleOptions>, GoogleConfigureOptions>();
-            return services.AddGoogleAuthentication(o => { });
+            return services.AddScheme<GoogleOptions, GoogleHandler>(authenticationScheme, configureOptions);
         }
-
-        public static IServiceCollection AddGoogleAuthentication(this IServiceCollection services, Action<GoogleOptions> configureOptions) =>
-            services.AddGoogleAuthentication(GoogleDefaults.AuthenticationScheme, configureOptions);
-
-        public static IServiceCollection AddGoogleAuthentication(this IServiceCollection services, string authenticationScheme, Action<GoogleOptions> configureOptions) =>
-            services.AddScheme<GoogleOptions, GoogleHandler>(authenticationScheme, configureOptions);
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerConfigureOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerConfigureOptions.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Authentication.JwtBearer
+{
+    internal class JwtBearerConfigureOptions : ConfigureNamedOptions<JwtBearerOptions>
+    {
+        // Bind to "Bearer" section by default
+        public JwtBearerConfigureOptions(IConfiguration config) :
+            base(JwtBearerDefaults.AuthenticationScheme,
+                options => config.GetSection(JwtBearerDefaults.AuthenticationScheme).Bind(options))
+        { }
+    }
+}

--- a/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerExtensions.cs
@@ -16,15 +16,15 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services"></param>
         /// <returns></returns>
         public static IServiceCollection AddJwtBearerAuthentication(this IServiceCollection services)
+            => services.AddJwtBearerAuthentication(JwtBearerDefaults.AuthenticationScheme, _ => { });
+
+        public static IServiceCollection AddJwtBearerAuthentication(this IServiceCollection services, Action<JwtBearerOptions> configureOptions) 
+            => services.AddJwtBearerAuthentication(JwtBearerDefaults.AuthenticationScheme, configureOptions);
+
+        public static IServiceCollection AddJwtBearerAuthentication(this IServiceCollection services, string authenticationScheme, Action<JwtBearerOptions> configureOptions)
         {
             services.AddSingleton<IConfigureOptions<JwtBearerOptions>, JwtBearerConfigureOptions>();
-            return services.AddJwtBearerAuthentication(o => { });
+            return services.AddScheme<JwtBearerOptions, JwtBearerHandler>(authenticationScheme, configureOptions);
         }
-
-        public static IServiceCollection AddJwtBearerAuthentication(this IServiceCollection services, Action<JwtBearerOptions> configureOptions) =>
-            services.AddJwtBearerAuthentication(JwtBearerDefaults.AuthenticationScheme, configureOptions);
-
-        public static IServiceCollection AddJwtBearerAuthentication(this IServiceCollection services, string authenticationScheme, Action<JwtBearerOptions> configureOptions) =>
-            services.AddScheme<JwtBearerOptions, JwtBearerHandler>(authenticationScheme, configureOptions);
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerExtensions.cs
@@ -3,11 +3,24 @@
 
 using System;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
     public static class JwtBearerExtensions
     {
+        /// <summary>
+        /// Adds JwtBearer authentication with options bound against the "Bearer" section 
+        /// from the IConfiguration in the service container.
+        /// </summary>
+        /// <param name="services"></param>
+        /// <returns></returns>
+        public static IServiceCollection AddJwtBearerAuthentication(this IServiceCollection services)
+        {
+            services.AddSingleton<IConfigureOptions<JwtBearerOptions>, JwtBearerConfigureOptions>();
+            return services.AddJwtBearerAuthentication(o => { });
+        }
+
         public static IServiceCollection AddJwtBearerAuthentication(this IServiceCollection services, Action<JwtBearerOptions> configureOptions) =>
             services.AddJwtBearerAuthentication(JwtBearerDefaults.AuthenticationScheme, configureOptions);
 

--- a/src/Microsoft.AspNetCore.Authentication.JwtBearer/Microsoft.AspNetCore.Authentication.JwtBearer.csproj
+++ b/src/Microsoft.AspNetCore.Authentication.JwtBearer/Microsoft.AspNetCore.Authentication.JwtBearer.csproj
@@ -11,6 +11,7 @@
     <ProjectReference Include="..\Microsoft.AspNetCore.Authentication\Microsoft.AspNetCore.Authentication.csproj" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(IdentityModelOpenIdVersion)" />
     <PackageReference Include="System.Security.Claims" Version="$(CoreFxVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.TaskCache.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/Microsoft.AspNetCore.Authentication.MicrosoftAccount.csproj
+++ b/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/Microsoft.AspNetCore.Authentication.MicrosoftAccount.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.AspNetCore.Authentication.OAuth\Microsoft.AspNetCore.Authentication.OAuth.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountConfigureOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountConfigureOptions.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
+{
+    internal class MicrosoftAccountConfigureOptions : ConfigureNamedOptions<MicrosoftAccountOptions>
+    {
+        // Bind to "Microsoft" section by default
+        public MicrosoftAccountConfigureOptions(IConfiguration config) :
+            base(MicrosoftAccountDefaults.AuthenticationScheme,
+                options => config.GetSection(MicrosoftAccountDefaults.AuthenticationScheme).Bind(options))
+        { }
+    }
+}

--- a/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountExtensions.cs
@@ -16,15 +16,15 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services"></param>
         /// <returns></returns>
         public static IServiceCollection AddMicrosoftAccountAuthentication(this IServiceCollection services)
-        {
-            services.AddSingleton<IConfigureOptions<MicrosoftAccountOptions>, MicrosoftAccountConfigureOptions>();
-            return services.AddMicrosoftAccountAuthentication(o => { });
-        }
+            => services.AddMicrosoftAccountAuthentication(MicrosoftAccountDefaults.AuthenticationScheme, o => { });
 
         public static IServiceCollection AddMicrosoftAccountAuthentication(this IServiceCollection services, Action<MicrosoftAccountOptions> configureOptions) =>
             services.AddMicrosoftAccountAuthentication(MicrosoftAccountDefaults.AuthenticationScheme, configureOptions);
 
-        public static IServiceCollection AddMicrosoftAccountAuthentication(this IServiceCollection services, string authenticationScheme, Action<MicrosoftAccountOptions> configureOptions) =>
-            services.AddScheme<MicrosoftAccountOptions, MicrosoftAccountHandler>(authenticationScheme, configureOptions);
+        public static IServiceCollection AddMicrosoftAccountAuthentication(this IServiceCollection services, string authenticationScheme, Action<MicrosoftAccountOptions> configureOptions)
+        {
+            services.AddSingleton<IConfigureOptions<MicrosoftAccountOptions>, MicrosoftAccountConfigureOptions>();
+            return services.AddScheme<MicrosoftAccountOptions, MicrosoftAccountHandler>(authenticationScheme, configureOptions);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountExtensions.cs
@@ -3,12 +3,24 @@
 
 using System;
 using Microsoft.AspNetCore.Authentication.MicrosoftAccount;
-using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
     public static class MicrosoftAccountExtensions
     {
+        /// <summary>
+        /// Adds MicrosoftAccount authentication with options bound against the "Microsoft" section 
+        /// from the IConfiguration in the service container.
+        /// </summary>
+        /// <param name="services"></param>
+        /// <returns></returns>
+        public static IServiceCollection AddMicrosoftAccountAuthentication(this IServiceCollection services)
+        {
+            services.AddSingleton<IConfigureOptions<MicrosoftAccountOptions>, MicrosoftAccountConfigureOptions>();
+            return services.AddMicrosoftAccountAuthentication(o => { });
+        }
+
         public static IServiceCollection AddMicrosoftAccountAuthentication(this IServiceCollection services, Action<MicrosoftAccountOptions> configureOptions) =>
             services.AddMicrosoftAccountAuthentication(MicrosoftAccountDefaults.AuthenticationScheme, configureOptions);
 

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/Microsoft.AspNetCore.Authentication.OpenIdConnect.csproj
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/Microsoft.AspNetCore.Authentication.OpenIdConnect.csproj
@@ -11,6 +11,7 @@
     <ProjectReference Include="..\Microsoft.AspNetCore.Authentication.OAuth\Microsoft.AspNetCore.Authentication.OAuth.csproj" />
     <PackageReference Include="Microsoft.Extensions.TaskCache.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(IdentityModelOpenIdVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="System.Security.Claims" Version="$(CoreFxVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectConfigureOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectConfigureOptions.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
+{
+    internal class OpenIdConnectConfigureOptions : ConfigureNamedOptions<OpenIdConnectOptions>
+    {
+        // Bind to "OpenIdConnect" section by default
+        public OpenIdConnectConfigureOptions(IConfiguration config) :
+            base(OpenIdConnectDefaults.AuthenticationScheme,
+                options => config.GetSection(OpenIdConnectDefaults.AuthenticationScheme).Bind(options))
+        { }
+    }
+}

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectExtensions.cs
@@ -3,11 +3,24 @@
 
 using System;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
     public static class OpenIdConnectExtensions
     {
+        /// <summary>
+        /// Adds OpenIdConnect authentication with options bound against the "OpenIdConnect" section 
+        /// from the IConfiguration in the service container.
+        /// </summary>
+        /// <param name="services"></param>
+        /// <returns></returns>
+        public static IServiceCollection AddOpenIdConnectAuthentication(this IServiceCollection services)
+        {
+            services.AddSingleton<IConfigureOptions<OpenIdConnectOptions>, OpenIdConnectConfigureOptions>();
+            return services.AddOpenIdConnectAuthentication(o => { });
+        }
+
         public static IServiceCollection AddOpenIdConnectAuthentication(this IServiceCollection services, Action<OpenIdConnectOptions> configureOptions) =>
             services.AddOpenIdConnectAuthentication(OpenIdConnectDefaults.AuthenticationScheme, configureOptions);
 

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectExtensions.cs
@@ -16,19 +16,15 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services"></param>
         /// <returns></returns>
         public static IServiceCollection AddOpenIdConnectAuthentication(this IServiceCollection services)
-        {
-            services.AddSingleton<IConfigureOptions<OpenIdConnectOptions>, OpenIdConnectConfigureOptions>();
-            return services.AddOpenIdConnectAuthentication(o => { });
-        }
+            => services.AddOpenIdConnectAuthentication(OpenIdConnectDefaults.AuthenticationScheme, _ => { });
 
-        public static IServiceCollection AddOpenIdConnectAuthentication(this IServiceCollection services, Action<OpenIdConnectOptions> configureOptions) =>
-            services.AddOpenIdConnectAuthentication(OpenIdConnectDefaults.AuthenticationScheme, configureOptions);
+        public static IServiceCollection AddOpenIdConnectAuthentication(this IServiceCollection services, Action<OpenIdConnectOptions> configureOptions) 
+            => services.AddOpenIdConnectAuthentication(OpenIdConnectDefaults.AuthenticationScheme, configureOptions);
 
         public static IServiceCollection AddOpenIdConnectAuthentication(this IServiceCollection services, string authenticationScheme, Action<OpenIdConnectOptions> configureOptions)
         {
-            //services.AddRemoteScheme<OpenIdConnectOptions, OpenIdConnectHandler>(authenticationScheme, configureOptions, o => new PathString[] { o.CallbackPath, o.SignedOutCallbackPath, o.RemoteSignOutPath });
-            services.AddScheme<OpenIdConnectOptions, OpenIdConnectHandler>(authenticationScheme, configureOptions);
-            return services;
+            services.AddSingleton<IConfigureOptions<OpenIdConnectOptions>, OpenIdConnectConfigureOptions>();
+            return services.AddScheme<OpenIdConnectOptions, OpenIdConnectHandler>(authenticationScheme, configureOptions);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.Twitter/Microsoft.AspNetCore.Authentication.Twitter.csproj
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/Microsoft.AspNetCore.Authentication.Twitter.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.AspNetCore.Authentication.OAuth\Microsoft.AspNetCore.Authentication.OAuth.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.TaskCache.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterConfigureOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterConfigureOptions.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Authentication.Twitter
+{
+    internal class TwitterConfigureOptions : ConfigureNamedOptions<TwitterOptions>
+    {
+        // Bind to "Twitter" section by default
+        public TwitterConfigureOptions(IConfiguration config) :
+            base(TwitterDefaults.AuthenticationScheme,
+                options => config.GetSection(TwitterDefaults.AuthenticationScheme).Bind(options))
+        { }
+    }
+}

--- a/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterExtensions.cs
@@ -3,11 +3,24 @@
 
 using System;
 using Microsoft.AspNetCore.Authentication.Twitter;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
     public static class TwitterExtensions
     {
+        /// <summary>
+        /// Adds Twitter authentication with options bound against the "Twitter" section 
+        /// from the IConfiguration in the service container.
+        /// </summary>
+        /// <param name="services"></param>
+        /// <returns></returns>
+        public static IServiceCollection AddTwitterAuthentication(this IServiceCollection services)
+        {
+            services.AddSingleton<IConfigureOptions<TwitterOptions>, TwitterConfigureOptions>();
+            return services.AddTwitterAuthentication(o => { });
+        }
+
         public static IServiceCollection AddTwitterAuthentication(this IServiceCollection services, Action<TwitterOptions> configureOptions) =>
             services.AddTwitterAuthentication(TwitterDefaults.AuthenticationScheme, configureOptions);
 

--- a/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterExtensions.cs
@@ -16,15 +16,15 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services"></param>
         /// <returns></returns>
         public static IServiceCollection AddTwitterAuthentication(this IServiceCollection services)
+            => services.AddTwitterAuthentication(TwitterDefaults.AuthenticationScheme, _ => { });
+
+        public static IServiceCollection AddTwitterAuthentication(this IServiceCollection services, Action<TwitterOptions> configureOptions)
+            => services.AddTwitterAuthentication(TwitterDefaults.AuthenticationScheme, configureOptions);
+
+        public static IServiceCollection AddTwitterAuthentication(this IServiceCollection services, string authenticationScheme, Action<TwitterOptions> configureOptions)
         {
             services.AddSingleton<IConfigureOptions<TwitterOptions>, TwitterConfigureOptions>();
-            return services.AddTwitterAuthentication(o => { });
+            return services.AddScheme<TwitterOptions, TwitterHandler>(authenticationScheme, configureOptions);
         }
-
-        public static IServiceCollection AddTwitterAuthentication(this IServiceCollection services, Action<TwitterOptions> configureOptions) =>
-            services.AddTwitterAuthentication(TwitterDefaults.AuthenticationScheme, configureOptions);
-
-        public static IServiceCollection AddTwitterAuthentication(this IServiceCollection services, string authenticationScheme, Action<TwitterOptions> configureOptions) =>
-            services.AddScheme<TwitterOptions, TwitterHandler>(authenticationScheme, configureOptions);
     }
 }

--- a/test/Microsoft.AspNetCore.Authentication.Test/FacebookTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/FacebookTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -15,8 +16,10 @@ using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -24,6 +27,25 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
 {
     public class FacebookTests
     {
+        [Fact]
+        public void AddCanBindAgainstDefaultConfig()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"Facebook:AppId", "<id>"},
+                {"Facebook:AppSecret", "<secret>"}
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            var config = configurationBuilder.Build();
+            var services = new ServiceCollection().AddFacebookAuthentication().AddSingleton<IConfiguration>(config);
+            var sp = services.BuildServiceProvider();
+
+            var options = sp.GetRequiredService<IOptionsSnapshot<FacebookOptions>>().Get(FacebookDefaults.AuthenticationScheme);
+            Assert.Equal("<id>", options.AppId);
+            Assert.Equal("<secret>", options.AppSecret);
+        }
+
         [Fact]
         public async Task ThrowsIfAppIdMissing()
         {

--- a/test/Microsoft.AspNetCore.Authentication.Test/FacebookTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/FacebookTests.cs
@@ -33,7 +33,18 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             var dic = new Dictionary<string, string>
             {
                 {"Facebook:AppId", "<id>"},
-                {"Facebook:AppSecret", "<secret>"}
+                {"Facebook:AppSecret", "<secret>"},
+                {"Facebook:AuthorizationEndpoint", "<authEndpoint>"},
+                {"Facebook:BackchannelTimeout", "0.0:0:30"},
+                //{"Facebook:CallbackPath", "/callbackpath"}, // PathString doesn't convert
+                {"Facebook:ClaimsIssuer", "<issuer>"},
+                {"Facebook:DisplayName", "<display>"},
+                {"Facebook:RemoteAuthenticationTimeout", "0.0:0:30"},
+                {"Facebook:SaveTokens", "true"},
+                {"Facebook:SendAppSecretProof", "true"},
+                {"Facebook:SignInScheme", "<signIn>"},
+                {"Facebook:TokenEndpoint", "<tokenEndpoint>"},
+                {"Facebook:UserInformationEndpoint", "<userEndpoint>"},
             };
             var configurationBuilder = new ConfigurationBuilder();
             configurationBuilder.AddInMemoryCollection(dic);
@@ -44,6 +55,62 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             var options = sp.GetRequiredService<IOptionsSnapshot<FacebookOptions>>().Get(FacebookDefaults.AuthenticationScheme);
             Assert.Equal("<id>", options.AppId);
             Assert.Equal("<secret>", options.AppSecret);
+            Assert.Equal("<authEndpoint>", options.AuthorizationEndpoint);
+            Assert.Equal(new TimeSpan(0, 0, 0, 30), options.BackchannelTimeout);
+            //Assert.Equal("/callbackpath", options.CallbackPath); // NOTE: PathString doesn't convert
+            Assert.Equal("<issuer>", options.ClaimsIssuer);
+            Assert.Equal("<id>", options.ClientId);
+            Assert.Equal("<secret>", options.ClientSecret);
+            Assert.Equal("<display>", options.DisplayName);
+            Assert.Equal(new TimeSpan(0, 0, 0, 30), options.RemoteAuthenticationTimeout);
+            Assert.True(options.SaveTokens);
+            Assert.True(options.SendAppSecretProof);
+            Assert.Equal("<signIn>", options.SignInScheme);
+            Assert.Equal("<tokenEndpoint>", options.TokenEndpoint);
+            Assert.Equal("<userEndpoint>", options.UserInformationEndpoint);
+        }
+
+        [Fact]
+        public void AddCanBindAgainstDefaultConfigAndOverride()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"Facebook:AppId", "<id>"},
+                {"Facebook:AppSecret", "<secret>"},
+                {"Facebook:AuthorizationEndpoint", "<authEndpoint>"},
+                {"Facebook:BackchannelTimeout", "0.0:0:30"},
+                //{"Facebook:CallbackPath", "/callbackpath"}, // PathString doesn't convert
+                {"Facebook:ClaimsIssuer", "<issuer>"},
+                {"Facebook:DisplayName", "<display>"},
+                {"Facebook:RemoteAuthenticationTimeout", "0.0:0:30"},
+                {"Facebook:SaveTokens", "true"},
+                {"Facebook:SendAppSecretProof", "true"},
+                {"Facebook:SignInScheme", "<signIn>"},
+                {"Facebook:TokenEndpoint", "<tokenEndpoint>"},
+                {"Facebook:UserInformationEndpoint", "<userEndpoint>"},
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            var config = configurationBuilder.Build();
+            var services = new ServiceCollection().AddFacebookAuthentication(o => o.SaveTokens = false).AddSingleton<IConfiguration>(config);
+            var sp = services.BuildServiceProvider();
+
+            var options = sp.GetRequiredService<IOptionsSnapshot<FacebookOptions>>().Get(FacebookDefaults.AuthenticationScheme);
+            Assert.Equal("<id>", options.AppId);
+            Assert.Equal("<secret>", options.AppSecret);
+            Assert.Equal("<authEndpoint>", options.AuthorizationEndpoint);
+            Assert.Equal(new TimeSpan(0, 0, 0, 30), options.BackchannelTimeout);
+            //Assert.Equal("/callbackpath", options.CallbackPath); // NOTE: PathString doesn't convert
+            Assert.Equal("<issuer>", options.ClaimsIssuer);
+            Assert.Equal("<id>", options.ClientId);
+            Assert.Equal("<secret>", options.ClientSecret);
+            Assert.Equal("<display>", options.DisplayName);
+            Assert.Equal(new TimeSpan(0, 0, 0, 30), options.RemoteAuthenticationTimeout);
+            Assert.False(options.SaveTokens);
+            Assert.True(options.SendAppSecretProof);
+            Assert.Equal("<signIn>", options.SignInScheme);
+            Assert.Equal("<tokenEndpoint>", options.TokenEndpoint);
+            Assert.Equal("<userEndpoint>", options.UserInformationEndpoint);
         }
 
         [Fact]
@@ -91,7 +158,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
                     services.AddAuthentication(options =>
                     {
                         options.DefaultSignInScheme = "External";
-                        options.DefaultAuthenticationScheme = "External";
+                        options.DefaultAuthenticateScheme = "External";
                     });
                     services.AddCookieAuthentication("External", o => { });
                     services.AddFacebookAuthentication(o =>
@@ -233,7 +300,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
                     services.AddAuthentication(options =>
                     {
                         options.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-                        options.DefaultAuthenticationScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                        options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                     });
                     services.AddCookieAuthentication();
                     services.AddFacebookAuthentication(o => 

--- a/test/Microsoft.AspNetCore.Authentication.Test/GoogleTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/GoogleTests.cs
@@ -27,12 +27,23 @@ namespace Microsoft.AspNetCore.Authentication.Google
     public class GoogleTests
     {
         [Fact]
-        public void AddGoogleCanBindAgainstDefaultConfig()
+        public void AddCanBindAgainstDefaultConfig()
         {
             var dic = new Dictionary<string, string>
             {
                 {"Google:ClientId", "<id>"},
-                {"Google:ClientSecret", "<secret>"}
+                {"Google:ClientSecret", "<secret>"},
+                {"Google:AuthorizationEndpoint", "<authEndpoint>"},
+                {"Google:BackchannelTimeout", "0.0:0:30"},
+                //{"Google:CallbackPath", "/callbackpath"}, // PathString doesn't convert
+                {"Google:ClaimsIssuer", "<issuer>"},
+                {"Google:DisplayName", "<display>"},
+                {"Google:RemoteAuthenticationTimeout", "0.0:0:30"},
+                {"Google:SaveTokens", "true"},
+                {"Google:SendAppSecretProof", "true"},
+                {"Google:SignInScheme", "<signIn>"},
+                {"Google:TokenEndpoint", "<tokenEndpoint>"},
+                {"Google:UserInformationEndpoint", "<userEndpoint>"},
             };
             var configurationBuilder = new ConfigurationBuilder();
             configurationBuilder.AddInMemoryCollection(dic);
@@ -41,8 +52,58 @@ namespace Microsoft.AspNetCore.Authentication.Google
             var sp = services.BuildServiceProvider();
 
             var options = sp.GetRequiredService<IOptionsSnapshot<GoogleOptions>>().Get(GoogleDefaults.AuthenticationScheme);
+            Assert.Equal("<authEndpoint>", options.AuthorizationEndpoint);
+            Assert.Equal(new TimeSpan(0, 0, 0, 30), options.BackchannelTimeout);
+            //Assert.Equal("/callbackpath", options.CallbackPath); // NOTE: PathString doesn't convert
+            Assert.Equal("<issuer>", options.ClaimsIssuer);
             Assert.Equal("<id>", options.ClientId);
             Assert.Equal("<secret>", options.ClientSecret);
+            Assert.Equal("<display>", options.DisplayName);
+            Assert.Equal(new TimeSpan(0, 0, 0, 30), options.RemoteAuthenticationTimeout);
+            Assert.True(options.SaveTokens);
+            Assert.Equal("<signIn>", options.SignInScheme);
+            Assert.Equal("<tokenEndpoint>", options.TokenEndpoint);
+            Assert.Equal("<userEndpoint>", options.UserInformationEndpoint);
+        }
+
+        [Fact]
+        public void AddCanBindAgainstDefaultConfigAndOverride()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"Google:ClientId", "<id>"},
+                {"Google:ClientSecret", "<secret>"},
+                {"Google:AuthorizationEndpoint", "<authEndpoint>"},
+                {"Google:BackchannelTimeout", "0.0:0:30"},
+                //{"Google:CallbackPath", "/callbackpath"}, // PathString doesn't convert
+                {"Google:ClaimsIssuer", "<issuer>"},
+                {"Google:DisplayName", "<display>"},
+                {"Google:RemoteAuthenticationTimeout", "0.0:0:30"},
+                {"Google:SaveTokens", "true"},
+                {"Google:SendAppSecretProof", "true"},
+                {"Google:SignInScheme", "<signIn>"},
+                {"Google:TokenEndpoint", "<tokenEndpoint>"},
+                {"Google:UserInformationEndpoint", "<userEndpoint>"},
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            var config = configurationBuilder.Build();
+            var services = new ServiceCollection().AddGoogleAuthentication(o => o.SaveTokens = false).AddSingleton<IConfiguration>(config);
+            var sp = services.BuildServiceProvider();
+
+            var options = sp.GetRequiredService<IOptionsSnapshot<GoogleOptions>>().Get(GoogleDefaults.AuthenticationScheme);
+            Assert.Equal("<authEndpoint>", options.AuthorizationEndpoint);
+            Assert.Equal(new TimeSpan(0, 0, 0, 30), options.BackchannelTimeout);
+            //Assert.Equal("/callbackpath", options.CallbackPath); // NOTE: PathString doesn't convert
+            Assert.Equal("<issuer>", options.ClaimsIssuer);
+            Assert.Equal("<id>", options.ClientId);
+            Assert.Equal("<secret>", options.ClientSecret);
+            Assert.Equal("<display>", options.DisplayName);
+            Assert.Equal(new TimeSpan(0, 0, 0, 30), options.RemoteAuthenticationTimeout);
+            Assert.False(options.SaveTokens);
+            Assert.Equal("<signIn>", options.SignInScheme);
+            Assert.Equal("<tokenEndpoint>", options.TokenEndpoint);
+            Assert.Equal("<userEndpoint>", options.UserInformationEndpoint);
         }
 
         [Fact]
@@ -1092,7 +1153,7 @@ namespace Microsoft.AspNetCore.Authentication.Google
                     services.AddTransient<IClaimsTransformation, ClaimsTransformer>();
                     services.AddAuthentication(o =>
                     {
-                        o.DefaultAuthenticationScheme = TestExtensions.CookieAuthenticationScheme;
+                        o.DefaultAuthenticateScheme = TestExtensions.CookieAuthenticationScheme;
                         o.DefaultSignInScheme = TestExtensions.CookieAuthenticationScheme;
                         o.DefaultChallengeScheme = GoogleDefaults.AuthenticationScheme;
                     });

--- a/test/Microsoft.AspNetCore.Authentication.Test/GoogleTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/GoogleTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Authentication.Google
             var services = new ServiceCollection().AddGoogleAuthentication().AddSingleton<IConfiguration>(config);
             var sp = services.BuildServiceProvider();
 
-            var options = sp.GetRequiredService<IOptionsSnapshot<GoogleOptions>>().Get("Google");
+            var options = sp.GetRequiredService<IOptionsSnapshot<GoogleOptions>>().Get(GoogleDefaults.AuthenticationScheme);
             Assert.Equal("<id>", options.ClientId);
             Assert.Equal("<secret>", options.ClientSecret);
         }

--- a/test/Microsoft.AspNetCore.Authentication.Test/JwtBearerTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/JwtBearerTests.cs
@@ -31,8 +31,17 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
         {
             var dic = new Dictionary<string, string>
             {
-                {"Bearer:Audience", "<aud>"},
-                {"Bearer:Authority", "<auth>"}
+                {"Bearer:Audience", "<audience>"},
+                {"Bearer:Authority", "<authority>"},
+                {"Bearer:BackchannelTimeout", "0.0:0:30"},
+                {"Bearer:Challenge", "<challenge>"},
+                {"Bearer:ClaimsIssuer", "<issuer>"},
+                {"Bearer:DisplayName", "<display>"},
+                {"Bearer:IncludeErrorDetails", "true"},
+                {"Bearer:MetadataAddress", "<metadata>"},
+                {"Bearer:RefreshOnIssuerKeyNotFound", "true"},
+                {"Bearer:RequireHttpsMetadata", "true"},
+                {"Bearer:SaveToken", "true"},
             };
             var configurationBuilder = new ConfigurationBuilder();
             configurationBuilder.AddInMemoryCollection(dic);
@@ -41,8 +50,54 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
             var sp = services.BuildServiceProvider();
 
             var options = sp.GetRequiredService<IOptionsSnapshot<JwtBearerOptions>>().Get(JwtBearerDefaults.AuthenticationScheme);
-            Assert.Equal("<aud>", options.Audience);
-            Assert.Equal("<auth>", options.Authority);
+            Assert.Equal(new TimeSpan(0, 0, 0, 30), options.BackchannelTimeout);
+            Assert.Equal("<audience>", options.Audience);
+            Assert.Equal("<authority>", options.Authority);
+            Assert.Equal("<challenge>", options.Challenge);
+            Assert.Equal("<issuer>", options.ClaimsIssuer);
+            Assert.Equal("<display>", options.DisplayName);
+            Assert.True(options.IncludeErrorDetails);
+            Assert.Equal("<metadata>", options.MetadataAddress);
+            Assert.True(options.RefreshOnIssuerKeyNotFound);
+            Assert.True(options.RequireHttpsMetadata);
+            Assert.True(options.SaveToken);
+        }
+
+        [Fact]
+        public void AddCanBindAgainstDefaultConfigAndOverride()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"Bearer:Audience", "<audience>"},
+                {"Bearer:Authority", "<authority>"},
+                {"Bearer:BackchannelTimeout", "0.0:0:30"},
+                {"Bearer:Challenge", "<challenge>"},
+                {"Bearer:ClaimsIssuer", "<issuer>"},
+                {"Bearer:DisplayName", "<display>"},
+                {"Bearer:IncludeErrorDetails", "true"},
+                {"Bearer:MetadataAddress", "<metadata>"},
+                {"Bearer:RefreshOnIssuerKeyNotFound", "true"},
+                {"Bearer:RequireHttpsMetadata", "true"},
+                {"Bearer:SaveToken", "true"},
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            var config = configurationBuilder.Build();
+            var services = new ServiceCollection().AddJwtBearerAuthentication(o => o.IncludeErrorDetails = false).AddSingleton<IConfiguration>(config);
+            var sp = services.BuildServiceProvider();
+
+            var options = sp.GetRequiredService<IOptionsSnapshot<JwtBearerOptions>>().Get(JwtBearerDefaults.AuthenticationScheme);
+            Assert.Equal(new TimeSpan(0, 0, 0, 30), options.BackchannelTimeout);
+            Assert.Equal("<audience>", options.Audience);
+            Assert.Equal("<authority>", options.Authority);
+            Assert.Equal("<challenge>", options.Challenge);
+            Assert.Equal("<issuer>", options.ClaimsIssuer);
+            Assert.Equal("<display>", options.DisplayName);
+            Assert.False(options.IncludeErrorDetails);
+            Assert.Equal("<metadata>", options.MetadataAddress);
+            Assert.True(options.RefreshOnIssuerKeyNotFound);
+            Assert.True(options.RequireHttpsMetadata);
+            Assert.True(options.SaveToken);
         }
 
         [ConditionalFact(Skip = "Need to remove dependency on AAD since the generated tokens will expire")]

--- a/test/Microsoft.AspNetCore.Authentication.Test/MicrosoftAccountTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/MicrosoftAccountTests.cs
@@ -33,7 +33,18 @@ namespace Microsoft.AspNetCore.Authentication.Tests.MicrosoftAccount
             var dic = new Dictionary<string, string>
             {
                 {"Microsoft:ClientId", "<id>"},
-                {"Microsoft:ClientSecret", "<secret>"}
+                {"Microsoft:ClientSecret", "<secret>"},
+                {"Microsoft:AuthorizationEndpoint", "<authEndpoint>"},
+                {"Microsoft:BackchannelTimeout", "0.0:0:30"},
+                //{"Microsoft:CallbackPath", "/callbackpath"}, // PathString doesn't convert
+                {"Microsoft:ClaimsIssuer", "<issuer>"},
+                {"Microsoft:DisplayName", "<display>"},
+                {"Microsoft:RemoteAuthenticationTimeout", "0.0:0:30"},
+                {"Microsoft:SaveTokens", "true"},
+                {"Microsoft:SendAppSecretProof", "true"},
+                {"Microsoft:SignInScheme", "<signIn>"},
+                {"Microsoft:TokenEndpoint", "<tokenEndpoint>"},
+                {"Microsoft:UserInformationEndpoint", "<userEndpoint>"},
             };
             var configurationBuilder = new ConfigurationBuilder();
             configurationBuilder.AddInMemoryCollection(dic);
@@ -41,11 +52,61 @@ namespace Microsoft.AspNetCore.Authentication.Tests.MicrosoftAccount
             var services = new ServiceCollection().AddMicrosoftAccountAuthentication().AddSingleton<IConfiguration>(config);
             var sp = services.BuildServiceProvider();
 
-            var options = sp.GetRequiredService<IOptionsSnapshot<MicrosoftAccountOptions>>().Get("Microsoft");
+            var options = sp.GetRequiredService<IOptionsSnapshot<MicrosoftAccountOptions>>().Get(MicrosoftAccountDefaults.AuthenticationScheme);
+            Assert.Equal("<authEndpoint>", options.AuthorizationEndpoint);
+            Assert.Equal(new TimeSpan(0, 0, 0, 30), options.BackchannelTimeout);
+            //Assert.Equal("/callbackpath", options.CallbackPath); // NOTE: PathString doesn't convert
+            Assert.Equal("<issuer>", options.ClaimsIssuer);
             Assert.Equal("<id>", options.ClientId);
             Assert.Equal("<secret>", options.ClientSecret);
+            Assert.Equal("<display>", options.DisplayName);
+            Assert.Equal(new TimeSpan(0, 0, 0, 30), options.RemoteAuthenticationTimeout);
+            Assert.True(options.SaveTokens);
+            Assert.Equal("<signIn>", options.SignInScheme);
+            Assert.Equal("<tokenEndpoint>", options.TokenEndpoint);
+            Assert.Equal("<userEndpoint>", options.UserInformationEndpoint);
         }
-        
+
+        [Fact]
+        public void AddCanBindAgainstDefaultConfigAndOverride()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"Microsoft:ClientId", "<id>"},
+                {"Microsoft:ClientSecret", "<secret>"},
+                {"Microsoft:AuthorizationEndpoint", "<authEndpoint>"},
+                {"Microsoft:BackchannelTimeout", "0.0:0:30"},
+                //{"Microsoft:CallbackPath", "/callbackpath"}, // PathString doesn't convert
+                {"Microsoft:ClaimsIssuer", "<issuer>"},
+                {"Microsoft:DisplayName", "<display>"},
+                {"Microsoft:RemoteAuthenticationTimeout", "0.0:0:30"},
+                {"Microsoft:SaveTokens", "true"},
+                {"Microsoft:SendAppSecretProof", "true"},
+                {"Microsoft:SignInScheme", "<signIn>"},
+                {"Microsoft:TokenEndpoint", "<tokenEndpoint>"},
+                {"Microsoft:UserInformationEndpoint", "<userEndpoint>"},
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            var config = configurationBuilder.Build();
+            var services = new ServiceCollection().AddMicrosoftAccountAuthentication(o => o.SaveTokens = false).AddSingleton<IConfiguration>(config);
+            var sp = services.BuildServiceProvider();
+
+            var options = sp.GetRequiredService<IOptionsSnapshot<MicrosoftAccountOptions>>().Get(MicrosoftAccountDefaults.AuthenticationScheme);
+            Assert.Equal("<authEndpoint>", options.AuthorizationEndpoint);
+            Assert.Equal(new TimeSpan(0, 0, 0, 30), options.BackchannelTimeout);
+            //Assert.Equal("/callbackpath", options.CallbackPath); // NOTE: PathString doesn't convert
+            Assert.Equal("<issuer>", options.ClaimsIssuer);
+            Assert.Equal("<id>", options.ClientId);
+            Assert.Equal("<secret>", options.ClientSecret);
+            Assert.Equal("<display>", options.DisplayName);
+            Assert.Equal(new TimeSpan(0, 0, 0, 30), options.RemoteAuthenticationTimeout);
+            Assert.False(options.SaveTokens);
+            Assert.Equal("<signIn>", options.SignInScheme);
+            Assert.Equal("<tokenEndpoint>", options.TokenEndpoint);
+            Assert.Equal("<userEndpoint>", options.UserInformationEndpoint);
+        }
+
         [Fact]
         public async Task ChallengeWillTriggerApplyRedirectEvent()
         {
@@ -232,7 +293,7 @@ namespace Microsoft.AspNetCore.Authentication.Tests.MicrosoftAccount
                 {
                     services.AddAuthentication(o =>
                     {
-                        o.DefaultAuthenticationScheme = TestExtensions.CookieAuthenticationScheme;
+                        o.DefaultAuthenticateScheme = TestExtensions.CookieAuthenticationScheme;
                         o.DefaultSignInScheme = TestExtensions.CookieAuthenticationScheme;
                     });
                     services.AddCookieAuthentication(TestExtensions.CookieAuthenticationScheme, o => { });

--- a/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectTests.cs
@@ -2,20 +2,25 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
 {
-    public class OpenIdConnectMiddlewareTests
+    public class OpenIdConnectTests
     {
         static string noncePrefix = "OpenIdConnect." + "Nonce.";
         static string nonceDelimiter = ".";
@@ -23,6 +28,27 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
         const string Logout = "/logout";
         const string Signin = "/signin";
         const string Signout = "/signout";
+
+        [Fact]
+        public void AddCanBindAgainstDefaultConfig()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"OpenIdConnect:ClientId", "<id>"},
+                {"OpenIdConnect:ClientSecret", "<secret>"},
+                {"OpenIdConnect:Authority", "<auth>"}
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            var config = configurationBuilder.Build();
+            var services = new ServiceCollection().AddOpenIdConnectAuthentication().AddSingleton<IConfiguration>(config);
+            var sp = services.BuildServiceProvider();
+
+            var options = sp.GetRequiredService<IOptionsSnapshot<OpenIdConnectOptions>>().Get(OpenIdConnectDefaults.AuthenticationScheme);
+            Assert.Equal("<id>", options.ClientId);
+            Assert.Equal("<secret>", options.ClientSecret);
+            Assert.Equal("<auth>", options.Authority);
+        }
 
 
         /// <summary>

--- a/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/TestServerBuilder.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/TestServerBuilder.cs
@@ -111,7 +111,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 {
                     services.AddAuthentication(o =>
                     {
-                        o.DefaultAuthenticationScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                        o.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                         o.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                     });
                     services.AddCookieAuthentication();

--- a/test/Microsoft.AspNetCore.Authentication.Test/TwitterTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/TwitterTests.cs
@@ -26,7 +26,15 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
             var dic = new Dictionary<string, string>
             {
                 {"Twitter:ConsumerKey", "<key>"},
-                {"Twitter:ConsumerSecret", "<secret>"}
+                {"Twitter:ConsumerSecret", "<secret>"},
+                {"Twitter:BackchannelTimeout", "0.0:0:30"},
+                //{"Twitter:CallbackPath", "/callbackpath"}, // PathString doesn't convert
+                {"Twitter:ClaimsIssuer", "<issuer>"},
+                {"Twitter:DisplayName", "<display>"},
+                {"Twitter:RemoteAuthenticationTimeout", "0.0:0:30"},
+                {"Twitter:SaveTokens", "true"},
+                {"Twitter:SendAppSecretProof", "true"},
+                {"Twitter:SignInScheme", "<signIn>"},
             };
             var configurationBuilder = new ConfigurationBuilder();
             configurationBuilder.AddInMemoryCollection(dic);
@@ -35,8 +43,49 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
             var sp = services.BuildServiceProvider();
 
             var options = sp.GetRequiredService<IOptionsSnapshot<TwitterOptions>>().Get(TwitterDefaults.AuthenticationScheme);
+            Assert.Equal(new TimeSpan(0, 0, 0, 30), options.BackchannelTimeout);
+            //Assert.Equal("/callbackpath", options.CallbackPath); // NOTE: PathString doesn't convert
+            Assert.Equal("<issuer>", options.ClaimsIssuer);
             Assert.Equal("<key>", options.ConsumerKey);
             Assert.Equal("<secret>", options.ConsumerSecret);
+            Assert.Equal("<display>", options.DisplayName);
+            Assert.Equal(new TimeSpan(0, 0, 0, 30), options.RemoteAuthenticationTimeout);
+            Assert.True(options.SaveTokens);
+            Assert.Equal("<signIn>", options.SignInScheme);
+        }
+
+        [Fact]
+        public void AddCanBindAgainstDefaultConfigAndOverride()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"Twitter:ConsumerKey", "<key>"},
+                {"Twitter:ConsumerSecret", "<secret>"},
+                {"Twitter:BackchannelTimeout", "0.0:0:30"},
+                //{"Twitter:CallbackPath", "/callbackpath"}, // PathString doesn't convert
+                {"Twitter:ClaimsIssuer", "<issuer>"},
+                {"Twitter:DisplayName", "<display>"},
+                {"Twitter:RemoteAuthenticationTimeout", "0.0:0:30"},
+                {"Twitter:SaveTokens", "true"},
+                {"Twitter:SendAppSecretProof", "true"},
+                {"Twitter:SignInScheme", "<signIn>"},
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            var config = configurationBuilder.Build();
+            var services = new ServiceCollection().AddTwitterAuthentication(o => o.SaveTokens = false).AddSingleton<IConfiguration>(config);
+            var sp = services.BuildServiceProvider();
+
+            var options = sp.GetRequiredService<IOptionsSnapshot<TwitterOptions>>().Get(TwitterDefaults.AuthenticationScheme);
+            Assert.Equal(new TimeSpan(0, 0, 0, 30), options.BackchannelTimeout);
+            //Assert.Equal("/callbackpath", options.CallbackPath); // NOTE: PathString doesn't convert
+            Assert.Equal("<issuer>", options.ClaimsIssuer);
+            Assert.Equal("<key>", options.ConsumerKey);
+            Assert.Equal("<secret>", options.ConsumerSecret);
+            Assert.Equal("<display>", options.DisplayName);
+            Assert.Equal(new TimeSpan(0, 0, 0, 30), options.RemoteAuthenticationTimeout);
+            Assert.False(options.SaveTokens);
+            Assert.Equal("<signIn>", options.SignInScheme);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Authentication.Test/TwitterTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/TwitterTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Security.Claims;
@@ -10,13 +11,34 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Authentication.Twitter
 {
-    public class TwitterMiddlewareTests
+    public class TwitterTests
     {
+        [Fact]
+        public void AddCanBindAgainstDefaultConfig()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"Twitter:ConsumerKey", "<key>"},
+                {"Twitter:ConsumerSecret", "<secret>"}
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            var config = configurationBuilder.Build();
+            var services = new ServiceCollection().AddTwitterAuthentication().AddSingleton<IConfiguration>(config);
+            var sp = services.BuildServiceProvider();
+
+            var options = sp.GetRequiredService<IOptionsSnapshot<TwitterOptions>>().Get(TwitterDefaults.AuthenticationScheme);
+            Assert.Equal("<key>", options.ConsumerKey);
+            Assert.Equal("<secret>", options.ConsumerSecret);
+        }
+
         [Fact]
         public async Task ChallengeWillTriggerApplyRedirectEvent()
         {


### PR DESCRIPTION
I didn't add these overloads for Cookies/generic OAuth since those are more likely to have multiple instances, but I can if we want.

cc @glennc @ajcvickers @Tratcher @divega @davidfowl 