### PR TITLE
Update test framework versions and fix issues with tests

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -6,7 +6,7 @@
     <InternalAspNetCoreSdkVersion>2.1.0-*</InternalAspNetCoreSdkVersion>
     <JsonNetVersion>10.0.1</JsonNetVersion>
     <NETStandardImplicitPackageVersion>$(BundledNETStandardPackageVersion)</NETStandardImplicitPackageVersion>
-    <TestSdkVersion>15.0.0</TestSdkVersion>
-    <XunitVersion>2.2.0</XunitVersion>
+    <TestSdkVersion>15.3.0-*</TestSdkVersion>
+    <XunitVersion>2.3.0-beta2-*</XunitVersion>
   </PropertyGroup>
 </Project>

--- a/test/Microsoft.AspNetCore.Authentication.Test/GoogleTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/GoogleTests.cs
@@ -405,7 +405,7 @@ namespace Microsoft.AspNetCore.Authentication.Google
             Assert.Equal("Test Family Name", transaction.FindClaimValue(ClaimTypes.Surname, expectedIssuer));
             Assert.Equal("Test email", transaction.FindClaimValue(ClaimTypes.Email, expectedIssuer));
 
-            // Ensure claims transformation 
+            // Ensure claims transformation
             Assert.Equal("yup", transaction.FindClaimValue("xform"));
 
             transaction = await server.SendAsync("https://example.com/tokens", authCookie);
@@ -688,14 +688,14 @@ namespace Microsoft.AspNetCore.Authentication.Google
                     OnCreatingTicket = context =>
                     {
                         Assert.NotNull(context.User);
-                        Assert.Equal(context.AccessToken, "Test Access Token");
-                        Assert.Equal(context.RefreshToken, "Test Refresh Token");
-                        Assert.Equal(context.ExpiresIn, TimeSpan.FromSeconds(3600));
-                        Assert.Equal(context.Identity.FindFirst(ClaimTypes.Email)?.Value, "Test email");
-                        Assert.Equal(context.Identity.FindFirst(ClaimTypes.NameIdentifier)?.Value, "Test User ID");
-                        Assert.Equal(context.Identity.FindFirst(ClaimTypes.Name)?.Value, "Test Name");
-                        Assert.Equal(context.Identity.FindFirst(ClaimTypes.Surname)?.Value, "Test Family Name");
-                        Assert.Equal(context.Identity.FindFirst(ClaimTypes.GivenName)?.Value, "Test Given Name");
+                        Assert.Equal("Test Access Token", context.AccessToken);
+                        Assert.Equal("Test Refresh Token", context.RefreshToken);
+                        Assert.Equal(TimeSpan.FromSeconds(3600), context.ExpiresIn);
+                        Assert.Equal("Test email", context.Identity.FindFirst(ClaimTypes.Email)?.Value);
+                        Assert.Equal("Test User ID", context.Identity.FindFirst(ClaimTypes.NameIdentifier)?.Value);
+                        Assert.Equal("Test Name", context.Identity.FindFirst(ClaimTypes.Name)?.Value);
+                        Assert.Equal("Test Family Name", context.Identity.FindFirst(ClaimTypes.Surname)?.Value);
+                        Assert.Equal("Test Given Name", context.Identity.FindFirst(ClaimTypes.GivenName)?.Value);
                         return Task.FromResult(0);
                     }
                 };
@@ -954,7 +954,7 @@ namespace Microsoft.AspNetCore.Authentication.Google
             var authCookie = transaction.AuthenticationCookieValue;
             transaction = await server.SendAsync("https://example.com/authenticateFacebook", authCookie);
             Assert.Equal(HttpStatusCode.OK, transaction.Response.StatusCode);
-            Assert.Equal(null, transaction.FindClaimValue(ClaimTypes.Name));
+            Assert.Null(transaction.FindClaimValue(ClaimTypes.Name));
         }
 
         [Fact]
@@ -1103,7 +1103,7 @@ namespace Microsoft.AspNetCore.Authentication.Google
                         }
                         else if (req.Path == new PathString("/unauthorized"))
                         {
-                            // Simulate Authorization failure 
+                            // Simulate Authorization failure
                             var result = await context.AuthenticateAsync("Google");
                             await context.ChallengeAsync("Google");
                         }

--- a/test/Microsoft.AspNetCore.Authentication.Test/Microsoft.AspNetCore.Authentication.Test.csproj
+++ b/test/Microsoft.AspNetCore.Authentication.Test/Microsoft.AspNetCore.Authentication.Test.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\build\common.props" />
+
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Authentication.Cookies\Microsoft.AspNetCore.Authentication.Cookies.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Authentication.Facebook\Microsoft.AspNetCore.Authentication.Facebook.csproj" />
@@ -16,14 +18,14 @@
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Authentication.MicrosoftAccount\Microsoft.AspNetCore.Authentication.MicrosoftAccount.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Authentication.JwtBearer\Microsoft.AspNetCore.Authentication.JwtBearer.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Authentication.Twitter\Microsoft.AspNetCore.Authentication.Twitter.csproj" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Testing" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.AspNetCore.Authentication.Test/OAuthTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/OAuthTests.cs
@@ -73,6 +73,7 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
             Assert.Equal(HttpStatusCode.OK, transaction.Response.StatusCode);
         }
 
+        [Fact]
         public async Task ThrowsIfCallbackPathMissing()
         {
             var server = CreateServer(
@@ -118,6 +119,7 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
             Assert.Equal(HttpStatusCode.OK, transaction.Response.StatusCode);
         }
 
+        [Fact]
         public async Task ThrowsIfAuthorizationEndpointMissing()
         {
             var server = CreateServer(

--- a/test/Microsoft.AspNetCore.Authentication.Test/TicketSerializerTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/TicketSerializerTests.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Authentication
 
                 var identity = (ClaimsIdentity) readTicket.Principal.Identity;
                 Assert.NotNull(identity.Actor);
-                Assert.Equal(identity.Actor.AuthenticationType, "actor");
+                Assert.Equal("actor", identity.Actor.AuthenticationType);
             }
         }
 
@@ -113,17 +113,17 @@ namespace Microsoft.AspNetCore.Authentication
 
                 var readClaim = readTicket.Principal.FindFirst("type");
                 Assert.NotNull(claim);
-                Assert.Equal(claim.Type, "type");
-                Assert.Equal(claim.Value, "value");
-                Assert.Equal(claim.ValueType, "valueType");
-                Assert.Equal(claim.Issuer, "issuer");
-                Assert.Equal(claim.OriginalIssuer, "original-issuer");
+                Assert.Equal("type", claim.Type);
+                Assert.Equal("value", claim.Value);
+                Assert.Equal("valueType", claim.ValueType);
+                Assert.Equal("issuer", claim.Issuer);
+                Assert.Equal("original-issuer", claim.OriginalIssuer);
 
                 var property1 = readClaim.Properties["property-1"];
-                Assert.Equal(property1, "property-value");
+                Assert.Equal("property-value", property1);
 
                 var property2 = readClaim.Properties["property-2"];
-                Assert.Equal(property2, string.Empty);
+                Assert.Equal(string.Empty, property2);
             }
         }
     }

--- a/test/Microsoft.AspNetCore.Authentication.Test/TokenExtensionTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/TokenExtensionTests.cs
@@ -45,9 +45,9 @@ namespace Microsoft.AspNetCore.Authentication
             props.StoreTokens(new[] { new AuthenticationToken { Name = "Zero", Value = "0" } });
 
             Assert.Equal("0", props.GetTokenValue("Zero"));
-            Assert.Equal(null, props.GetTokenValue("One"));
-            Assert.Equal(null, props.GetTokenValue("Two"));
-            Assert.Equal(null, props.GetTokenValue("Three"));
+            Assert.Null(props.GetTokenValue("One"));
+            Assert.Null(props.GetTokenValue("Two"));
+            Assert.Null(props.GetTokenValue("Three"));
             Assert.Equal(1, props.GetTokens().Count());
         }
 

--- a/test/Microsoft.AspNetCore.Authorization.Test/DefaultAuthorizationServiceTests.cs
+++ b/test/Microsoft.AspNetCore.Authorization.Test/DefaultAuthorizationServiceTests.cs
@@ -106,6 +106,7 @@ namespace Microsoft.AspNetCore.Authorization.Test
             Assert.True(allowed);
         }
 
+        [Fact]
         public async Task Authorize_ShouldInvokeAllHandlersByDefault()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Authorization.Test/Microsoft.AspNetCore.Authorization.Test.csproj
+++ b/test/Microsoft.AspNetCore.Authorization.Test/Microsoft.AspNetCore.Authorization.Test.csproj
@@ -1,19 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\build\common.props" />
+
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Authorization\Microsoft.AspNetCore.Authorization.csproj" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Testing" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
+
 </Project>

--- a/test/Microsoft.AspNetCore.ChunkingCookieManager.Sources.Test/Microsoft.AspNetCore.ChunkingCookieManager.Sources.Test.csproj
+++ b/test/Microsoft.AspNetCore.ChunkingCookieManager.Sources.Test/Microsoft.AspNetCore.ChunkingCookieManager.Sources.Test.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\build\common.props" />
+
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\..\shared\Microsoft.AspNetCore.ChunkingCookieManager.Sources\**\*.cs" />
   </ItemGroup>
+
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.AspNetCore.CookiePolicy.Test/Microsoft.AspNetCore.CookiePolicy.Test.csproj
+++ b/test/Microsoft.AspNetCore.CookiePolicy.Test/Microsoft.AspNetCore.CookiePolicy.Test.csproj
@@ -6,16 +6,18 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Authentication.Cookies\Microsoft.AspNetCore.Authentication.Cookies.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.CookiePolicy\Microsoft.AspNetCore.CookiePolicy.csproj" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Updating to xunit 2.3 (which includes xunit.analyzers) revealed some methods that should have been marked `[Fact]` and some asserts that were backwards.