### PR TITLE
Switch to builder pattern for AddXyzAuth

### DIFF
--- a/samples/CookieSample/Startup.cs
+++ b/samples/CookieSample/Startup.cs
@@ -18,9 +18,7 @@ namespace CookieSample
             {
                 options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                 options.DefaultChallengeScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-            });
-
-            services.AddCookieAuthentication();
+            }).AddCookie();
         }
 
         public void Configure(IApplicationBuilder app)

--- a/samples/CookieSessionSample/Startup.cs
+++ b/samples/CookieSessionSample/Startup.cs
@@ -19,9 +19,7 @@ namespace CookieSessionSample
             {
                 options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                 options.DefaultChallengeScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-            });
-
-            services.AddCookieAuthentication(o => o.SessionStore = new MemoryCacheTicketStore());
+            }).AddCookie(o => o.SessionStore = new MemoryCacheTicketStore());
         }
 
         public void Configure(IApplicationBuilder app)

--- a/samples/JwtBearerSample/Startup.cs
+++ b/samples/JwtBearerSample/Startup.cs
@@ -48,9 +48,7 @@ namespace JwtBearerSample
             {
                 options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
                 options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
-            });
-
-            services.AddJwtBearerAuthentication(o =>
+            }).AddJwtBearer(o =>
             {
                 // You also need to update /wwwroot/app/scripts/app.js
                 o.Authority = Configuration["jwt:authority"];

--- a/samples/OpenIdConnect.AzureAdSample/Startup.cs
+++ b/samples/OpenIdConnect.AzureAdSample/Startup.cs
@@ -48,11 +48,9 @@ namespace OpenIdConnect.AzureAdSample
                 sharedOptions.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                 sharedOptions.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                 sharedOptions.DefaultChallengeScheme = OpenIdConnectDefaults.AuthenticationScheme;
-            });
-
-            services.AddCookieAuthentication();
-
-            services.AddOpenIdConnectAuthentication(o =>
+            })
+                .AddCookie()
+                .AddOpenIdConnect(o =>
             {
                 o.ClientId = ClientId;
                 o.ClientSecret = ClientSecret; // for code flow

--- a/samples/OpenIdConnectSample/Startup.cs
+++ b/samples/OpenIdConnectSample/Startup.cs
@@ -45,11 +45,9 @@ namespace OpenIdConnectSample
                 sharedOptions.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                 sharedOptions.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                 sharedOptions.DefaultChallengeScheme = OpenIdConnectDefaults.AuthenticationScheme;
-            });
-
-            services.AddCookieAuthentication();
-
-            services.AddOpenIdConnectAuthentication(o =>
+            })
+                .AddCookie()
+                .AddOpenIdConnect(o =>
             {
                 o.ClientId = Configuration["oidc:clientid"];
                 o.ClientSecret = Configuration["oidc:clientsecret"]; // for code flow

--- a/samples/SocialSample/Startup.cs
+++ b/samples/SocialSample/Startup.cs
@@ -55,13 +55,11 @@ namespace SocialSample
                 options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                 options.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                 options.DefaultChallengeScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-            });
-
-            services.AddCookieAuthentication(o => o.LoginPath = new PathString("/login"));
-
-            // You must first create an app with Facebook and add its ID and Secret to your user-secrets.
-            // https://developers.facebook.com/apps/
-            services.AddFacebookAuthentication(o =>
+            })
+                .AddCookie(o => o.LoginPath = new PathString("/login"))
+                // You must first create an app with Facebook and add its ID and Secret to your user-secrets.
+                // https://developers.facebook.com/apps/
+                .AddFacebook(o =>
             {
                 o.AppId = Configuration["facebook:appid"];
                 o.AppSecret = Configuration["facebook:appsecret"];
@@ -69,11 +67,10 @@ namespace SocialSample
                 o.Fields.Add("name");
                 o.Fields.Add("email");
                 o.SaveTokens = true;
-            });
-
-            // You must first create an app with Google and add its ID and Secret to your user-secrets.
-            // https://console.developers.google.com/project
-            services.AddOAuthAuthentication("Google-AccessToken", o =>
+            })
+                // You must first create an app with Google and add its ID and Secret to your user-secrets.
+                // https://console.developers.google.com/project
+                .AddOAuth("Google-AccessToken", o =>
             {
                 o.ClientId = Configuration["google:clientid"];
                 o.ClientSecret = Configuration["google:clientsecret"];
@@ -84,11 +81,10 @@ namespace SocialSample
                 o.Scope.Add("profile");
                 o.Scope.Add("email");
                 o.SaveTokens = true;
-            });
-
-            // You must first create an app with Google and add its ID and Secret to your user-secrets.
-            // https://console.developers.google.com/project
-            services.AddGoogleAuthentication(o =>
+            })
+                // You must first create an app with Google and add its ID and Secret to your user-secrets.
+                // https://console.developers.google.com/project
+                .AddGoogle(o =>
             {
                 o.ClientId = Configuration["google:clientid"];
                 o.ClientSecret = Configuration["google:clientsecret"];
@@ -104,11 +100,10 @@ namespace SocialSample
                 };
                 o.ClaimActions.MapJsonSubKey("urn:google:image", "image", "url");
                 o.ClaimActions.Remove(ClaimTypes.GivenName);
-            });
-
-            // You must first create an app with Twitter and add its key and Secret to your user-secrets.
-            // https://apps.twitter.com/
-            services.AddTwitterAuthentication(o =>
+            })
+                // You must first create an app with Twitter and add its key and Secret to your user-secrets.
+                // https://apps.twitter.com/
+                .AddTwitter(o =>
             {
                 o.ConsumerKey = Configuration["twitter:consumerkey"];
                 o.ConsumerSecret = Configuration["twitter:consumersecret"];
@@ -126,15 +121,14 @@ namespace SocialSample
                         return Task.FromResult(0);
                     }
                 };
-            });
-
-            /* Azure AD app model v2 has restrictions that prevent the use of plain HTTP for redirect URLs.
-               Therefore, to authenticate through microsoft accounts, tryout the sample using the following URL:
-               https://localhost:44318/
-            */
-            // You must first create an app with Microsoft Account and add its ID and Secret to your user-secrets.
-            // https://apps.dev.microsoft.com/
-            services.AddOAuthAuthentication("Microsoft-AccessToken", o =>
+            })
+                /* Azure AD app model v2 has restrictions that prevent the use of plain HTTP for redirect URLs.
+                   Therefore, to authenticate through microsoft accounts, tryout the sample using the following URL:
+                   https://localhost:44318/
+                */
+                // You must first create an app with Microsoft Account and add its ID and Secret to your user-secrets.
+                // https://apps.dev.microsoft.com/
+                .AddOAuth("Microsoft-AccessToken", o =>
             {
                 o.ClientId = Configuration["microsoftaccount:clientid"];
                 o.ClientSecret = Configuration["microsoftaccount:clientsecret"];
@@ -143,20 +137,18 @@ namespace SocialSample
                 o.TokenEndpoint = MicrosoftAccountDefaults.TokenEndpoint;
                 o.Scope.Add("https://graph.microsoft.com/user.read");
                 o.SaveTokens = true;
-            });
-
-            // You must first create an app with Microsoft Account and add its ID and Secret to your user-secrets.
-            // https://azure.microsoft.com/en-us/documentation/articles/active-directory-v2-app-registration/
-            services.AddMicrosoftAccountAuthentication(o =>
+            })
+                // You must first create an app with Microsoft Account and add its ID and Secret to your user-secrets.
+                // https://azure.microsoft.com/en-us/documentation/articles/active-directory-v2-app-registration/
+                .AddMicrosoftAccount(o =>
             {
                 o.ClientId = Configuration["microsoftaccount:clientid"];
                 o.ClientSecret = Configuration["microsoftaccount:clientsecret"];
                 o.SaveTokens = true;
-            });
-
-            // You must first create an app with GitHub and add its ID and Secret to your user-secrets.
-            // https://github.com/settings/applications/
-            services.AddOAuthAuthentication("GitHub-AccessToken", o =>
+            })
+                // You must first create an app with GitHub and add its ID and Secret to your user-secrets.
+                // https://github.com/settings/applications/
+                .AddOAuth("GitHub-AccessToken", o =>
             {
                 o.ClientId = Configuration["github-token:clientid"];
                 o.ClientSecret = Configuration["github-token:clientsecret"];
@@ -164,11 +156,10 @@ namespace SocialSample
                 o.AuthorizationEndpoint = "https://github.com/login/oauth/authorize";
                 o.TokenEndpoint = "https://github.com/login/oauth/access_token";
                 o.SaveTokens = true;
-            });
-
-            // You must first create an app with GitHub and add its ID and Secret to your user-secrets.
-            // https://github.com/settings/applications/
-            services.AddOAuthAuthentication("GitHub", o =>
+            })
+                // You must first create an app with GitHub and add its ID and Secret to your user-secrets.
+                // https://github.com/settings/applications/
+                .AddOAuth("GitHub", o =>
             {
                 o.ClientId = Configuration["github:clientid"];
                 o.ClientSecret = Configuration["github:clientsecret"];

--- a/src/Microsoft.AspNetCore.Authentication.Cookies/CookieExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/CookieExtensions.cs
@@ -2,16 +2,30 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.AspNetCore.Authentication.Cookies;
-using Microsoft.AspNetCore.DataProtection;
-using Microsoft.Extensions.Options;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
     public static class CookieExtensions
     {
+        public static AuthenticationBuilder AddCookie(this AuthenticationBuilder builder) => builder.AddCookie(CookieAuthenticationDefaults.AuthenticationScheme);
+
+        public static AuthenticationBuilder AddCookie(this AuthenticationBuilder builder, string authenticationScheme) => builder.AddCookie(authenticationScheme, configureOptions: null);
+
+        public static AuthenticationBuilder AddCookie(this AuthenticationBuilder builder, Action<CookieAuthenticationOptions> configureOptions) =>
+            builder.AddCookie(CookieAuthenticationDefaults.AuthenticationScheme, configureOptions);
+
+        public static AuthenticationBuilder AddCookie(this AuthenticationBuilder builder, string authenticationScheme, Action<CookieAuthenticationOptions> configureOptions)
+        {
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<CookieAuthenticationOptions>, PostConfigureCookieAuthenticationOptions>());
+            return builder.AddScheme<CookieAuthenticationOptions, CookieAuthenticationHandler>(authenticationScheme, configureOptions);
+        }
+
+
+        // REMOVE below once callers have been updated
         public static IServiceCollection AddCookieAuthentication(this IServiceCollection services) => services.AddCookieAuthentication(CookieAuthenticationDefaults.AuthenticationScheme);
 
         public static IServiceCollection AddCookieAuthentication(this IServiceCollection services, string authenticationScheme) => services.AddCookieAuthentication(authenticationScheme, configureOptions: null);

--- a/src/Microsoft.AspNetCore.Authentication.Cookies/CookieExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/CookieExtensions.cs
@@ -11,12 +11,14 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class CookieExtensions
     {
-        public static AuthenticationBuilder AddCookie(this AuthenticationBuilder builder) => builder.AddCookie(CookieAuthenticationDefaults.AuthenticationScheme);
+        public static AuthenticationBuilder AddCookie(this AuthenticationBuilder builder)
+            => builder.AddCookie(CookieAuthenticationDefaults.AuthenticationScheme);
 
-        public static AuthenticationBuilder AddCookie(this AuthenticationBuilder builder, string authenticationScheme) => builder.AddCookie(authenticationScheme, configureOptions: null);
+        public static AuthenticationBuilder AddCookie(this AuthenticationBuilder builder, string authenticationScheme)
+            => builder.AddCookie(authenticationScheme, configureOptions: null);
 
-        public static AuthenticationBuilder AddCookie(this AuthenticationBuilder builder, Action<CookieAuthenticationOptions> configureOptions) =>
-            builder.AddCookie(CookieAuthenticationDefaults.AuthenticationScheme, configureOptions);
+        public static AuthenticationBuilder AddCookie(this AuthenticationBuilder builder, Action<CookieAuthenticationOptions> configureOptions) 
+            => builder.AddCookie(CookieAuthenticationDefaults.AuthenticationScheme, configureOptions);
 
         public static AuthenticationBuilder AddCookie(this AuthenticationBuilder builder, string authenticationScheme, Action<CookieAuthenticationOptions> configureOptions)
         {

--- a/src/Microsoft.AspNetCore.Authentication.Cookies/PostConfigureCookieAuthenticationOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/PostConfigureCookieAuthenticationOptions.cs
@@ -55,6 +55,5 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
                 options.AccessDeniedPath = CookieAuthenticationDefaults.AccessDeniedPath;
             }
         }
-
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookExtensions.cs
@@ -2,12 +2,24 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Facebook;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
     public static class FacebookAuthenticationOptionsExtensions
     {
+        public static AuthenticationBuilder AddFacebook(this AuthenticationBuilder builder)
+            => builder.AddFacebook(FacebookDefaults.AuthenticationScheme, _ => { });
+
+        public static AuthenticationBuilder AddFacebook(this AuthenticationBuilder builder, Action<FacebookOptions> configureOptions)
+            => builder.AddFacebook(FacebookDefaults.AuthenticationScheme, configureOptions);
+
+        public static AuthenticationBuilder AddFacebook(this AuthenticationBuilder builder, string authenticationScheme, Action<FacebookOptions> configureOptions)
+            => builder.AddOAuth<FacebookOptions, FacebookHandler>(authenticationScheme, configureOptions);
+
+
+        // REMOVE below once callers have been updated
         public static IServiceCollection AddFacebookAuthentication(this IServiceCollection services) 
             => services.AddFacebookAuthentication(FacebookDefaults.AuthenticationScheme, _ => { });
 

--- a/src/Microsoft.AspNetCore.Authentication.Google/GoogleExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Google/GoogleExtensions.cs
@@ -2,12 +2,25 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Google;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
     public static class GoogleExtensions
     {
+        public static AuthenticationBuilder AddGoogle(this AuthenticationBuilder builder)
+            => builder.AddGoogle(GoogleDefaults.AuthenticationScheme, _ => { });
+
+        public static AuthenticationBuilder AddGoogle(this AuthenticationBuilder builder, Action<GoogleOptions> configureOptions)
+            => builder.AddGoogle(GoogleDefaults.AuthenticationScheme, configureOptions);
+
+        public static AuthenticationBuilder AddGoogle(this AuthenticationBuilder builder, string authenticationScheme, Action<GoogleOptions> configureOptions)
+            => builder.AddOAuth<GoogleOptions, GoogleHandler>(authenticationScheme, configureOptions);
+
+
+        // REMOVE below once callers have been updated
+
         public static IServiceCollection AddGoogleAuthentication(this IServiceCollection services) 
             => services.AddGoogleAuthentication(GoogleDefaults.AuthenticationScheme, _ => { });
 

--- a/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
@@ -10,6 +11,20 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class JwtBearerExtensions
     {
+        public static AuthenticationBuilder AddJwtBearer(this AuthenticationBuilder builder)
+            => builder.AddJwtBearer(JwtBearerDefaults.AuthenticationScheme, _ => { });
+
+        public static AuthenticationBuilder AddJwtBearer(this AuthenticationBuilder builder, Action<JwtBearerOptions> configureOptions)
+            => builder.AddJwtBearer(JwtBearerDefaults.AuthenticationScheme, configureOptions);
+
+        public static AuthenticationBuilder AddJwtBearer(this AuthenticationBuilder builder, string authenticationScheme, Action<JwtBearerOptions> configureOptions)
+        {
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<JwtBearerOptions>, JwtBearerPostConfigureOptions>());
+            return builder.AddScheme<JwtBearerOptions, JwtBearerHandler>(authenticationScheme, configureOptions);
+        }
+
+
+        // REMOVE once callers updated
         public static IServiceCollection AddJwtBearerAuthentication(this IServiceCollection services) 
             => services.AddJwtBearerAuthentication(JwtBearerDefaults.AuthenticationScheme, _ => { });
 

--- a/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountExtensions.cs
@@ -2,12 +2,25 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.MicrosoftAccount;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
     public static class MicrosoftAccountExtensions
     {
+        public static AuthenticationBuilder AddMicrosoftAccount(this AuthenticationBuilder builder)
+            => builder.AddMicrosoftAccount(MicrosoftAccountDefaults.AuthenticationScheme, _ => { });
+
+        public static AuthenticationBuilder AddMicrosoftAccount(this AuthenticationBuilder builder, Action<MicrosoftAccountOptions> configureOptions)
+            => builder.AddMicrosoftAccount(MicrosoftAccountDefaults.AuthenticationScheme, configureOptions);
+
+        public static AuthenticationBuilder AddMicrosoftAccount(this AuthenticationBuilder builder, string authenticationScheme, Action<MicrosoftAccountOptions> configureOptions)
+            => builder.AddOAuth<MicrosoftAccountOptions, MicrosoftAccountHandler>(authenticationScheme, configureOptions);
+
+
+        // REMOVE below once callers have been updated
+
         public static IServiceCollection AddMicrosoftAccountAuthentication(this IServiceCollection services) 
             => services.AddMicrosoftAccountAuthentication(MicrosoftAccountDefaults.AuthenticationScheme, _ => { });
 

--- a/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
@@ -10,6 +11,18 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class OAuthExtensions
     {
+        public static AuthenticationBuilder AddOAuth(this AuthenticationBuilder builder, string authenticationScheme, Action<OAuthOptions> configureOptions)
+            => builder.AddOAuth<OAuthOptions, OAuthHandler<OAuthOptions>>(authenticationScheme, configureOptions);
+
+        public static AuthenticationBuilder AddOAuth<TOptions, THandler>(this AuthenticationBuilder builder, string authenticationScheme, Action<TOptions> configureOptions)
+            where TOptions : OAuthOptions, new()
+            where THandler : OAuthHandler<TOptions>
+        {
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<TOptions>, OAuthPostConfigureOptions<TOptions, THandler>>());
+            return builder.AddRemoteScheme<TOptions, THandler>(authenticationScheme, authenticationScheme, configureOptions);
+        }
+
+        // REMOVE below once callers have been updated
         public static IServiceCollection AddOAuthAuthentication(this IServiceCollection services, string authenticationScheme, Action<OAuthOptions> configureOptions)
         {
             return services.AddOAuthAuthentication<OAuthOptions, OAuthHandler<OAuthOptions>>(authenticationScheme, configureOptions);

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
@@ -10,6 +11,19 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class OpenIdConnectExtensions
     {
+        public static AuthenticationBuilder AddOpenIdConnect(this AuthenticationBuilder builder)
+            => builder.AddOpenIdConnect(OpenIdConnectDefaults.AuthenticationScheme, _ => { });
+
+        public static AuthenticationBuilder AddOpenIdConnect(this AuthenticationBuilder builder, Action<OpenIdConnectOptions> configureOptions)
+            => builder.AddOpenIdConnect(OpenIdConnectDefaults.AuthenticationScheme, configureOptions);
+
+        public static AuthenticationBuilder AddOpenIdConnect(this AuthenticationBuilder builder, string authenticationScheme, Action<OpenIdConnectOptions> configureOptions)
+        {
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<OpenIdConnectOptions>, OpenIdConnectPostConfigureOptions>());
+            return builder.AddRemoteScheme<OpenIdConnectOptions, OpenIdConnectHandler>(authenticationScheme, authenticationScheme, configureOptions);
+        }
+
+        // REMOVE once callers have been updated
         public static IServiceCollection AddOpenIdConnectAuthentication(this IServiceCollection services)
             => services.AddOpenIdConnectAuthentication(OpenIdConnectDefaults.AuthenticationScheme, _ => { });
 

--- a/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Twitter;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
@@ -10,6 +11,19 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class TwitterExtensions
     {
+        public static AuthenticationBuilder AddTwitter(this AuthenticationBuilder builder)
+            => builder.AddTwitter(TwitterDefaults.AuthenticationScheme, _ => { });
+
+        public static AuthenticationBuilder AddTwitter(this AuthenticationBuilder builder, Action<TwitterOptions> configureOptions)
+            => builder.AddTwitter(TwitterDefaults.AuthenticationScheme, configureOptions);
+
+        public static AuthenticationBuilder AddTwitter(this AuthenticationBuilder builder, string authenticationScheme, Action<TwitterOptions> configureOptions)
+        {
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<TwitterOptions>, TwitterPostConfigureOptions>());
+            return builder.AddRemoteScheme<TwitterOptions, TwitterHandler>(authenticationScheme, authenticationScheme, configureOptions);
+        }
+
+        // REMOVE below once callers have been updated.
         public static IServiceCollection AddTwitterAuthentication(this IServiceCollection services)
             => services.AddTwitterAuthentication(TwitterDefaults.AuthenticationScheme, _ => { });
 

--- a/src/Microsoft.AspNetCore.Authentication/AuthenticationBuilder.cs
+++ b/src/Microsoft.AspNetCore.Authentication/AuthenticationBuilder.cs
@@ -1,0 +1,103 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Authentication
+{
+    /// <summary>
+    /// Used to configure authentication
+    /// </summary>
+    public class AuthenticationBuilder
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="services">The services being configured.</param>
+        public AuthenticationBuilder(IServiceCollection services)
+            => Services = services;
+
+        /// <summary>
+        /// The services being configured.
+        /// </summary>
+        public virtual IServiceCollection Services { get; }
+
+        /// <summary>
+        /// Adds a <see cref="AuthenticationScheme"/> which can be used by <see cref="IAuthenticationService"/>.
+        /// </summary>
+        /// <typeparam name="TOptions">The <see cref="AuthenticationSchemeOptions"/> type to configure the handler."/>.</typeparam>
+        /// <typeparam name="THandler">The <see cref="AuthenticationHandler{TOptions}"/> used to handle this scheme.</typeparam>
+        /// <param name="authenticationScheme">The name of this scheme.</param>
+        /// <param name="displayName">The display name of this scheme.</param>
+        /// <param name="configureOptions">Used to configure the scheme options.</param>
+        /// <returns>The builder.</returns>
+        public virtual AuthenticationBuilder AddScheme<TOptions, THandler>(string authenticationScheme, string displayName, Action<TOptions> configureOptions)
+            where TOptions : AuthenticationSchemeOptions, new()
+            where THandler : AuthenticationHandler<TOptions>
+        {
+            Services.Configure<AuthenticationOptions>(o =>
+            {
+                o.AddScheme(authenticationScheme, scheme => {
+                    scheme.HandlerType = typeof(THandler);
+                    scheme.DisplayName = displayName;
+                });
+            });
+            if (configureOptions != null)
+            {
+                Services.Configure(authenticationScheme, configureOptions);
+            }
+            Services.AddTransient<THandler>();
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a <see cref="AuthenticationScheme"/> which can be used by <see cref="IAuthenticationService"/>.
+        /// </summary>
+        /// <typeparam name="TOptions">The <see cref="AuthenticationSchemeOptions"/> type to configure the handler."/>.</typeparam>
+        /// <typeparam name="THandler">The <see cref="AuthenticationHandler{TOptions}"/> used to handle this scheme.</typeparam>
+        /// <param name="authenticationScheme">The name of this scheme.</param>
+        /// <param name="configureOptions">Used to configure the scheme options.</param>
+        /// <returns>The builder.</returns>
+        public virtual AuthenticationBuilder AddScheme<TOptions, THandler>(string authenticationScheme, Action<TOptions> configureOptions)
+            where TOptions : AuthenticationSchemeOptions, new()
+            where THandler : AuthenticationHandler<TOptions>
+            => AddScheme<TOptions, THandler>(authenticationScheme, displayName: null, configureOptions: configureOptions);
+
+        /// <summary>
+        /// Adds a <see cref="RemoteAuthenticationHandler{TOptions}"/> based <see cref="AuthenticationScheme"/> that supports remote authentication
+        /// which can be used by <see cref="IAuthenticationService"/>.
+        /// </summary>
+        /// <typeparam name="TOptions">The <see cref="RemoteAuthenticationOptions"/> type to configure the handler."/>.</typeparam>
+        /// <typeparam name="THandler">The <see cref="RemoteAuthenticationHandler{TOptions}"/> used to handle this scheme.</typeparam>
+        /// <param name="authenticationScheme">The name of this scheme.</param>
+        /// <param name="displayName">The display name of this scheme.</param>
+        /// <param name="configureOptions">Used to configure the scheme options.</param>
+        /// <returns>The builder.</returns>
+        public virtual AuthenticationBuilder AddRemoteScheme<TOptions, THandler>(string authenticationScheme, string displayName, Action<TOptions> configureOptions)
+            where TOptions : RemoteAuthenticationOptions, new()
+            where THandler : RemoteAuthenticationHandler<TOptions>
+        {
+            Services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<TOptions>, EnsureSignInScheme<TOptions>>());
+            return AddScheme<TOptions, THandler>(authenticationScheme, displayName, configureOptions: configureOptions);
+        }
+
+        // Used to ensure that there's always a default data protection provider
+        private class EnsureSignInScheme<TOptions> : IPostConfigureOptions<TOptions> where TOptions : RemoteAuthenticationOptions
+        {
+            private readonly AuthenticationOptions _authOptions;
+
+            public EnsureSignInScheme(IOptions<AuthenticationOptions> authOptions)
+            {
+                _authOptions = authOptions.Value;
+            }
+
+            public void PostConfigure(string name, TOptions options)
+            {
+                options.SignInScheme = options.SignInScheme ?? _authOptions.DefaultSignInScheme;
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Authentication/AuthenticationServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication/AuthenticationServiceCollectionExtensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.DependencyInjection
     /// </summary>
     public static class AuthenticationServiceCollectionExtensions
     {
-        public static IServiceCollection AddAuthentication(this IServiceCollection services)
+        public static AuthenticationBuilder AddAuthentication(this IServiceCollection services)
         {
             if (services == null)
             {
@@ -24,10 +24,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddDataProtection();
             services.AddWebEncoders();
             services.TryAddSingleton<ISystemClock, SystemClock>();
-            return services;
+            return new AuthenticationBuilder(services);
         }
 
-        public static IServiceCollection AddAuthentication(this IServiceCollection services, Action<AuthenticationOptions> configureOptions) {
+        public static AuthenticationBuilder AddAuthentication(this IServiceCollection services, Action<AuthenticationOptions> configureOptions) {
             if (services == null)
             {
                 throw new ArgumentNullException(nameof(services));
@@ -38,11 +38,12 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(configureOptions));
             }
 
-            services.AddAuthentication();
+            var builder = services.AddAuthentication();
             services.Configure(configureOptions);
-            return services;
+            return builder;
         }
 
+        // REMOVE below once callers have been updated
         public static IServiceCollection AddScheme<TOptions, THandler>(this IServiceCollection services, string authenticationScheme, string displayName, Action<AuthenticationSchemeBuilder> configureScheme, Action<TOptions> configureOptions)
             where TOptions : AuthenticationSchemeOptions, new()
             where THandler : AuthenticationHandler<TOptions>

--- a/test/Microsoft.AspNetCore.Authentication.Test/CookieTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/CookieTests.cs
@@ -29,7 +29,8 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         [Fact]
         public async Task VerifySchemeDefaults()
         {
-            var services = new ServiceCollection().AddCookieAuthentication();
+            var services = new ServiceCollection();
+            services.AddAuthentication().AddCookie();
             var sp = services.BuildServiceProvider();
             var schemeProvider = sp.GetRequiredService<IAuthenticationSchemeProvider>();
             var scheme = await schemeProvider.GetSchemeAsync(CookieAuthenticationDefaults.AuthenticationScheme);
@@ -124,7 +125,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         [Fact]
         public async Task SignInCausesDefaultCookieToBeCreated()
         {
-            var server = CreateServerWithServices(s => s.AddCookieAuthentication(o =>
+            var server = CreateServerWithServices(s => s.AddAuthentication().AddCookie(o =>
             {
                 o.LoginPath = new PathString("/login");
                 o.CookieName = "TestCookie";
@@ -772,7 +773,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
                     }
                     app.Map("/login", signoutApp => signoutApp.Run(context => context.ChallengeAsync("Cookies", new AuthenticationProperties() { RedirectUri = "/" })));
                 })
-                .ConfigureServices(s => s.AddCookieAuthentication(o => o.LoginPath = new PathString("/page")));
+                .ConfigureServices(s => s.AddAuthentication().AddCookie(o => o.LoginPath = new PathString("/page")));
             var server = new TestServer(builder);
 
             var transaction = await server.SendAsync("http://example.com/login");
@@ -803,7 +804,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
                         await Assert.ThrowsAsync<InvalidOperationException>(() => context.ChallengeAsync(CookieAuthenticationDefaults.AuthenticationScheme));
                     });
                 })
-                .ConfigureServices(services => services.AddCookieAuthentication());
+                .ConfigureServices(services => services.AddAuthentication().AddCookie());
             var server = new TestServer(builder);
 
             var transaction = await server.SendAsync("http://example.com");
@@ -821,7 +822,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
                 })
                 .ConfigureServices(services =>
                 {
-                    services.AddCookieAuthentication();
+                    services.AddAuthentication().AddCookie();
                     services.Configure<CookieAuthenticationOptions>(CookieAuthenticationDefaults.AuthenticationScheme,
                         o => o.CookieName = "One");
                 });
@@ -844,7 +845,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
                 })
                 .ConfigureServices(services =>
                 {
-                    services.AddCookieAuthentication("Cookie1");
+                    services.AddAuthentication().AddCookie("Cookie1");
                     services.Configure<CookieAuthenticationOptions>("Cookie1",
                         o => o.CookieName = "One");
                 });
@@ -866,7 +867,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
                     app.Map("/notlogin", signoutApp => signoutApp.Run(context => context.SignInAsync("Cookies",
                         new ClaimsPrincipal())));
                 })
-                .ConfigureServices(services => services.AddCookieAuthentication(o => o.LoginPath = new PathString("/login")));
+                .ConfigureServices(services => services.AddAuthentication().AddCookie(o => o.LoginPath = new PathString("/login")));
             var server = new TestServer(builder);
 
             var transaction = await server.SendAsync("http://example.com/notlogin?ReturnUrl=%2Fpage");
@@ -883,7 +884,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
                     app.UseAuthentication();
                     app.Map("/login", signoutApp => signoutApp.Run(context => context.SignInAsync("Cookies", new ClaimsPrincipal())));
                 })
-                .ConfigureServices(services => services.AddCookieAuthentication(o => o.LoginPath = new PathString("/login")));
+                .ConfigureServices(services => services.AddAuthentication().AddCookie(o => o.LoginPath = new PathString("/login")));
 
             var server = new TestServer(builder);
 
@@ -905,7 +906,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
                     app.UseAuthentication();
                     app.Map("/notlogout", signoutApp => signoutApp.Run(context => context.SignOutAsync("Cookies")));
                 })
-                .ConfigureServices(services => services.AddCookieAuthentication(o => o.LogoutPath = new PathString("/logout")));
+                .ConfigureServices(services => services.AddAuthentication().AddCookie(o => o.LogoutPath = new PathString("/logout")));
             var server = new TestServer(builder);
 
             var transaction = await server.SendAsync("http://example.com/notlogout?ReturnUrl=%2Fpage");
@@ -922,7 +923,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
                     app.UseAuthentication();
                     app.Map("/logout", signoutApp => signoutApp.Run(context => context.SignOutAsync("Cookies")));
                 })
-                .ConfigureServices(services => services.AddCookieAuthentication(o => o.LogoutPath = new PathString("/logout")));
+                .ConfigureServices(services => services.AddAuthentication().AddCookie(o => o.LogoutPath = new PathString("/logout")));
             var server = new TestServer(builder);
 
             var transaction = await server.SendAsync("http://example.com/logout?ReturnUrl=%2Fpage");
@@ -943,7 +944,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
                     app.UseAuthentication();
                     app.Map("/forbid", signoutApp => signoutApp.Run(context => context.ForbidAsync("Cookies")));
                 })
-                .ConfigureServices(services => services.AddCookieAuthentication(o => o.AccessDeniedPath = new PathString("/denied")));
+                .ConfigureServices(services => services.AddAuthentication().AddCookie(o => o.AccessDeniedPath = new PathString("/denied")));
             var server = new TestServer(builder);
             var transaction = await server.SendAsync("http://example.com/forbid");
 
@@ -963,7 +964,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
                         map.UseAuthentication();
                         map.Map("/login", signoutApp => signoutApp.Run(context => context.ChallengeAsync("Cookies", new AuthenticationProperties() { RedirectUri = "/" })));
                     }))
-                .ConfigureServices(services => services.AddCookieAuthentication(o => o.LoginPath = new PathString("/page")));
+                .ConfigureServices(services => services.AddAuthentication().AddCookie(o => o.LoginPath = new PathString("/page")));
             var server = new TestServer(builder);
             var transaction = await server.SendAsync("http://example.com/base/login");
 
@@ -1073,7 +1074,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
                         map.UseAuthentication();
                         map.Map("/forbid", signoutApp => signoutApp.Run(context => context.ForbidAsync("Cookies")));
                     }))
-                    .ConfigureServices(services => services.AddCookieAuthentication(o => o.AccessDeniedPath = new PathString("/denied")));
+                    .ConfigureServices(services => services.AddAuthentication().AddCookie(o => o.AccessDeniedPath = new PathString("/denied")));
             var server = new TestServer(builder);
             var transaction = await server.SendAsync("http://example.com/base/forbid");
 
@@ -1097,7 +1098,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
                                         new ClaimsPrincipal(new ClaimsIdentity(new GenericIdentity("Alice", "Cookies"))),
                                         new AuthenticationProperties()));
                 })
-                .ConfigureServices(services => services.AddCookieAuthentication(o =>
+                .ConfigureServices(services => services.AddAuthentication().AddCookie(o =>
                 {
                     o.TicketDataFormat = new TicketDataFormat(dp);
                     o.CookieName = "Cookie";
@@ -1117,7 +1118,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
                         Describe(context.Response, result);
                     });
                 })
-                .ConfigureServices(services => services.AddCookieAuthentication("Cookies", o =>
+                .ConfigureServices(services => services.AddAuthentication().AddCookie("Cookies", o =>
                 {
                     o.CookieName = "Cookie";
                     o.TicketDataFormat = new TicketDataFormat(dp);
@@ -1132,7 +1133,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         public async Task NullExpiresUtcPropertyIsGuarded()
         {
             var builder = new WebHostBuilder()
-                .ConfigureServices(services => services.AddCookieAuthentication(o =>
+                .ConfigureServices(services => services.AddAuthentication().AddCookie(o =>
                 {
                     o.Events = new CookieAuthenticationEvents
                     {
@@ -1229,7 +1230,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
             => CreateServerWithServices(s =>
             {
                 s.AddSingleton<ISystemClock>(_clock);
-                s.AddCookieAuthentication(configureOptions);
+                s.AddAuthentication().AddCookie(configureOptions);
                 s.AddSingleton<IClaimsTransformation, ClaimsTransformer>();
             }, testpath, baseAddress);
 

--- a/test/Microsoft.AspNetCore.Authentication.Test/FacebookTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/FacebookTests.cs
@@ -85,9 +85,9 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
                     {
                         options.DefaultSignInScheme = "External";
                         options.DefaultAuthenticateScheme = "External";
-                    });
-                    services.AddCookieAuthentication("External", o => { });
-                    services.AddFacebookAuthentication(o =>
+                    })
+                        .AddCookie("External", o => { })
+                        .AddFacebook(o =>
                     {
                         o.AppId = "Test App Id";
                         o.AppSecret = "Test App Secret";
@@ -123,8 +123,9 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             }),
             services =>
             {
-                services.AddCookieAuthentication("External", o => { });
-                services.AddFacebookAuthentication(o =>
+                services.AddAuthentication()
+                    .AddCookie("External", o => { })
+                    .AddFacebook(o =>
                 {
                     o.AppId = "Test App Id";
                     o.AppSecret = "Test App Secret";
@@ -155,8 +156,9 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
                 },
                 services =>
                 {
-                    services.AddCookieAuthentication("External", o => { });
-                    services.AddFacebookAuthentication(o =>
+                    services.AddAuthentication()
+                        .AddCookie("External", o => { })
+                        .AddFacebook(o =>
                     {
                         o.AppId = "Test App Id";
                         o.AppSecret = "Test App Secret";
@@ -185,9 +187,9 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
                     services.AddAuthentication(options =>
                     {
                         options.DefaultSignInScheme = "External";
-                    });
-                    services.AddCookieAuthentication();
-                    services.AddFacebookAuthentication(o =>
+                    })
+                        .AddCookie()
+                        .AddFacebook(o =>
                     {
                         o.AppId = "Test App Id";
                         o.AppSecret = "Test App Secret";
@@ -217,19 +219,16 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             var finalUserInfoEndpoint = string.Empty;
             var stateFormat = new PropertiesDataFormat(new EphemeralDataProtectionProvider(NullLoggerFactory.Instance).CreateProtector("FacebookTest"));
             var server = CreateServer(
-                app =>
-                {
-                    app.UseAuthentication();
-                },
+                app => app.UseAuthentication(),
                 services =>
                 {
                     services.AddAuthentication(options =>
                     {
                         options.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                         options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-                    });
-                    services.AddCookieAuthentication();
-                    services.AddFacebookAuthentication(o => 
+                    })
+                        .AddCookie()
+                        .AddFacebook(o => 
                     {
                         o.AppId = "Test App Id";
                         o.AppSecret = "Test App Secret";

--- a/test/Microsoft.AspNetCore.Authentication.Test/GoogleTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/GoogleTests.cs
@@ -1053,9 +1053,10 @@ namespace Microsoft.AspNetCore.Authentication.Google
                         o.DefaultSignInScheme = TestExtensions.CookieAuthenticationScheme;
                         o.DefaultChallengeScheme = GoogleDefaults.AuthenticationScheme;
                     });
-                    services.AddCookieAuthentication(TestExtensions.CookieAuthenticationScheme);
-                    services.AddGoogleAuthentication(configureOptions);
-                    services.AddFacebookAuthentication(o =>
+                    services.AddAuthentication()
+                        .AddCookie(TestExtensions.CookieAuthenticationScheme)
+                        .AddGoogle(configureOptions)
+                        .AddFacebook(o =>
                     {
                         o.AppId = "Test AppId";
                         o.AppSecret = "Test AppSecrent";

--- a/test/Microsoft.AspNetCore.Authentication.Test/MicrosoftAccountTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/MicrosoftAccountTests.cs
@@ -228,8 +228,9 @@ namespace Microsoft.AspNetCore.Authentication.Tests.MicrosoftAccount
                         o.DefaultAuthenticateScheme = TestExtensions.CookieAuthenticationScheme;
                         o.DefaultSignInScheme = TestExtensions.CookieAuthenticationScheme;
                     });
-                    services.AddCookieAuthentication(TestExtensions.CookieAuthenticationScheme, o => { });
-                    services.AddMicrosoftAccountAuthentication(configureOptions);
+                    services.AddAuthentication()
+                        .AddCookie(TestExtensions.CookieAuthenticationScheme, o => { })
+                        .AddMicrosoftAccount(configureOptions);
                 });
             return new TestServer(builder);
         }

--- a/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectConfigurationTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectConfigurationTests.cs
@@ -22,8 +22,9 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
             var builder = new WebHostBuilder()
                 .ConfigureServices(services =>
                 {
-                    services.AddCookieAuthentication();
-                    services.AddOpenIdConnectAuthentication(o =>
+                    services.AddAuthentication()
+                        .AddCookie()
+                        .AddOpenIdConnect(o =>
                     {
                         o.Authority = TestServerBuilder.DefaultAuthority;
                         o.ClientId = Guid.NewGuid().ToString();
@@ -119,8 +120,9 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
             var builder = new WebHostBuilder()
                 .ConfigureServices(services =>
                 {
-                    services.AddCookieAuthentication();
-                    services.AddOpenIdConnectAuthentication(options);
+                    services.AddAuthentication()
+                        .AddCookie()
+                        .AddOpenIdConnect(options);
                 })
                 .Configure(app => app.UseAuthentication());
 

--- a/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectEventTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectEventTests.cs
@@ -1408,8 +1408,9 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
             var builder = new WebHostBuilder()
                 .ConfigureServices(services =>
                 {
-                    services.AddCookieAuthentication();
-                    services.AddOpenIdConnectAuthentication(o =>
+                    services.AddAuthentication()
+                        .AddCookie()
+                        .AddOpenIdConnect(o =>
                     {
                         o.Events = events;
                         o.SignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;

--- a/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/TestServerBuilder.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/TestServerBuilder.cs
@@ -114,8 +114,9 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                         o.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                         o.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                     });
-                    services.AddCookieAuthentication();
-                    services.AddOpenIdConnectAuthentication(options);
+                    services.AddAuthentication()
+                        .AddCookie()
+                        .AddOpenIdConnect(options);
                 });
 
             return new TestServer(builder);

--- a/test/Microsoft.AspNetCore.Authentication.Test/TwitterTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/TwitterTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Security.Claims;
@@ -13,7 +12,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Authentication.Twitter
@@ -195,13 +193,14 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
                 })
                 .ConfigureServices(services =>
                 {
-                    services.AddCookieAuthentication("External", _ => { });
                     Action<TwitterOptions> wrapOptions = o =>
                     {
                         o.SignInScheme = "External";
                         options(o);
                     };
-                    services.AddTwitterAuthentication(wrapOptions);
+                    services.AddAuthentication()
+                        .AddCookie("External", _ => { })
+                        .AddTwitter(wrapOptions);
                 });
             return new TestServer(builder);
         }

--- a/test/Microsoft.AspNetCore.CookiePolicy.Test/CookiePolicyTests.cs
+++ b/test/Microsoft.AspNetCore.CookiePolicy.Test/CookiePolicyTests.cs
@@ -312,7 +312,7 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
             var builder = new WebHostBuilder()
                 .ConfigureServices(services =>
                 {
-                    services.AddCookieAuthentication(o =>
+                    services.AddAuthentication().AddCookie(o =>
                     {
                         o.CookieName = "TestCookie";
                         o.CookieHttpOnly = false;
@@ -352,7 +352,7 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
             var builder = new WebHostBuilder()
                 .ConfigureServices(services =>
                 {
-                    services.AddCookieAuthentication(o =>
+                    services.AddAuthentication().AddCookie(o =>
                     {
                         o.CookieName = "TestCookie";
                         o.CookieHttpOnly = false;

--- a/test/Microsoft.Owin.Security.Interop.Test/CookieInteropTests.cs
+++ b/test/Microsoft.Owin.Security.Interop.Test/CookieInteropTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Owin.Security.Interop
                         await context.Response.WriteAsync(result.Ticket.Principal.Identity.Name);
                     });
                 })
-                .ConfigureServices(services => services.AddCookieAuthentication(o => o.DataProtectionProvider = dataProtection));
+                .ConfigureServices(services => services.AddAuthentication().AddCookie(o => o.DataProtectionProvider = dataProtection));
             var newServer = new AspNetCore.TestHost.TestServer(builder);
 
             var request = new HttpRequestMessage(HttpMethod.Get, "http://example.com/login");
@@ -123,7 +123,7 @@ namespace Microsoft.Owin.Security.Interop
                         await context.Response.WriteAsync(result.Ticket.Principal.Identity.Name);
                     });
                 })
-                .ConfigureServices(services => services.AddCookieAuthentication(o => o.DataProtectionProvider = dataProtection));
+                .ConfigureServices(services => services.AddAuthentication().AddCookie(o => o.DataProtectionProvider = dataProtection));
             var newServer = new AspNetCore.TestHost.TestServer(builder);
 
             var request = new HttpRequestMessage(HttpMethod.Get, "http://example.com/login");
@@ -155,7 +155,7 @@ namespace Microsoft.Owin.Security.Interop
                     app.UseAuthentication();
                     app.Run(context => context.SignInAsync("Cookies", user));
                 })
-                .ConfigureServices(services => services.AddCookieAuthentication(o => o.DataProtectionProvider = dataProtection));
+                .ConfigureServices(services => services.AddAuthentication().AddCookie(o => o.DataProtectionProvider = dataProtection));
             var newServer = new AspNetCore.TestHost.TestServer(builder);
 
             var cookies = await SendAndGetCookies(newServer, "http://example.com/login");
@@ -202,7 +202,7 @@ namespace Microsoft.Owin.Security.Interop
                     app.UseAuthentication();
                     app.Run(context => context.SignInAsync("Cookies", user));
                 })
-                .ConfigureServices(services => services.AddCookieAuthentication(o => o.DataProtectionProvider = dataProtection));
+                .ConfigureServices(services => services.AddAuthentication().AddCookie(o => o.DataProtectionProvider = dataProtection));
             var newServer = new AspNetCore.TestHost.TestServer(builder);
 
             var cookies = await SendAndGetCookies(newServer, "http://example.com/login");


### PR DESCRIPTION
New pattern:

```C#
services.AddAuthentication()
    .AddCookie()
    .AddGoogle(o => { })
    .AddOpenIdConnect(o => { })
```

Will remove old AddXyz methods in a followup PR after everything has been updated to use the new builder methods.

Fixes https://github.com/aspnet/Security/issues/1269

@davidfowl @Tratcher 

