### PR TITLE
Rename PostLogoutRedirectUri to avoid spec confusion

### DIFF
--- a/samples/OpenIdConnect.AzureAdSample/Startup.cs
+++ b/samples/OpenIdConnect.AzureAdSample/Startup.cs
@@ -58,7 +58,7 @@ namespace OpenIdConnect.AzureAdSample
                 o.ClientSecret = ClientSecret; // for code flow
                 o.Authority = Authority;
                 o.ResponseType = OpenIdConnectResponseType.CodeIdToken;
-                o.PostLogoutRedirectUri = "/signed-out";
+                o.SignedOutRedirectUri = "/signed-out";
                 // GetClaimsFromUserInfoEndpoint = true,
                 o.Events = new OpenIdConnectEvents()
                 {

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
@@ -182,7 +182,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
             // Get the post redirect URI.
             if (string.IsNullOrEmpty(properties.RedirectUri))
             {
-                properties.RedirectUri = BuildRedirectUriIfRelative(Options.PostLogoutRedirectUri);
+                properties.RedirectUri = BuildRedirectUriIfRelative(Options.SignedOutRedirectUri);
                 if (string.IsNullOrWhiteSpace(properties.RedirectUri))
                 {
                     properties.RedirectUri = CurrentUri;

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectOptions.cs
@@ -167,15 +167,16 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
 
         /// <summary>
         /// The request path within the application's base path where the user agent will be returned after sign out from the identity provider.
+        /// See post_logout_redirect_uri from http://openid.net/specs/openid-connect-session-1_0.html#RedirectionAfterLogout.
         /// </summary>
         public PathString SignedOutCallbackPath { get; set; }
 
         /// <summary>
-        /// The uri where the user agent will be returned to after application is signed out from the identity provider.
+        /// The uri where the user agent will be redirected to after application is signed out from the identity provider.
         /// The redirect will happen after the SignedOutCallbackPath is invoked.
         /// </summary>
         /// <remarks>This URI can be out of the application's domain. By default it points to the root.</remarks>
-        public string PostLogoutRedirectUri { get; set; } = "/";
+        public string SignedOutRedirectUri { get; set; } = "/";
 
         /// <summary>
         /// Gets or sets if a metadata refresh should be attempted after a SecurityTokenSignatureKeyNotFoundException. This allows for automatic

--- a/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectTests.cs
@@ -119,7 +119,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 o.Configuration = configuration;
                 o.StateDataFormat = stateFormat;
                 o.SignedOutCallbackPath = "/thelogout";
-                o.PostLogoutRedirectUri = "https://example.com/postlogout";
+                o.SignedOutRedirectUri = "https://example.com/postlogout";
             });
 
             var transaction = await server.SendAsync(DefaultHost + TestServerBuilder.Signout);
@@ -150,7 +150,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 o.StateDataFormat = stateFormat;
                 o.ClientId = "Test Id";
                 o.Configuration = configuration;
-                o.PostLogoutRedirectUri = "https://example.com/postlogout";
+                o.SignedOutRedirectUri = "https://example.com/postlogout";
             });
 
             var transaction = await server.SendAsync("https://example.com/signout_with_specific_redirect_uri");


### PR DESCRIPTION
@PinpointTownes 
The usage of PostLogoutRedirectUri changed in 1.1 so that it no longer aligned with the spec term field. SignedOutCallbackPath has been used since 1.1 for the post_logout_redirect_uri protocol field. Renaming PostLogoutRedirectUri now to avoid confusion.