### PR TITLE
Switch to services.Initialize<TOptions>

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationHandler.cs
@@ -59,39 +59,6 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         /// <returns>A new instance of the events instance.</returns>
         protected override Task<object> CreateEventsAsync() => Task.FromResult<object>(new CookieAuthenticationEvents());
 
-        protected override void InitializeOptions()
-        {
-            base.InitializeOptions();
-
-            if (String.IsNullOrEmpty(Options.CookieName))
-            {
-                Options.CookieName = CookieAuthenticationDefaults.CookiePrefix + Scheme.Name;
-            }
-            if (Options.TicketDataFormat == null)
-            {
-                var provider = Options.DataProtectionProvider ?? Context.RequestServices.GetRequiredService<IDataProtectionProvider>();
-                // Note: the purpose for the data protector must remain fixed for interop to work.
-                var dataProtector = provider.CreateProtector("Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationMiddleware", Scheme.Name, "v2");
-                Options.TicketDataFormat = new TicketDataFormat(dataProtector);
-            }
-            if (Options.CookieManager == null)
-            {
-                Options.CookieManager = new ChunkingCookieManager();
-            }
-            if (!Options.LoginPath.HasValue)
-            {
-                Options.LoginPath = CookieAuthenticationDefaults.LoginPath;
-            }
-            if (!Options.LogoutPath.HasValue)
-            {
-                Options.LogoutPath = CookieAuthenticationDefaults.LogoutPath;
-            }
-            if (!Options.AccessDeniedPath.HasValue)
-            {
-                Options.AccessDeniedPath = CookieAuthenticationDefaults.AccessDeniedPath;
-            }
-        }
-
         private Task<AuthenticateResult> EnsureCookieTicket()
         {
             // We only need to read the ticket once

--- a/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationInitializer.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationInitializer.cs
@@ -34,12 +34,6 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
             }
             if (options.TicketDataFormat == null)
             {
-                if (options.DataProtectionProvider == null)
-                {
-                    // This shouldn't happen normally due to the EnsureDataProtection initialize options.
-                    throw new InvalidOperationException("DataProtectionProvider must be provided.");
-                }
-
                 // Note: the purpose for the data protector must remain fixed for interop to work.
                 var dataProtector = options.DataProtectionProvider.CreateProtector("Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationMiddleware", name, "v2");
                 options.TicketDataFormat = new TicketDataFormat(dataProtector);

--- a/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationInitializer.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationInitializer.cs
@@ -1,0 +1,66 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Authentication.Cookies
+{
+    /// <summary>
+    /// Used to setup defaults for all <see cref="CookieAuthenticationOptions"/>.
+    /// </summary>
+    public class CookieAuthenticationInitializer : IInitializeOptions<CookieAuthenticationOptions>
+    {
+        private readonly IDataProtectionProvider _dp;
+
+        public CookieAuthenticationInitializer(IDataProtectionProvider dataProtection)
+        {
+            _dp = dataProtection;
+        }
+
+        /// <summary>
+        /// Invoked to initialize a TOptions instance.
+        /// </summary>
+        /// <param name="name">The name of the options instance being initialized.</param>
+        /// <param name="options">The options instance to initialize.</param>
+        public void Initialize(string name, CookieAuthenticationOptions options)
+        {
+            options.DataProtectionProvider = options.DataProtectionProvider ?? _dp;
+
+            if (String.IsNullOrEmpty(options.CookieName))
+            {
+                options.CookieName = CookieAuthenticationDefaults.CookiePrefix + name;
+            }
+            if (options.TicketDataFormat == null)
+            {
+                if (options.DataProtectionProvider == null)
+                {
+                    // This shouldn't happen normally due to the EnsureDataProtection initialize options.
+                    throw new InvalidOperationException("DataProtectionProvider must be provided.");
+                }
+
+                // Note: the purpose for the data protector must remain fixed for interop to work.
+                var dataProtector = options.DataProtectionProvider.CreateProtector("Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationMiddleware", name, "v2");
+                options.TicketDataFormat = new TicketDataFormat(dataProtector);
+            }
+            if (options.CookieManager == null)
+            {
+                options.CookieManager = new ChunkingCookieManager();
+            }
+            if (!options.LoginPath.HasValue)
+            {
+                options.LoginPath = CookieAuthenticationDefaults.LoginPath;
+            }
+            if (!options.LogoutPath.HasValue)
+            {
+                options.LogoutPath = CookieAuthenticationDefaults.LogoutPath;
+            }
+            if (!options.AccessDeniedPath.HasValue)
+            {
+                options.AccessDeniedPath = CookieAuthenticationDefaults.AccessDeniedPath;
+            }
+        }
+
+    }
+}

--- a/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationOptions.cs
@@ -72,9 +72,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         public CookieSecurePolicy CookieSecure { get; set; }
 
         /// <summary>
-        /// If set this will be used by the CookieAuthenticationMiddleware for data protection.
-        /// he default data protection service is based on machine key when running on ASP.NET, 
-        /// and on DPAPI when running in a different process.
+        /// If set this will be used by the CookieAuthenticationHandler for data protection.
         /// </summary>
         public IDataProtectionProvider DataProtectionProvider { get; set; }
 

--- a/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationOptions.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Authentication.Cookies
 {
@@ -72,6 +73,8 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
 
         /// <summary>
         /// If set this will be used by the CookieAuthenticationMiddleware for data protection.
+        /// he default data protection service is based on machine key when running on ASP.NET, 
+        /// and on DPAPI when running in a different process.
         /// </summary>
         public IDataProtectionProvider DataProtectionProvider { get; set; }
 
@@ -129,9 +132,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
 
         /// <summary>
         /// The TicketDataFormat is used to protect and unprotect the identity and other properties which are stored in the
-        /// cookie value. If it is not provided a default data handler is created using the data protection service contained
-        /// in the IApplicationBuilder.Properties. The default data protection service is based on machine key when running on ASP.NET, 
-        /// and on DPAPI when running in a different process.
+        /// cookie value. If not provided one will be created using <see cref="DataProtectionProvider"/>.
         /// </summary>
         public ISecureDataFormat<AuthenticationTicket> TicketDataFormat { get; set; }
 

--- a/src/Microsoft.AspNetCore.Authentication.Cookies/CookieExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/CookieExtensions.cs
@@ -3,6 +3,10 @@
 
 using System;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.AspNetCore.Authentication;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -15,7 +19,63 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddCookieAuthentication(this IServiceCollection services, Action<CookieAuthenticationOptions> configureOptions) =>
             services.AddCookieAuthentication(CookieAuthenticationDefaults.AuthenticationScheme, configureOptions);
 
-        public static IServiceCollection AddCookieAuthentication(this IServiceCollection services, string authenticationScheme, Action<CookieAuthenticationOptions> configureOptions) =>
-            services.AddScheme<CookieAuthenticationOptions, CookieAuthenticationHandler>(authenticationScheme, configureOptions);
+        public static IServiceCollection AddCookieAuthentication(this IServiceCollection services, string authenticationScheme, Action<CookieAuthenticationOptions> configureOptions)
+        {
+            // Makes sure that DataProtectionProvider is always set.
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IInitializeOptions<CookieAuthenticationOptions>, EnsureDataProtection>());
+            services.Initialize<CookieAuthenticationOptions>(authenticationScheme, options =>
+            {
+                if (String.IsNullOrEmpty(options.CookieName))
+                {
+                    options.CookieName = CookieAuthenticationDefaults.CookiePrefix + authenticationScheme;
+                }
+                if (options.TicketDataFormat == null)
+                {
+                    if (options.DataProtectionProvider == null)
+                    {
+                        // This shouldn't happen normally due to the EnsureDataProtection initialize options.
+                        throw new InvalidOperationException("DataProtectionProvider must be provided.");
+                    }
+
+                    // Note: the purpose for the data protector must remain fixed for interop to work.
+                    var dataProtector = options.DataProtectionProvider.CreateProtector("Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationMiddleware", authenticationScheme, "v2");
+                    options.TicketDataFormat = new TicketDataFormat(dataProtector);
+                }
+                if (options.CookieManager == null)
+                {
+                    options.CookieManager = new ChunkingCookieManager();
+                }
+                if (!options.LoginPath.HasValue)
+                {
+                    options.LoginPath = CookieAuthenticationDefaults.LoginPath;
+                }
+                if (!options.LogoutPath.HasValue)
+                {
+                    options.LogoutPath = CookieAuthenticationDefaults.LogoutPath;
+                }
+                if (!options.AccessDeniedPath.HasValue)
+                {
+                    options.AccessDeniedPath = CookieAuthenticationDefaults.AccessDeniedPath;
+                }
+            });
+            return services.AddScheme<CookieAuthenticationOptions, CookieAuthenticationHandler>(authenticationScheme, configureOptions);
+        }
+
+        // Used to ensure that there's always a default data protection provider
+        private class EnsureDataProtection : IInitializeOptions<CookieAuthenticationOptions>
+        {
+            private readonly IDataProtectionProvider _dp;
+
+            public EnsureDataProtection(IDataProtectionProvider dataProtection)
+            {
+                _dp = dataProtection;
+            }
+
+            public void Initialize(string name, CookieAuthenticationOptions options)
+            {
+                options.DataProtectionProvider = options.DataProtectionProvider ?? _dp;
+            }
+        }
+
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.Cookies/CookieExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/CookieExtensions.cs
@@ -21,60 +21,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static IServiceCollection AddCookieAuthentication(this IServiceCollection services, string authenticationScheme, Action<CookieAuthenticationOptions> configureOptions)
         {
-            // Makes sure that DataProtectionProvider is always set.
-            services.TryAddEnumerable(ServiceDescriptor.Singleton<IInitializeOptions<CookieAuthenticationOptions>, EnsureDataProtection>());
-            services.Initialize<CookieAuthenticationOptions>(authenticationScheme, options =>
-            {
-                if (String.IsNullOrEmpty(options.CookieName))
-                {
-                    options.CookieName = CookieAuthenticationDefaults.CookiePrefix + authenticationScheme;
-                }
-                if (options.TicketDataFormat == null)
-                {
-                    if (options.DataProtectionProvider == null)
-                    {
-                        // This shouldn't happen normally due to the EnsureDataProtection initialize options.
-                        throw new InvalidOperationException("DataProtectionProvider must be provided.");
-                    }
-
-                    // Note: the purpose for the data protector must remain fixed for interop to work.
-                    var dataProtector = options.DataProtectionProvider.CreateProtector("Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationMiddleware", authenticationScheme, "v2");
-                    options.TicketDataFormat = new TicketDataFormat(dataProtector);
-                }
-                if (options.CookieManager == null)
-                {
-                    options.CookieManager = new ChunkingCookieManager();
-                }
-                if (!options.LoginPath.HasValue)
-                {
-                    options.LoginPath = CookieAuthenticationDefaults.LoginPath;
-                }
-                if (!options.LogoutPath.HasValue)
-                {
-                    options.LogoutPath = CookieAuthenticationDefaults.LogoutPath;
-                }
-                if (!options.AccessDeniedPath.HasValue)
-                {
-                    options.AccessDeniedPath = CookieAuthenticationDefaults.AccessDeniedPath;
-                }
-            });
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IInitializeOptions<CookieAuthenticationOptions>, CookieAuthenticationInitializer>());
             return services.AddScheme<CookieAuthenticationOptions, CookieAuthenticationHandler>(authenticationScheme, configureOptions);
-        }
-
-        // Used to ensure that there's always a default data protection provider
-        private class EnsureDataProtection : IInitializeOptions<CookieAuthenticationOptions>
-        {
-            private readonly IDataProtectionProvider _dp;
-
-            public EnsureDataProtection(IDataProtectionProvider dataProtection)
-            {
-                _dp = dataProtection;
-            }
-
-            public void Initialize(string name, CookieAuthenticationOptions options)
-            {
-                options.DataProtectionProvider = options.DataProtectionProvider ?? _dp;
-            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.Cookies/CookieExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/CookieExtensions.cs
@@ -76,6 +76,5 @@ namespace Microsoft.Extensions.DependencyInjection
                 options.DataProtectionProvider = options.DataProtectionProvider ?? _dp;
             }
         }
-
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.Cookies/Microsoft.AspNetCore.Authentication.Cookies.csproj
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/Microsoft.AspNetCore.Authentication.Cookies.csproj
@@ -18,7 +18,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.AspNetCore.Authentication\Microsoft.AspNetCore.Authentication.csproj" />
-    <PackageReference Include="Microsoft​.Extensions​.DependencyInjection​.Abstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.TaskCache.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Microsoft.AspNetCore.Authentication.Cookies/Microsoft.AspNetCore.Authentication.Cookies.csproj
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/Microsoft.AspNetCore.Authentication.Cookies.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.AspNetCore.Authentication\Microsoft.AspNetCore.Authentication.csproj" />
+    <PackageReference Include="Microsoft​.Extensions​.DependencyInjection​.Abstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.TaskCache.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static IServiceCollection AddFacebookAuthentication(this IServiceCollection services, string authenticationScheme, Action<FacebookOptions> configureOptions)
         {
-            return services.AddScheme<FacebookOptions, FacebookHandler>(authenticationScheme, authenticationScheme, configureOptions);
+            return services.AddOAuthAuthentication<FacebookOptions, FacebookHandler>(authenticationScheme, configureOptions);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
@@ -9,7 +9,6 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -19,8 +18,8 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
 {
     internal class FacebookHandler : OAuthHandler<FacebookOptions>
     {
-        public FacebookHandler(IOptions<AuthenticationOptions> sharedOptions, IOptionsSnapshot<FacebookOptions> options, ILoggerFactory logger, UrlEncoder encoder, IDataProtectionProvider dataProtection, ISystemClock clock)
-            : base(sharedOptions, options, logger, encoder, dataProtection, clock)
+        public FacebookHandler(IOptionsSnapshot<FacebookOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
+            : base(options, logger, encoder, clock)
         { }
 
         protected override async Task<AuthenticationTicket> CreateTicketAsync(ClaimsIdentity identity, AuthenticationProperties properties, OAuthTokenResponse tokens)

--- a/src/Microsoft.AspNetCore.Authentication.Google/GoogleExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Google/GoogleExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static IServiceCollection AddGoogleAuthentication(this IServiceCollection services, string authenticationScheme, Action<GoogleOptions> configureOptions)
         {
-            return services.AddScheme<GoogleOptions, GoogleHandler>(authenticationScheme, authenticationScheme, configureOptions);
+            return services.AddOAuthAuthentication<GoogleOptions, GoogleHandler>(authenticationScheme, configureOptions);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.Google/GoogleHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Google/GoogleHandler.cs
@@ -9,7 +9,6 @@ using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -19,8 +18,8 @@ namespace Microsoft.AspNetCore.Authentication.Google
 {
     internal class GoogleHandler : OAuthHandler<GoogleOptions>
     {
-        public GoogleHandler(IOptions<AuthenticationOptions> sharedOptions, IOptionsSnapshot<GoogleOptions> options, ILoggerFactory logger, UrlEncoder encoder, IDataProtectionProvider dataProtection, ISystemClock clock)
-            : base(sharedOptions, options, logger, encoder, dataProtection, clock)
+        public GoogleHandler(IOptionsSnapshot<GoogleOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
+            : base(options, logger, encoder, clock)
         { }
 
         protected override async Task<AuthenticationTicket> CreateTicketAsync(

--- a/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -26,6 +27,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static IServiceCollection AddJwtBearerAuthentication(this IServiceCollection services, string authenticationScheme, Action<JwtBearerOptions> configureOptions)
         {
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IInitializeOptions<JwtBearerOptions>, JwtBearerInitializer>());
             return services.AddScheme<JwtBearerOptions, JwtBearerHandler>(authenticationScheme, configureOptions);
         }
     }

--- a/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerHandler.cs
@@ -40,49 +40,6 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
 
         protected override Task<object> CreateEventsAsync() => Task.FromResult<object>(new JwtBearerEvents());
 
-        protected override void InitializeOptions()
-        {
-            base.InitializeOptions();
-
-            if (string.IsNullOrEmpty(Options.TokenValidationParameters.ValidAudience) && !string.IsNullOrEmpty(Options.Audience))
-            {
-                Options.TokenValidationParameters.ValidAudience = Options.Audience;
-            }
-
-            if (Options.ConfigurationManager == null)
-            {
-                if (Options.Configuration != null)
-                {
-                    Options.ConfigurationManager = new StaticConfigurationManager<OpenIdConnectConfiguration>(Options.Configuration);
-                }
-                else if (!(string.IsNullOrEmpty(Options.MetadataAddress) && string.IsNullOrEmpty(Options.Authority)))
-                {
-                    if (string.IsNullOrEmpty(Options.MetadataAddress) && !string.IsNullOrEmpty(Options.Authority))
-                    {
-                        Options.MetadataAddress = Options.Authority;
-                        if (!Options.MetadataAddress.EndsWith("/", StringComparison.Ordinal))
-                        {
-                            Options.MetadataAddress += "/";
-                        }
-
-                        Options.MetadataAddress += ".well-known/openid-configuration";
-                    }
-
-                    if (Options.RequireHttpsMetadata && !Options.MetadataAddress.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
-                    {
-                        throw new InvalidOperationException("The MetadataAddress or Authority must use HTTPS unless disabled for development by setting RequireHttpsMetadata=false.");
-                    }
-
-                    var httpClient = new HttpClient(Options.BackchannelHttpHandler ?? new HttpClientHandler());
-                    httpClient.Timeout = Options.BackchannelTimeout;
-                    httpClient.MaxResponseContentBufferSize = 1024 * 1024 * 10; // 10 MB
-
-                    Options.ConfigurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(Options.MetadataAddress, new OpenIdConnectConfigurationRetriever(),
-                        new HttpDocumentRetriever(httpClient) { RequireHttps = Options.RequireHttpsMetadata });
-                }
-            }
-        }
-
         /// <summary>
         /// Searches the 'Authorization' header for a 'Bearer' token. If the 'Bearer' token is found, it is validated using <see cref="TokenValidationParameters"/> set in the options.
         /// </summary>

--- a/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerInitializer.cs
+++ b/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerInitializer.cs
@@ -1,0 +1,63 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace Microsoft.AspNetCore.Authentication.JwtBearer
+{
+    /// <summary>
+    /// Used to setup defaults for all <see cref="JwtBearerOptions"/>.
+    /// </summary>
+    public class JwtBearerInitializer : IInitializeOptions<JwtBearerOptions>
+    {
+        /// <summary>
+        /// Invoked to initialize a JwtBearerOptions instance.
+        /// </summary>
+        /// <param name="name">The name of the options instance being initialized.</param>
+        /// <param name="options">The options instance to initialize.</param>
+        public void Initialize(string name, JwtBearerOptions options)
+        {
+            if (string.IsNullOrEmpty(options.TokenValidationParameters.ValidAudience) && !string.IsNullOrEmpty(options.Audience))
+            {
+                options.TokenValidationParameters.ValidAudience = options.Audience;
+            }
+
+            if (options.ConfigurationManager == null)
+            {
+                if (options.Configuration != null)
+                {
+                    options.ConfigurationManager = new StaticConfigurationManager<OpenIdConnectConfiguration>(options.Configuration);
+                }
+                else if (!(string.IsNullOrEmpty(options.MetadataAddress) && string.IsNullOrEmpty(options.Authority)))
+                {
+                    if (string.IsNullOrEmpty(options.MetadataAddress) && !string.IsNullOrEmpty(options.Authority))
+                    {
+                        options.MetadataAddress = options.Authority;
+                        if (!options.MetadataAddress.EndsWith("/", StringComparison.Ordinal))
+                        {
+                            options.MetadataAddress += "/";
+                        }
+
+                        options.MetadataAddress += ".well-known/openid-configuration";
+                    }
+
+                    if (options.RequireHttpsMetadata && !options.MetadataAddress.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new InvalidOperationException("The MetadataAddress or Authority must use HTTPS unless disabled for development by setting RequireHttpsMetadata=false.");
+                    }
+
+                    var httpClient = new HttpClient(options.BackchannelHttpHandler ?? new HttpClientHandler());
+                    httpClient.Timeout = options.BackchannelTimeout;
+                    httpClient.MaxResponseContentBufferSize = 1024 * 1024 * 10; // 10 MB
+
+                    options.ConfigurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(options.MetadataAddress, new OpenIdConnectConfigurationRetriever(),
+                        new HttpDocumentRetriever(httpClient) { RequireHttps = options.RequireHttpsMetadata });
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static IServiceCollection AddMicrosoftAccountAuthentication(this IServiceCollection services, string authenticationScheme, Action<MicrosoftAccountOptions> configureOptions)
         {
-            return services.AddScheme<MicrosoftAccountOptions, MicrosoftAccountHandler>(authenticationScheme, authenticationScheme, configureOptions);
+            return services.AddOAuthAuthentication<MicrosoftAccountOptions, MicrosoftAccountHandler>(authenticationScheme, configureOptions);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountHandler.cs
@@ -7,7 +7,6 @@ using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json.Linq;
@@ -16,8 +15,8 @@ namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
 {
     internal class MicrosoftAccountHandler : OAuthHandler<MicrosoftAccountOptions>
     {
-        public MicrosoftAccountHandler(IOptions<AuthenticationOptions> sharedOptions, IOptionsSnapshot<MicrosoftAccountOptions> options, ILoggerFactory logger, UrlEncoder encoder, IDataProtectionProvider dataProtection, ISystemClock clock)
-            : base(sharedOptions, options, logger, encoder, dataProtection, clock)
+        public MicrosoftAccountHandler(IOptionsSnapshot<MicrosoftAccountOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
+            : base(options, logger, encoder, clock)
         { }
 
         protected override async Task<AuthenticationTicket> CreateTicketAsync(ClaimsIdentity identity, AuthenticationProperties properties, OAuthTokenResponse tokens)

--- a/src/Microsoft.AspNetCore.Authentication.OAuth/Events/OAuthCreatingTicketContext.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OAuth/Events/OAuthCreatingTicketContext.cs
@@ -170,7 +170,7 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
 
             foreach (var action in Options.ClaimActions)
             {
-                action.Run(userData, Identity, Options.ClaimsIssuer);
+                action.Run(userData, Identity, Options.ClaimsIssuer ?? Scheme.Name);
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthExtensions.cs
@@ -2,14 +2,69 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Net.Http;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
-namespace Microsoft.AspNetCore.Builder
+namespace Microsoft.Extensions.DependencyInjection
 {
     public static class OAuthExtensions
     {
-        public static IServiceCollection AddOAuthAuthentication(this IServiceCollection services, string authenticationScheme, Action<OAuthOptions> configureOptions) =>
-            services.AddScheme<OAuthOptions, OAuthHandler<OAuthOptions>>(authenticationScheme, authenticationScheme, configureOptions);
+        public static IServiceCollection AddOAuthAuthentication(this IServiceCollection services, string authenticationScheme, Action<OAuthOptions> configureOptions)
+        {
+            return services.AddScheme<OAuthOptions, OAuthHandler<OAuthOptions>>(authenticationScheme, authenticationScheme, configureOptions);
+        }
+
+        public static IServiceCollection AddOAuthAuthentication<TOptions, THandler>(this IServiceCollection services, string authenticationScheme, Action<TOptions> configureOptions)
+            where TOptions : OAuthOptions, new()
+            where THandler : OAuthHandler<TOptions>
+        {
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IInitializeOptions<TOptions>, EnsureDataProtection<TOptions>>());
+            services.Initialize<TOptions>(authenticationScheme, options =>
+            {
+                if (options.Backchannel == null)
+                {
+                    options.Backchannel = new HttpClient(options.BackchannelHttpHandler ?? new HttpClientHandler());
+                    options.Backchannel.DefaultRequestHeaders.UserAgent.ParseAdd("Microsoft ASP.NET Core OAuth handler");
+                    options.Backchannel.Timeout = options.BackchannelTimeout;
+                    options.Backchannel.MaxResponseContentBufferSize = 1024 * 1024 * 10; // 10 MB
+                }
+
+                if (options.StateDataFormat == null)
+                {
+                    if (options.DataProtectionProvider == null)
+                    {
+                        // This shouldn't happen normally due to the EnsureDataProtection initialize options.
+                        throw new InvalidOperationException("DataProtectionProvider must be provided.");
+                    }
+
+                    var dataProtector = options.DataProtectionProvider.CreateProtector(
+                        typeof(THandler).FullName, authenticationScheme, "v1");
+                    options.StateDataFormat = new PropertiesDataFormat(dataProtector);
+                }
+            });
+            return services.AddScheme<TOptions, THandler>(authenticationScheme, authenticationScheme, configureOptions);
+        }
+
+        // Used to ensure that there's always a default data protection provider
+        private class EnsureDataProtection<TOptions> : IInitializeOptions<TOptions> where TOptions : OAuthOptions
+        {
+            private readonly IDataProtectionProvider _dp;
+
+            public EnsureDataProtection(IDataProtectionProvider dataProtection)
+            {
+                _dp = dataProtection;
+            }
+
+            public void Initialize(string name, TOptions options)
+            {
+                options.DataProtectionProvider = options.DataProtectionProvider ?? _dp;
+            }
+        }
+
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthExtensions.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     options.StateDataFormat = new PropertiesDataFormat(dataProtector);
                 }
             });
-            return services.AddScheme<TOptions, THandler>(authenticationScheme, authenticationScheme, configureOptions);
+            return services.AddRemoteScheme<TOptions, THandler>(authenticationScheme, authenticationScheme, configureOptions);
         }
 
         // Used to ensure that there's always a default data protection provider

--- a/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthExtensions.cs
@@ -2,11 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Net.Http;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.DataProtection;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
@@ -23,48 +19,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TOptions : OAuthOptions, new()
             where THandler : OAuthHandler<TOptions>
         {
-            services.TryAddEnumerable(ServiceDescriptor.Singleton<IInitializeOptions<TOptions>, EnsureDataProtection<TOptions>>());
-            services.Initialize<TOptions>(authenticationScheme, options =>
-            {
-                if (options.Backchannel == null)
-                {
-                    options.Backchannel = new HttpClient(options.BackchannelHttpHandler ?? new HttpClientHandler());
-                    options.Backchannel.DefaultRequestHeaders.UserAgent.ParseAdd("Microsoft ASP.NET Core OAuth handler");
-                    options.Backchannel.Timeout = options.BackchannelTimeout;
-                    options.Backchannel.MaxResponseContentBufferSize = 1024 * 1024 * 10; // 10 MB
-                }
-
-                if (options.StateDataFormat == null)
-                {
-                    if (options.DataProtectionProvider == null)
-                    {
-                        // This shouldn't happen normally due to the EnsureDataProtection initialize options.
-                        throw new InvalidOperationException("DataProtectionProvider must be provided.");
-                    }
-
-                    var dataProtector = options.DataProtectionProvider.CreateProtector(
-                        typeof(THandler).FullName, authenticationScheme, "v1");
-                    options.StateDataFormat = new PropertiesDataFormat(dataProtector);
-                }
-            });
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IInitializeOptions<TOptions>, OAuthInitializer<TOptions, THandler>>());
             return services.AddRemoteScheme<TOptions, THandler>(authenticationScheme, authenticationScheme, configureOptions);
         }
-
-        // Used to ensure that there's always a default data protection provider
-        private class EnsureDataProtection<TOptions> : IInitializeOptions<TOptions> where TOptions : OAuthOptions
-        {
-            private readonly IDataProtectionProvider _dp;
-
-            public EnsureDataProtection(IDataProtectionProvider dataProtection)
-            {
-                _dp = dataProtection;
-            }
-
-            public void Initialize(string name, TOptions options)
-            {
-                options.DataProtectionProvider = options.DataProtectionProvider ?? _dp;
-            }
-        }
-
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthHandler.cs
@@ -10,7 +10,6 @@ using System.Security.Claims;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -33,15 +32,9 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
             set { base.Events = value; }
         }
 
-        public OAuthHandler(IOptions<AuthenticationOptions> sharedOptions, IOptionsSnapshot<TOptions> options, ILoggerFactory logger, UrlEncoder encoder, IDataProtectionProvider dataProtection, ISystemClock clock)
-            : base(sharedOptions, options, dataProtection, logger, encoder, clock)
+        public OAuthHandler(IOptionsSnapshot<TOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
+            : base(options, logger, encoder, clock)
         { }
-
-        protected override void InitializeOptions()
-        {
-            base.InitializeOptions();
-
-        }
 
         /// <summary>
         /// Creates a new instance of the events instance.

--- a/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthHandler.cs
@@ -41,20 +41,6 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
         {
             base.InitializeOptions();
 
-            if (Options.Backchannel == null)
-            {
-                Options.Backchannel = new HttpClient(Options.BackchannelHttpHandler ?? new HttpClientHandler());
-                Options.Backchannel.DefaultRequestHeaders.UserAgent.ParseAdd("Microsoft ASP.NET Core OAuth handler");
-                Options.Backchannel.Timeout = Options.BackchannelTimeout;
-                Options.Backchannel.MaxResponseContentBufferSize = 1024 * 1024 * 10; // 10 MB
-            }
-
-            if (Options.StateDataFormat == null)
-            {
-                var dataProtector = DataProtection.CreateProtector(
-                    GetType().FullName, Scheme.Name, "v1");
-                Options.StateDataFormat = new PropertiesDataFormat(dataProtector);
-            }
         }
 
         /// <summary>
@@ -119,7 +105,7 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
                 return AuthenticateResult.Fail("Failed to retrieve access token.");
             }
 
-            var identity = new ClaimsIdentity(Options.ClaimsIssuer);
+            var identity = new ClaimsIdentity(ClaimsIssuer);
 
             if (Options.SaveTokens)
             {

--- a/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthInitializer.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthInitializer.cs
@@ -1,0 +1,54 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OAuth;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Used to setup defaults for the OAuthOptions.
+    /// </summary>
+    public class OAuthInitializer<TOptions, THandler> : IInitializeOptions<TOptions>
+        where TOptions : OAuthOptions, new()
+        where THandler : OAuthHandler<TOptions>
+    {
+        private readonly IDataProtectionProvider _dp;
+
+        public OAuthInitializer(IDataProtectionProvider dataProtection)
+        {
+            _dp = dataProtection;
+        }
+
+        public void Initialize(string name, TOptions options)
+        {
+            options.DataProtectionProvider = options.DataProtectionProvider ?? _dp;
+            if (options.Backchannel == null)
+            {
+                options.Backchannel = new HttpClient(options.BackchannelHttpHandler ?? new HttpClientHandler());
+                options.Backchannel.DefaultRequestHeaders.UserAgent.ParseAdd("Microsoft ASP.NET Core OAuth handler");
+                options.Backchannel.Timeout = options.BackchannelTimeout;
+                options.Backchannel.MaxResponseContentBufferSize = 1024 * 1024 * 10; // 10 MB
+            }
+
+            if (options.StateDataFormat == null)
+            {
+                if (options.DataProtectionProvider == null)
+                {
+                    // This shouldn't happen normally due to the EnsureDataProtection initialize options.
+                    throw new InvalidOperationException("DataProtectionProvider must be provided.");
+                }
+
+                var dataProtector = options.DataProtectionProvider.CreateProtector(
+                    typeof(THandler).FullName, name, "v1");
+                options.StateDataFormat = new PropertiesDataFormat(dataProtector);
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthInitializer.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthInitializer.cs
@@ -1,13 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Net.Http;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.AspNetCore.DataProtection;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -39,12 +36,6 @@ namespace Microsoft.Extensions.DependencyInjection
 
             if (options.StateDataFormat == null)
             {
-                if (options.DataProtectionProvider == null)
-                {
-                    // This shouldn't happen normally due to the EnsureDataProtection initialize options.
-                    throw new InvalidOperationException("DataProtectionProvider must be provided.");
-                }
-
                 var dataProtector = options.DataProtectionProvider.CreateProtector(
                     typeof(THandler).FullName, name, "v1");
                 options.StateDataFormat = new PropertiesDataFormat(dataProtector);

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectExtensions.cs
@@ -2,8 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Net.Http;
+using System.Text;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -26,7 +33,117 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static IServiceCollection AddOpenIdConnectAuthentication(this IServiceCollection services, string authenticationScheme, Action<OpenIdConnectOptions> configureOptions)
         {
-            return services.AddScheme<OpenIdConnectOptions, OpenIdConnectHandler>(authenticationScheme, authenticationScheme, configureOptions);
+            // Makes sure that DataProtectionProvider is always set.
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IInitializeOptions<OpenIdConnectOptions>, EnsureDataProtection>());
+            services.Initialize<OpenIdConnectOptions>(authenticationScheme, options =>
+            {
+                if (string.IsNullOrEmpty(options.SignOutScheme))
+                {
+                    options.SignOutScheme = options.SignInScheme;
+                }
+
+                if (options.StateDataFormat == null)
+                {
+                    if (options.DataProtectionProvider == null)
+                    {
+                        // This shouldn't happen normally due to the EnsureDataProtection initialize options.
+                        throw new InvalidOperationException("DataProtectionProvider must be provided.");
+                    }
+
+                    var dataProtector = options.DataProtectionProvider.CreateProtector(
+                        typeof(OpenIdConnectHandler).FullName, authenticationScheme, "v1");
+                    options.StateDataFormat = new PropertiesDataFormat(dataProtector);
+                }
+
+                if (options.StringDataFormat == null)
+                {
+                    if (options.DataProtectionProvider == null)
+                    {
+                        // This shouldn't happen normally due to the EnsureDataProtection initialize options.
+                        throw new InvalidOperationException("DataProtectionProvider must be provided.");
+                    }
+
+                    var dataProtector = options.DataProtectionProvider.CreateProtector(
+                        typeof(OpenIdConnectHandler).FullName,
+                        typeof(string).FullName,
+                        authenticationScheme,
+                        "v1");
+
+                    options.StringDataFormat = new SecureDataFormat<string>(new StringSerializer(), dataProtector);
+                }
+
+                if (string.IsNullOrEmpty(options.TokenValidationParameters.ValidAudience) && !string.IsNullOrEmpty(options.ClientId))
+                {
+                    options.TokenValidationParameters.ValidAudience = options.ClientId;
+                }
+
+                if (options.Backchannel == null)
+                {
+                    options.Backchannel = new HttpClient(options.BackchannelHttpHandler ?? new HttpClientHandler());
+                    options.Backchannel.DefaultRequestHeaders.UserAgent.ParseAdd("Microsoft ASP.NET Core OpenIdConnect handler");
+                    options.Backchannel.Timeout = options.BackchannelTimeout;
+                    options.Backchannel.MaxResponseContentBufferSize = 1024 * 1024 * 10; // 10 MB
+                }
+
+                if (options.ConfigurationManager == null)
+                {
+                    if (options.Configuration != null)
+                    {
+                        options.ConfigurationManager = new StaticConfigurationManager<OpenIdConnectConfiguration>(options.Configuration);
+                    }
+                    else if (!(string.IsNullOrEmpty(options.MetadataAddress) && string.IsNullOrEmpty(options.Authority)))
+                    {
+                        if (string.IsNullOrEmpty(options.MetadataAddress) && !string.IsNullOrEmpty(options.Authority))
+                        {
+                            options.MetadataAddress = options.Authority;
+                            if (!options.MetadataAddress.EndsWith("/", StringComparison.Ordinal))
+                            {
+                                options.MetadataAddress += "/";
+                            }
+
+                            options.MetadataAddress += ".well-known/openid-configuration";
+                        }
+
+                        if (options.RequireHttpsMetadata && !options.MetadataAddress.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+                        {
+                            throw new InvalidOperationException("The MetadataAddress or Authority must use HTTPS unless disabled for development by setting RequireHttpsMetadata=false.");
+                        }
+
+                        options.ConfigurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(options.MetadataAddress, new OpenIdConnectConfigurationRetriever(),
+                            new HttpDocumentRetriever(options.Backchannel) { RequireHttps = options.RequireHttpsMetadata });
+                    }
+                }
+            });
+            return services.AddRemoteScheme<OpenIdConnectOptions, OpenIdConnectHandler>(authenticationScheme, authenticationScheme, configureOptions);
+        }
+
+        // Used to ensure that there's always a default data protection provider
+        private class EnsureDataProtection : IInitializeOptions<OpenIdConnectOptions>
+        {
+            private readonly IDataProtectionProvider _dp;
+
+            public EnsureDataProtection(IDataProtectionProvider dataProtection)
+            {
+                _dp = dataProtection;
+            }
+
+            public void Initialize(string name, OpenIdConnectOptions options)
+            {
+                options.DataProtectionProvider = options.DataProtectionProvider ?? _dp;
+            }
+        }
+
+        private class StringSerializer : IDataSerializer<string>
+        {
+            public string Deserialize(byte[] data)
+            {
+                return Encoding.UTF8.GetString(data);
+            }
+
+            public byte[] Serialize(string model)
+            {
+                return Encoding.UTF8.GetBytes(model);
+            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectExtensions.cs
@@ -2,15 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Net.Http;
-using System.Text;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
-using Microsoft.IdentityModel.Protocols;
-using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -33,117 +27,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static IServiceCollection AddOpenIdConnectAuthentication(this IServiceCollection services, string authenticationScheme, Action<OpenIdConnectOptions> configureOptions)
         {
-            // Makes sure that DataProtectionProvider is always set.
-            services.TryAddEnumerable(ServiceDescriptor.Singleton<IInitializeOptions<OpenIdConnectOptions>, EnsureDataProtection>());
-            services.Initialize<OpenIdConnectOptions>(authenticationScheme, options =>
-            {
-                if (string.IsNullOrEmpty(options.SignOutScheme))
-                {
-                    options.SignOutScheme = options.SignInScheme;
-                }
-
-                if (options.StateDataFormat == null)
-                {
-                    if (options.DataProtectionProvider == null)
-                    {
-                        // This shouldn't happen normally due to the EnsureDataProtection initialize options.
-                        throw new InvalidOperationException("DataProtectionProvider must be provided.");
-                    }
-
-                    var dataProtector = options.DataProtectionProvider.CreateProtector(
-                        typeof(OpenIdConnectHandler).FullName, authenticationScheme, "v1");
-                    options.StateDataFormat = new PropertiesDataFormat(dataProtector);
-                }
-
-                if (options.StringDataFormat == null)
-                {
-                    if (options.DataProtectionProvider == null)
-                    {
-                        // This shouldn't happen normally due to the EnsureDataProtection initialize options.
-                        throw new InvalidOperationException("DataProtectionProvider must be provided.");
-                    }
-
-                    var dataProtector = options.DataProtectionProvider.CreateProtector(
-                        typeof(OpenIdConnectHandler).FullName,
-                        typeof(string).FullName,
-                        authenticationScheme,
-                        "v1");
-
-                    options.StringDataFormat = new SecureDataFormat<string>(new StringSerializer(), dataProtector);
-                }
-
-                if (string.IsNullOrEmpty(options.TokenValidationParameters.ValidAudience) && !string.IsNullOrEmpty(options.ClientId))
-                {
-                    options.TokenValidationParameters.ValidAudience = options.ClientId;
-                }
-
-                if (options.Backchannel == null)
-                {
-                    options.Backchannel = new HttpClient(options.BackchannelHttpHandler ?? new HttpClientHandler());
-                    options.Backchannel.DefaultRequestHeaders.UserAgent.ParseAdd("Microsoft ASP.NET Core OpenIdConnect handler");
-                    options.Backchannel.Timeout = options.BackchannelTimeout;
-                    options.Backchannel.MaxResponseContentBufferSize = 1024 * 1024 * 10; // 10 MB
-                }
-
-                if (options.ConfigurationManager == null)
-                {
-                    if (options.Configuration != null)
-                    {
-                        options.ConfigurationManager = new StaticConfigurationManager<OpenIdConnectConfiguration>(options.Configuration);
-                    }
-                    else if (!(string.IsNullOrEmpty(options.MetadataAddress) && string.IsNullOrEmpty(options.Authority)))
-                    {
-                        if (string.IsNullOrEmpty(options.MetadataAddress) && !string.IsNullOrEmpty(options.Authority))
-                        {
-                            options.MetadataAddress = options.Authority;
-                            if (!options.MetadataAddress.EndsWith("/", StringComparison.Ordinal))
-                            {
-                                options.MetadataAddress += "/";
-                            }
-
-                            options.MetadataAddress += ".well-known/openid-configuration";
-                        }
-
-                        if (options.RequireHttpsMetadata && !options.MetadataAddress.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
-                        {
-                            throw new InvalidOperationException("The MetadataAddress or Authority must use HTTPS unless disabled for development by setting RequireHttpsMetadata=false.");
-                        }
-
-                        options.ConfigurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(options.MetadataAddress, new OpenIdConnectConfigurationRetriever(),
-                            new HttpDocumentRetriever(options.Backchannel) { RequireHttps = options.RequireHttpsMetadata });
-                    }
-                }
-            });
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IInitializeOptions<OpenIdConnectOptions>, OpenIdConnectInitializer>());
             return services.AddRemoteScheme<OpenIdConnectOptions, OpenIdConnectHandler>(authenticationScheme, authenticationScheme, configureOptions);
-        }
-
-        // Used to ensure that there's always a default data protection provider
-        private class EnsureDataProtection : IInitializeOptions<OpenIdConnectOptions>
-        {
-            private readonly IDataProtectionProvider _dp;
-
-            public EnsureDataProtection(IDataProtectionProvider dataProtection)
-            {
-                _dp = dataProtection;
-            }
-
-            public void Initialize(string name, OpenIdConnectOptions options)
-            {
-                options.DataProtectionProvider = options.DataProtectionProvider ?? _dp;
-            }
-        }
-
-        private class StringSerializer : IDataSerializer<string>
-        {
-            public string Deserialize(byte[] data)
-            {
-                return Encoding.UTF8.GetString(data);
-            }
-
-            public byte[] Serialize(string model)
-            {
-                return Encoding.UTF8.GetBytes(model);
-            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
@@ -13,12 +13,10 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
-using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Net.Http.Headers;
@@ -57,8 +55,8 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
 
         protected HtmlEncoder HtmlEncoder { get; }
 
-        public OpenIdConnectHandler(IOptions<AuthenticationOptions> sharedOptions, IOptionsSnapshot<OpenIdConnectOptions> options, ILoggerFactory logger, HtmlEncoder htmlEncoder, UrlEncoder encoder, IDataProtectionProvider dataProtection, ISystemClock clock)
-            : base(sharedOptions, options, dataProtection, logger, encoder, clock)
+        public OpenIdConnectHandler(IOptionsSnapshot<OpenIdConnectOptions> options, ILoggerFactory logger, HtmlEncoder htmlEncoder, UrlEncoder encoder, ISystemClock clock)
+            : base(options, logger, encoder, clock)
         {
             HtmlEncoder = htmlEncoder;
         }
@@ -74,76 +72,6 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
         }
 
         protected override Task<object> CreateEventsAsync() => Task.FromResult<object>(new OpenIdConnectEvents());
-
-        protected override void InitializeOptions()
-        {
-            base.InitializeOptions();
-
-            if (string.IsNullOrEmpty(Options.SignOutScheme))
-            {
-                Options.SignOutScheme = SignInScheme;
-            }
-
-            if (Options.StateDataFormat == null)
-            {
-                var dataProtector = DataProtection.CreateProtector(
-                    GetType().FullName, Scheme.Name, "v1");
-                Options.StateDataFormat = new PropertiesDataFormat(dataProtector);
-            }
-
-            if (Options.StringDataFormat == null)
-            {
-                var dataProtector = DataProtection.CreateProtector(
-                    GetType().FullName,
-                    typeof(string).FullName,
-                    Scheme.Name,
-                    "v1");
-
-                Options.StringDataFormat = new SecureDataFormat<string>(new StringSerializer(), dataProtector);
-            }
-
-            if (string.IsNullOrEmpty(Options.TokenValidationParameters.ValidAudience) && !string.IsNullOrEmpty(Options.ClientId))
-            {
-                Options.TokenValidationParameters.ValidAudience = Options.ClientId;
-            }
-
-            if (Options.Backchannel == null)
-            {
-                Options.Backchannel = new HttpClient(Options.BackchannelHttpHandler ?? new HttpClientHandler());
-                Options.Backchannel.DefaultRequestHeaders.UserAgent.ParseAdd("Microsoft ASP.NET Core OpenIdConnect handler");
-                Options.Backchannel.Timeout = Options.BackchannelTimeout;
-                Options.Backchannel.MaxResponseContentBufferSize = 1024 * 1024 * 10; // 10 MB
-            }
-
-            if (Options.ConfigurationManager == null)
-            {
-                if (Options.Configuration != null)
-                {
-                    Options.ConfigurationManager = new StaticConfigurationManager<OpenIdConnectConfiguration>(Options.Configuration);
-                }
-                else if (!(string.IsNullOrEmpty(Options.MetadataAddress) && string.IsNullOrEmpty(Options.Authority)))
-                {
-                    if (string.IsNullOrEmpty(Options.MetadataAddress) && !string.IsNullOrEmpty(Options.Authority))
-                    {
-                        Options.MetadataAddress = Options.Authority;
-                        if (!Options.MetadataAddress.EndsWith("/", StringComparison.Ordinal))
-                        {
-                            Options.MetadataAddress += "/";
-                        }
-
-                        Options.MetadataAddress += ".well-known/openid-configuration";
-                    }
-
-                    if (Options.RequireHttpsMetadata && !Options.MetadataAddress.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
-                    {
-                        throw new InvalidOperationException("The MetadataAddress or Authority must use HTTPS unless disabled for development by setting RequireHttpsMetadata=false.");
-                    }
-
-                    Options.ConfigurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(Options.MetadataAddress, new OpenIdConnectConfigurationRetriever(),
-                        new HttpDocumentRetriever(Backchannel) { RequireHttps = Options.RequireHttpsMetadata });
-                }
-            }
-        }
 
         public override Task<bool> HandleRequestAsync()
         {
@@ -1300,19 +1228,6 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                 message.Error,
                 description,
                 errorUri));
-        }
-
-        private class StringSerializer : IDataSerializer<string>
-        {
-            public string Deserialize(byte[] data)
-            {
-                return Encoding.UTF8.GetString(data);
-            }
-
-            public byte[] Serialize(string model)
-            {
-                return Encoding.UTF8.GetBytes(model);
-            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
@@ -749,7 +749,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                     var identity = (ClaimsIdentity)ticket.Principal.Identity;
                     foreach (var action in Options.ClaimActions)
                     {
-                        action.Run(null, identity, Options.ClaimsIssuer);
+                        action.Run(null, identity, ClaimsIssuer);
                     }
                 }
 
@@ -902,7 +902,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
 
             foreach (var action in Options.ClaimActions)
             {
-                action.Run(user, identity, Options.ClaimsIssuer);
+                action.Run(user, identity, ClaimsIssuer);
             }
 
             return AuthenticateResult.Success(ticket);

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectInitializer.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectInitializer.cs
@@ -1,0 +1,126 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using System.Text;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
+{
+    /// <summary>
+    /// Used to setup defaults for all <see cref="OpenIdConnectOptions"/>.
+    /// </summary>
+    public class OpenIdConnectInitializer : IInitializeOptions<OpenIdConnectOptions>
+    {
+        private readonly IDataProtectionProvider _dp;
+
+        public OpenIdConnectInitializer(IDataProtectionProvider dataProtection)
+        {
+            _dp = dataProtection;
+        }
+
+        /// <summary>
+        /// Invoked to initialize a TOptions instance.
+        /// </summary>
+        /// <param name="name">The name of the options instance being initialized.</param>
+        /// <param name="options">The options instance to initialize.</param>
+        public void Initialize(string name, OpenIdConnectOptions options)
+        {
+            options.DataProtectionProvider = options.DataProtectionProvider ?? _dp;
+
+            if (string.IsNullOrEmpty(options.SignOutScheme))
+            {
+                options.SignOutScheme = options.SignInScheme;
+            }
+
+            if (options.StateDataFormat == null)
+            {
+                if (options.DataProtectionProvider == null)
+                {
+                    // This shouldn't happen normally due to the EnsureDataProtection initialize options.
+                    throw new InvalidOperationException("DataProtectionProvider must be provided.");
+                }
+
+                var dataProtector = options.DataProtectionProvider.CreateProtector(
+                    typeof(OpenIdConnectHandler).FullName, name, "v1");
+                options.StateDataFormat = new PropertiesDataFormat(dataProtector);
+            }
+
+            if (options.StringDataFormat == null)
+            {
+                if (options.DataProtectionProvider == null)
+                {
+                    // This shouldn't happen normally due to the EnsureDataProtection initialize options.
+                    throw new InvalidOperationException("DataProtectionProvider must be provided.");
+                }
+
+                var dataProtector = options.DataProtectionProvider.CreateProtector(
+                    typeof(OpenIdConnectHandler).FullName,
+                    typeof(string).FullName,
+                    name,
+                    "v1");
+
+                options.StringDataFormat = new SecureDataFormat<string>(new StringSerializer(), dataProtector);
+            }
+
+            if (string.IsNullOrEmpty(options.TokenValidationParameters.ValidAudience) && !string.IsNullOrEmpty(options.ClientId))
+            {
+                options.TokenValidationParameters.ValidAudience = options.ClientId;
+            }
+
+            if (options.Backchannel == null)
+            {
+                options.Backchannel = new HttpClient(options.BackchannelHttpHandler ?? new HttpClientHandler());
+                options.Backchannel.DefaultRequestHeaders.UserAgent.ParseAdd("Microsoft ASP.NET Core OpenIdConnect handler");
+                options.Backchannel.Timeout = options.BackchannelTimeout;
+                options.Backchannel.MaxResponseContentBufferSize = 1024 * 1024 * 10; // 10 MB
+            }
+
+            if (options.ConfigurationManager == null)
+            {
+                if (options.Configuration != null)
+                {
+                    options.ConfigurationManager = new StaticConfigurationManager<OpenIdConnectConfiguration>(options.Configuration);
+                }
+                else if (!(string.IsNullOrEmpty(options.MetadataAddress) && string.IsNullOrEmpty(options.Authority)))
+                {
+                    if (string.IsNullOrEmpty(options.MetadataAddress) && !string.IsNullOrEmpty(options.Authority))
+                    {
+                        options.MetadataAddress = options.Authority;
+                        if (!options.MetadataAddress.EndsWith("/", StringComparison.Ordinal))
+                        {
+                            options.MetadataAddress += "/";
+                        }
+
+                        options.MetadataAddress += ".well-known/openid-configuration";
+                    }
+
+                    if (options.RequireHttpsMetadata && !options.MetadataAddress.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new InvalidOperationException("The MetadataAddress or Authority must use HTTPS unless disabled for development by setting RequireHttpsMetadata=false.");
+                    }
+
+                    options.ConfigurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(options.MetadataAddress, new OpenIdConnectConfigurationRetriever(),
+                        new HttpDocumentRetriever(options.Backchannel) { RequireHttps = options.RequireHttpsMetadata });
+                }
+            }
+        }
+
+        private class StringSerializer : IDataSerializer<string>
+        {
+            public string Deserialize(byte[] data)
+            {
+                return Encoding.UTF8.GetString(data);
+            }
+
+            public byte[] Serialize(string model)
+            {
+                return Encoding.UTF8.GetBytes(model);
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectInitializer.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectInitializer.cs
@@ -39,12 +39,6 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
 
             if (options.StateDataFormat == null)
             {
-                if (options.DataProtectionProvider == null)
-                {
-                    // This shouldn't happen normally due to the EnsureDataProtection initialize options.
-                    throw new InvalidOperationException("DataProtectionProvider must be provided.");
-                }
-
                 var dataProtector = options.DataProtectionProvider.CreateProtector(
                     typeof(OpenIdConnectHandler).FullName, name, "v1");
                 options.StateDataFormat = new PropertiesDataFormat(dataProtector);
@@ -52,12 +46,6 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
 
             if (options.StringDataFormat == null)
             {
-                if (options.DataProtectionProvider == null)
-                {
-                    // This shouldn't happen normally due to the EnsureDataProtection initialize options.
-                    throw new InvalidOperationException("DataProtectionProvider must be provided.");
-                }
-
                 var dataProtector = options.DataProtectionProvider.CreateProtector(
                     typeof(OpenIdConnectHandler).FullName,
                     typeof(string).FullName,

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectOptions.cs
@@ -39,7 +39,6 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
         /// </remarks>
         public OpenIdConnectOptions()
         {
-            DisplayName = OpenIdConnectDefaults.Caption;
             CallbackPath = new PathString("/signin-oidc");
             SignedOutCallbackPath = new PathString("/signout-callback-oidc");
             RemoteSignOutPath = new PathString("/signout-oidc");

--- a/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterExtensions.cs
@@ -2,10 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Net.Http;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Twitter;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
@@ -30,51 +27,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static IServiceCollection AddTwitterAuthentication(this IServiceCollection services, string authenticationScheme, Action<TwitterOptions> configureOptions)
         {
-            services.TryAddEnumerable(ServiceDescriptor.Singleton<IInitializeOptions<TwitterOptions>, EnsureDataProtection>());
-            services.Initialize<TwitterOptions>(authenticationScheme, options =>
-            {
-                if (options.StateDataFormat == null)
-                {
-                    if (options.DataProtectionProvider == null)
-                    {
-                        // This shouldn't happen normally due to the EnsureDataProtection initialize options.
-                        throw new InvalidOperationException("DataProtectionProvider must be provided.");
-                    }
-
-                    var dataProtector = options.DataProtectionProvider.CreateProtector(
-                        typeof(TwitterHandler).FullName, authenticationScheme, "v1");
-                    options.StateDataFormat = new SecureDataFormat<RequestToken>(
-                        new RequestTokenSerializer(),
-                        dataProtector);
-                }
-
-                if (options.Backchannel == null)
-                {
-                    options.Backchannel = new HttpClient(options.BackchannelHttpHandler ?? new HttpClientHandler());
-                    options.Backchannel.Timeout = options.BackchannelTimeout;
-                    options.Backchannel.MaxResponseContentBufferSize = 1024 * 1024 * 10; // 10 MB
-                    options.Backchannel.DefaultRequestHeaders.Accept.ParseAdd("*/*");
-                    options.Backchannel.DefaultRequestHeaders.UserAgent.ParseAdd("Microsoft ASP.NET Core Twitter handler");
-                    options.Backchannel.DefaultRequestHeaders.ExpectContinue = false;
-                }
-            });
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IInitializeOptions<TwitterOptions>, TwitterInitializer>());
             return services.AddRemoteScheme<TwitterOptions, TwitterHandler>(authenticationScheme, authenticationScheme, configureOptions);
-        }
-
-        // Used to ensure that there's always a default data protection provider
-        private class EnsureDataProtection : IInitializeOptions<TwitterOptions>
-        {
-            private readonly IDataProtectionProvider _dp;
-
-            public EnsureDataProtection(IDataProtectionProvider dataProtection)
-            {
-                _dp = dataProtection;
-            }
-
-            public void Initialize(string name, TwitterOptions options)
-            {
-                options.DataProtectionProvider = options.DataProtectionProvider ?? _dp;
-            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterExtensions.cs
@@ -2,7 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Net.Http;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Twitter;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -26,7 +30,51 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static IServiceCollection AddTwitterAuthentication(this IServiceCollection services, string authenticationScheme, Action<TwitterOptions> configureOptions)
         {
-            return services.AddScheme<TwitterOptions, TwitterHandler>(authenticationScheme, authenticationScheme, configureOptions);
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IInitializeOptions<TwitterOptions>, EnsureDataProtection>());
+            services.Initialize<TwitterOptions>(authenticationScheme, options =>
+            {
+                if (options.StateDataFormat == null)
+                {
+                    if (options.DataProtectionProvider == null)
+                    {
+                        // This shouldn't happen normally due to the EnsureDataProtection initialize options.
+                        throw new InvalidOperationException("DataProtectionProvider must be provided.");
+                    }
+
+                    var dataProtector = options.DataProtectionProvider.CreateProtector(
+                        typeof(TwitterHandler).FullName, authenticationScheme, "v1");
+                    options.StateDataFormat = new SecureDataFormat<RequestToken>(
+                        new RequestTokenSerializer(),
+                        dataProtector);
+                }
+
+                if (options.Backchannel == null)
+                {
+                    options.Backchannel = new HttpClient(options.BackchannelHttpHandler ?? new HttpClientHandler());
+                    options.Backchannel.Timeout = options.BackchannelTimeout;
+                    options.Backchannel.MaxResponseContentBufferSize = 1024 * 1024 * 10; // 10 MB
+                    options.Backchannel.DefaultRequestHeaders.Accept.ParseAdd("*/*");
+                    options.Backchannel.DefaultRequestHeaders.UserAgent.ParseAdd("Microsoft ASP.NET Core Twitter handler");
+                    options.Backchannel.DefaultRequestHeaders.ExpectContinue = false;
+                }
+            });
+            return services.AddRemoteScheme<TwitterOptions, TwitterHandler>(authenticationScheme, authenticationScheme, configureOptions);
+        }
+
+        // Used to ensure that there's always a default data protection provider
+        private class EnsureDataProtection : IInitializeOptions<TwitterOptions>
+        {
+            private readonly IDataProtectionProvider _dp;
+
+            public EnsureDataProtection(IDataProtectionProvider dataProtection)
+            {
+                _dp = dataProtection;
+            }
+
+            public void Initialize(string name, TwitterOptions options)
+            {
+                options.DataProtectionProvider = options.DataProtectionProvider ?? _dp;
+            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterHandler.cs
@@ -116,12 +116,12 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
 
             var identity = new ClaimsIdentity(new[]
             {
-                new Claim(ClaimTypes.NameIdentifier, accessToken.UserId, ClaimValueTypes.String, Options.ClaimsIssuer),
-                new Claim(ClaimTypes.Name, accessToken.ScreenName, ClaimValueTypes.String, Options.ClaimsIssuer),
-                new Claim("urn:twitter:userid", accessToken.UserId, ClaimValueTypes.String, Options.ClaimsIssuer),
-                new Claim("urn:twitter:screenname", accessToken.ScreenName, ClaimValueTypes.String, Options.ClaimsIssuer)
+                new Claim(ClaimTypes.NameIdentifier, accessToken.UserId, ClaimValueTypes.String, ClaimsIssuer),
+                new Claim(ClaimTypes.Name, accessToken.ScreenName, ClaimValueTypes.String, ClaimsIssuer),
+                new Claim("urn:twitter:userid", accessToken.UserId, ClaimValueTypes.String, ClaimsIssuer),
+                new Claim("urn:twitter:screenname", accessToken.ScreenName, ClaimValueTypes.String, ClaimsIssuer)
             },
-            Options.ClaimsIssuer);
+            ClaimsIssuer);
 
             JObject user = null;
             if (Options.RetrieveUserDetails)
@@ -145,7 +145,7 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
         {
             foreach (var action in Options.ClaimActions)
             {
-                action.Run(user, identity, Options.ClaimsIssuer);
+                action.Run(user, identity, ClaimsIssuer);
             }
 
             var context = new TwitterCreatingTicketContext(Context, Scheme, Options, properties, token.UserId, token.ScreenName, token.Token, token.TokenSecret, user)

--- a/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterHandler.cs
@@ -40,35 +40,11 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
             set { base.Events = value; }
         }
 
-        public TwitterHandler(IOptions<AuthenticationOptions> sharedOptions, IOptionsSnapshot<TwitterOptions> options, ILoggerFactory logger, UrlEncoder encoder, IDataProtectionProvider dataProtection, ISystemClock clock)
-            : base(sharedOptions, options, dataProtection, logger, encoder, clock)
+        public TwitterHandler(IOptionsSnapshot<TwitterOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
+            : base(options, logger, encoder, clock)
         { }
 
         protected override Task<object> CreateEventsAsync() => Task.FromResult<object>(new TwitterEvents());
-
-        protected override void InitializeOptions()
-        {
-            base.InitializeOptions();
-
-            if (Options.StateDataFormat == null)
-            {
-                var dataProtector = DataProtection.CreateProtector(
-                    GetType().FullName, Scheme.Name, "v1");
-                Options.StateDataFormat = new SecureDataFormat<RequestToken>(
-                    new RequestTokenSerializer(),
-                    dataProtector);
-            }
-
-            if (Options.Backchannel == null)
-            {
-                Options.Backchannel = new HttpClient(Options.BackchannelHttpHandler ?? new HttpClientHandler());
-                Options.Backchannel.Timeout = Options.BackchannelTimeout;
-                Options.Backchannel.MaxResponseContentBufferSize = 1024 * 1024 * 10; // 10 MB
-                Options.Backchannel.DefaultRequestHeaders.Accept.ParseAdd("*/*");
-                Options.Backchannel.DefaultRequestHeaders.UserAgent.ParseAdd("Microsoft ASP.NET Core Twitter handler");
-                Options.Backchannel.DefaultRequestHeaders.ExpectContinue = false;
-            }
-        }
 
         protected override async Task<AuthenticateResult> HandleRemoteAuthenticateAsync()
         {

--- a/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterInitializer.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterInitializer.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Net.Http;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Options;
@@ -31,12 +30,6 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
 
             if (options.StateDataFormat == null)
             {
-                if (options.DataProtectionProvider == null)
-                {
-                    // This shouldn't happen normally due to the EnsureDataProtection initialize options.
-                    throw new InvalidOperationException("DataProtectionProvider must be provided.");
-                }
-
                 var dataProtector = options.DataProtectionProvider.CreateProtector(
                     typeof(TwitterHandler).FullName, name, "v1");
                 options.StateDataFormat = new SecureDataFormat<RequestToken>(

--- a/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterInitializer.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterInitializer.cs
@@ -1,0 +1,58 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Authentication.Twitter
+{
+    /// <summary>
+    /// Used to setup defaults for all <see cref="TwitterOptions"/>.
+    /// </summary>
+    public class TwitterInitializer : IInitializeOptions<TwitterOptions>
+    {
+        private readonly IDataProtectionProvider _dp;
+
+        public TwitterInitializer(IDataProtectionProvider dataProtection)
+        {
+            _dp = dataProtection;
+        }
+
+        /// <summary>
+        /// Invoked to initialize a TOptions instance.
+        /// </summary>
+        /// <param name="name">The name of the options instance being initialized.</param>
+        /// <param name="options">The options instance to initialize.</param>
+        public void Initialize(string name, TwitterOptions options)
+        {
+            options.DataProtectionProvider = options.DataProtectionProvider ?? _dp;
+
+            if (options.StateDataFormat == null)
+            {
+                if (options.DataProtectionProvider == null)
+                {
+                    // This shouldn't happen normally due to the EnsureDataProtection initialize options.
+                    throw new InvalidOperationException("DataProtectionProvider must be provided.");
+                }
+
+                var dataProtector = options.DataProtectionProvider.CreateProtector(
+                    typeof(TwitterHandler).FullName, name, "v1");
+                options.StateDataFormat = new SecureDataFormat<RequestToken>(
+                    new RequestTokenSerializer(),
+                    dataProtector);
+            }
+
+            if (options.Backchannel == null)
+            {
+                options.Backchannel = new HttpClient(options.BackchannelHttpHandler ?? new HttpClientHandler());
+                options.Backchannel.Timeout = options.BackchannelTimeout;
+                options.Backchannel.MaxResponseContentBufferSize = 1024 * 1024 * 10; // 10 MB
+                options.Backchannel.DefaultRequestHeaders.Accept.ParseAdd("*/*");
+                options.Backchannel.DefaultRequestHeaders.UserAgent.ParseAdd("Microsoft ASP.NET Core Twitter handler");
+                options.Backchannel.DefaultRequestHeaders.ExpectContinue = false;
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Authentication/AuthenticationHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication/AuthenticationHandler.cs
@@ -87,18 +87,6 @@ namespace Microsoft.AspNetCore.Authentication
             Context = context;
 
             Options = OptionsSnapshot.Get(Scheme.Name) ?? new TOptions();
-            if (!Options.Initialized)
-            {
-                lock (Options.InitializeLock)
-                {
-                    if (!Options.Initialized)
-                    {
-                        InitializeOptions();
-                        Options.Initialized = true;
-                    }
-                }
-            }
-
             Options.Validate();
 
             await InitializeEventsAsync();
@@ -123,13 +111,6 @@ namespace Microsoft.AspNetCore.Authentication
         /// </summary>
         /// <returns>A new instance of the events instance.</returns>
         protected virtual Task<object> CreateEventsAsync() => Task.FromResult(new object());
-
-        /// <summary>
-        /// Initializes the options, will be called only once by <see cref="InitializeAsync(AuthenticationScheme, HttpContext)"/>.
-        /// </summary>
-        protected virtual void InitializeOptions()
-        {
-        }
 
         /// <summary>
         /// Called after options/events have been initialized for the handler to finish initializing itself.

--- a/src/Microsoft.AspNetCore.Authentication/AuthenticationHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication/AuthenticationHandler.cs
@@ -48,6 +48,8 @@ namespace Microsoft.AspNetCore.Authentication
         /// </summary>
         protected virtual object Events { get; set; }
 
+        protected virtual string ClaimsIssuer => Options.ClaimsIssuer ?? Scheme.Name;
+
         protected string CurrentUri
         {
             get
@@ -127,9 +129,6 @@ namespace Microsoft.AspNetCore.Authentication
         /// </summary>
         protected virtual void InitializeOptions()
         {
-            // REVIEW: is there a better place for this default?
-            Options.DisplayName = Options.DisplayName ?? Scheme.Name;
-            Options.ClaimsIssuer = Options.ClaimsIssuer ?? Scheme.Name;
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Authentication/AuthenticationSchemeOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication/AuthenticationSchemeOptions.cs
@@ -40,15 +40,5 @@ namespace Microsoft.AspNetCore.Authentication
         /// If set, will be used as the service type to get the Events instance instead of the property.
         /// </summary>
         public Type EventsType { get; set; }
-
-        /// <summary>
-        /// Used to ensure that the options are only initialized once.
-        /// </summary>
-        public bool Initialized { get; set; }
-
-        /// <summary>
-        /// Used to prevent concurrent access during intialization.
-        /// </summary>
-        public object InitializeLock { get; } = new object();
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication/AuthenticationSchemeOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication/AuthenticationSchemeOptions.cs
@@ -2,9 +2,18 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Authentication
 {
+    public class InitializeAuthenticationSchemeOptions<TOptions> : InitializeOptions<TOptions>
+        where TOptions : AuthenticationSchemeOptions
+    {
+        public InitializeAuthenticationSchemeOptions(string name) 
+            : base(name, options => options.ClaimsIssuer = options.ClaimsIssuer ?? name)
+        { }
+    }
+
     /// <summary>
     /// Contains the options used by the <see cref="AuthenticationHandler{T}"/>.
     /// </summary>
@@ -16,11 +25,6 @@ namespace Microsoft.AspNetCore.Authentication
         public virtual void Validate()
         {
         }
-
-        /// <summary>
-        /// Gets or sets the display name for the authentication provider.
-        /// </summary>
-        public string DisplayName { get; set; }
 
         /// <summary>
         /// Gets or sets the issuer that should be used for any claims that are created

--- a/src/Microsoft.AspNetCore.Authentication/AuthenticationServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication/AuthenticationServiceCollectionExtensions.cs
@@ -74,5 +74,30 @@ namespace Microsoft.Extensions.DependencyInjection
             where TOptions : AuthenticationSchemeOptions, new()
             where THandler : AuthenticationHandler<TOptions>
             => services.AddScheme<TOptions, THandler>(authenticationScheme, displayName, configureScheme: null, configureOptions: configureOptions);
+
+        public static IServiceCollection AddRemoteScheme<TOptions, THandler>(this IServiceCollection services, string authenticationScheme, string displayName, Action<TOptions> configureOptions)
+            where TOptions : RemoteAuthenticationOptions, new()
+            where THandler : AuthenticationHandler<TOptions>
+        {
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IInitializeOptions<TOptions>, EnsureSignInScheme<TOptions>>());
+            return services.AddScheme<TOptions, THandler>(authenticationScheme, displayName, configureScheme: null, configureOptions: configureOptions);
+        }
+
+        // Used to ensure that there's always a default data protection provider
+        private class EnsureSignInScheme<TOptions> : IInitializeOptions<TOptions> where TOptions : RemoteAuthenticationOptions
+        {
+            private readonly AuthenticationOptions _authOptions;
+
+            public EnsureSignInScheme(IOptions<AuthenticationOptions> authOptions)
+            {
+                _authOptions = authOptions.Value;
+            }
+
+            public void Initialize(string name, TOptions options)
+            {
+                options.SignInScheme = options.SignInScheme ?? _authOptions.DefaultSignInScheme;
+            }
+        }
+
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication/AuthenticationServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication/AuthenticationServiceCollectionExtensions.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static IServiceCollection AddRemoteScheme<TOptions, THandler>(this IServiceCollection services, string authenticationScheme, string displayName, Action<TOptions> configureOptions)
             where TOptions : RemoteAuthenticationOptions, new()
-            where THandler : AuthenticationHandler<TOptions>
+            where THandler : RemoteAuthenticationHandler<TOptions>
         {
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IInitializeOptions<TOptions>, EnsureSignInScheme<TOptions>>());
             return services.AddScheme<TOptions, THandler>(authenticationScheme, displayName, configureScheme: null, configureOptions: configureOptions);

--- a/src/Microsoft.AspNetCore.Authentication/Microsoft.AspNetCore.Authentication.csproj
+++ b/src/Microsoft.AspNetCore.Authentication/Microsoft.AspNetCore.Authentication.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="$(AspNetCoreVersion)" />
+    <ProjectReference Include="..\..\..\Options\src\Microsoft.Extensions.Options\Microsoft.Extensions.Options.csproj" />
     <PackageReference Include="Microsoft.Extensions.SecurityHelper.Sources"  Version="$(AspNetCoreVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.TaskCache.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.WebEncoders" Version="$(AspNetCoreVersion)" />

--- a/src/Microsoft.AspNetCore.Authentication/RemoteAuthenticationHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication/RemoteAuthenticationHandler.cs
@@ -5,9 +5,7 @@ using System;
 using System.Security.Cryptography;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -25,10 +23,6 @@ namespace Microsoft.AspNetCore.Authentication
 
         protected string SignInScheme => Options.SignInScheme;
 
-        protected IDataProtectionProvider DataProtection { get; set; }
-
-        private readonly AuthenticationOptions _authOptions;
-
         /// <summary>
         /// The handler calls methods on the events which give the application control at certain points where processing is occurring. 
         /// If it is not provided a default instance is supplied which does nothing when the methods are called.
@@ -39,32 +33,14 @@ namespace Microsoft.AspNetCore.Authentication
             set { base.Events = value; }
         }
 
-        protected RemoteAuthenticationHandler(IOptions<AuthenticationOptions> sharedOptions, IOptionsSnapshot<TOptions> options, IDataProtectionProvider dataProtection, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
+        protected RemoteAuthenticationHandler(IOptionsSnapshot<TOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
             : base(options, logger, encoder, clock)
         {
-            _authOptions = sharedOptions.Value;
-            DataProtection = dataProtection;
-        }
-
-        protected override Task InitializeHandlerAsync()
-        {
-            DataProtection = Options.DataProtectionProvider ?? DataProtection;
-            return TaskCache.CompletedTask;
         }
 
         protected override Task<object> CreateEventsAsync()
         {
             return Task.FromResult<object>(new RemoteAuthenticationEvents());
-        }
-
-        protected override void InitializeOptions()
-        {
-            base.InitializeOptions();
-
-            if (Options.SignInScheme == null)
-            {
-                Options.SignInScheme = _authOptions.DefaultSignInScheme;
-            }
         }
 
         public virtual Task<bool> ShouldHandleRequestAsync()

--- a/test/Microsoft.AspNetCore.Authentication.Test/FacebookTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/FacebookTests.cs
@@ -50,7 +50,6 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
                 {"Facebook:BackchannelTimeout", "0.0:0:30"},
                 //{"Facebook:CallbackPath", "/callbackpath"}, // PathString doesn't convert
                 {"Facebook:ClaimsIssuer", "<issuer>"},
-                {"Facebook:DisplayName", "<display>"},
                 {"Facebook:RemoteAuthenticationTimeout", "0.0:0:30"},
                 {"Facebook:SaveTokens", "true"},
                 {"Facebook:SendAppSecretProof", "true"},
@@ -73,7 +72,6 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             Assert.Equal("<issuer>", options.ClaimsIssuer);
             Assert.Equal("<id>", options.ClientId);
             Assert.Equal("<secret>", options.ClientSecret);
-            Assert.Equal("<display>", options.DisplayName);
             Assert.Equal(new TimeSpan(0, 0, 0, 30), options.RemoteAuthenticationTimeout);
             Assert.True(options.SaveTokens);
             Assert.True(options.SendAppSecretProof);

--- a/test/Microsoft.AspNetCore.Authentication.Test/GoogleTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/GoogleTests.cs
@@ -49,7 +49,6 @@ namespace Microsoft.AspNetCore.Authentication.Google
                 {"Google:BackchannelTimeout", "0.0:0:30"},
                 //{"Google:CallbackPath", "/callbackpath"}, // PathString doesn't convert
                 {"Google:ClaimsIssuer", "<issuer>"},
-                {"Google:DisplayName", "<display>"},
                 {"Google:RemoteAuthenticationTimeout", "0.0:0:30"},
                 {"Google:SaveTokens", "true"},
                 {"Google:SendAppSecretProof", "true"},
@@ -70,7 +69,6 @@ namespace Microsoft.AspNetCore.Authentication.Google
             Assert.Equal("<issuer>", options.ClaimsIssuer);
             Assert.Equal("<id>", options.ClientId);
             Assert.Equal("<secret>", options.ClientSecret);
-            Assert.Equal("<display>", options.DisplayName);
             Assert.Equal(new TimeSpan(0, 0, 0, 30), options.RemoteAuthenticationTimeout);
             Assert.True(options.SaveTokens);
             Assert.Equal("<signIn>", options.SignInScheme);

--- a/test/Microsoft.AspNetCore.Authentication.Test/JwtBearerTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/JwtBearerTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
                 {"Bearer:IncludeErrorDetails", "true"},
                 {"Bearer:MetadataAddress", "<metadata>"},
                 {"Bearer:RefreshOnIssuerKeyNotFound", "true"},
-                {"Bearer:RequireHttpsMetadata", "true"},
+                {"Bearer:RequireHttpsMetadata", "false"},
                 {"Bearer:SaveToken", "true"},
             };
             var configurationBuilder = new ConfigurationBuilder();
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
             Assert.True(options.IncludeErrorDetails);
             Assert.Equal("<metadata>", options.MetadataAddress);
             Assert.True(options.RefreshOnIssuerKeyNotFound);
-            Assert.True(options.RequireHttpsMetadata);
+            Assert.False(options.RequireHttpsMetadata);
             Assert.True(options.SaveToken);
         }
 

--- a/test/Microsoft.AspNetCore.Authentication.Test/JwtBearerTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/JwtBearerTests.cs
@@ -48,7 +48,6 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
                 {"Bearer:BackchannelTimeout", "0.0:0:30"},
                 {"Bearer:Challenge", "<challenge>"},
                 {"Bearer:ClaimsIssuer", "<issuer>"},
-                {"Bearer:DisplayName", "<display>"},
                 {"Bearer:IncludeErrorDetails", "true"},
                 {"Bearer:MetadataAddress", "<metadata>"},
                 {"Bearer:RefreshOnIssuerKeyNotFound", "true"},
@@ -67,7 +66,6 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
             Assert.Equal("<authority>", options.Authority);
             Assert.Equal("<challenge>", options.Challenge);
             Assert.Equal("<issuer>", options.ClaimsIssuer);
-            Assert.Equal("<display>", options.DisplayName);
             Assert.True(options.IncludeErrorDetails);
             Assert.Equal("<metadata>", options.MetadataAddress);
             Assert.True(options.RefreshOnIssuerKeyNotFound);

--- a/test/Microsoft.AspNetCore.Authentication.Test/MicrosoftAccountTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/MicrosoftAccountTests.cs
@@ -50,7 +50,6 @@ namespace Microsoft.AspNetCore.Authentication.Tests.MicrosoftAccount
                 {"Microsoft:BackchannelTimeout", "0.0:0:30"},
                 //{"Microsoft:CallbackPath", "/callbackpath"}, // PathString doesn't convert
                 {"Microsoft:ClaimsIssuer", "<issuer>"},
-                {"Microsoft:DisplayName", "<display>"},
                 {"Microsoft:RemoteAuthenticationTimeout", "0.0:0:30"},
                 {"Microsoft:SaveTokens", "true"},
                 {"Microsoft:SendAppSecretProof", "true"},
@@ -71,7 +70,6 @@ namespace Microsoft.AspNetCore.Authentication.Tests.MicrosoftAccount
             Assert.Equal("<issuer>", options.ClaimsIssuer);
             Assert.Equal("<id>", options.ClientId);
             Assert.Equal("<secret>", options.ClientSecret);
-            Assert.Equal("<display>", options.DisplayName);
             Assert.Equal(new TimeSpan(0, 0, 0, 30), options.RemoteAuthenticationTimeout);
             Assert.True(options.SaveTokens);
             Assert.Equal("<signIn>", options.SignInScheme);

--- a/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectTests.cs
@@ -36,6 +36,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
             {
                 {"OpenIdConnect:ClientId", "<id>"},
                 {"OpenIdConnect:ClientSecret", "<secret>"},
+                {"OpenIdConnect:RequireHttpsMetadata", "false"},
                 {"OpenIdConnect:Authority", "<auth>"}
             };
             var configurationBuilder = new ConfigurationBuilder();
@@ -48,6 +49,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
             Assert.Equal("<id>", options.ClientId);
             Assert.Equal("<secret>", options.ClientSecret);
             Assert.Equal("<auth>", options.Authority);
+            Assert.False(options.RequireHttpsMetadata);
         }
 
 

--- a/test/Microsoft.AspNetCore.Authentication.Test/TwitterTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/TwitterTests.cs
@@ -42,7 +42,6 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
                 {"Twitter:BackchannelTimeout", "0.0:0:30"},
                 //{"Twitter:CallbackPath", "/callbackpath"}, // PathString doesn't convert
                 {"Twitter:ClaimsIssuer", "<issuer>"},
-                {"Twitter:DisplayName", "<display>"},
                 {"Twitter:RemoteAuthenticationTimeout", "0.0:0:30"},
                 {"Twitter:SaveTokens", "true"},
                 {"Twitter:SendAppSecretProof", "true"},
@@ -60,7 +59,6 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
             Assert.Equal("<issuer>", options.ClaimsIssuer);
             Assert.Equal("<key>", options.ConsumerKey);
             Assert.Equal("<secret>", options.ConsumerSecret);
-            Assert.Equal("<display>", options.DisplayName);
             Assert.Equal(new TimeSpan(0, 0, 0, 30), options.RemoteAuthenticationTimeout);
             Assert.True(options.SaveTokens);
             Assert.Equal("<signIn>", options.SignInScheme);


### PR DESCRIPTION
Goal is to eliminate the virtual AuthenticationHandler.InitializeOptions and the double check locking logic.

Depends on: https://github.com/aspnet/Options/pull/187

Doesn't seem too bad but I had to add a global ensure dataprotection initializer to make things work, definitely is a bit subtle.
 
I only did Cookies + OAuth and its children for a proof of concept first step.  I'll do OIDC next.

cc @Tratcher @ajcvickers 