### PR TITLE
Switch to Principal/Properties instead of Ticket in events

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
@@ -42,13 +42,13 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
 
             var payload = JObject.Parse(await response.Content.ReadAsStringAsync());
 
-            var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), properties, Scheme.Name);
-            var context = new OAuthCreatingTicketContext(ticket, Context, Scheme, Options, Backchannel, tokens, payload);
+            var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens, payload);
             context.RunClaimActions();
 
             await Events.CreatingTicket(context);
 
-            return context.Ticket;
+            return new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name);
+
         }
 
         private string GenerateAppSecretProof(string accessToken)

--- a/src/Microsoft.AspNetCore.Authentication.Google/GoogleHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Google/GoogleHandler.cs
@@ -39,14 +39,11 @@ namespace Microsoft.AspNetCore.Authentication.Google
 
             var payload = JObject.Parse(await response.Content.ReadAsStringAsync());
 
-            var principal = new ClaimsPrincipal(identity);
-            var ticket = new AuthenticationTicket(principal, properties, Scheme.Name);
-            var context = new OAuthCreatingTicketContext(ticket, Context, Scheme, Options, Backchannel, tokens, payload);
+            var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens, payload);
             context.RunClaimActions();
 
             await Events.CreatingTicket(context);
-
-            return context.Ticket;
+            return new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name);
         }
 
         // TODO: Abstract this properties override pattern into the base class?

--- a/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerHandler.cs
@@ -135,10 +135,9 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
 
                         Logger.TokenValidationSucceeded();
 
-                        var ticket = new AuthenticationTicket(principal, new AuthenticationProperties(), Scheme.Name);
                         var tokenValidatedContext = new TokenValidatedContext(Context, Scheme, Options)
                         {
-                            Ticket = ticket,
+                            Principal = principal,
                             SecurityToken = validatedToken
                         };
 
@@ -147,17 +146,16 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
                         {
                             return tokenValidatedContext.Result;
                         }
-                        ticket = tokenValidatedContext.Ticket;
 
                         if (Options.SaveToken)
                         {
-                            ticket.Properties.StoreTokens(new[]
+                            tokenValidatedContext.Properties.StoreTokens(new[]
                             {
                                 new AuthenticationToken { Name = "access_token", Value = token }
                             });
                         }
 
-                        return AuthenticateResult.Success(ticket);
+                        return AuthenticateResult.Success(new AuthenticationTicket(tokenValidatedContext.Principal, tokenValidatedContext.Properties, Scheme.Name));
                     }
                 }
 

--- a/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerHandler.cs
@@ -155,7 +155,8 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
                             });
                         }
 
-                        return AuthenticateResult.Success(new AuthenticationTicket(tokenValidatedContext.Principal, tokenValidatedContext.Properties, Scheme.Name));
+                        tokenValidatedContext.Success();
+                        return tokenValidatedContext.Result;
                     }
                 }
 

--- a/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountHandler.cs
@@ -32,12 +32,11 @@ namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
 
             var payload = JObject.Parse(await response.Content.ReadAsStringAsync());
 
-            var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), properties, Scheme.Name);
-            var context = new OAuthCreatingTicketContext(ticket, Context, Scheme, Options, Backchannel, tokens, payload);
+            var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens, payload);
             context.RunClaimActions();
 
             await Events.CreatingTicket(context);
-            return context.Ticket;
+            return new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.OAuth/Events/OAuthCreatingTicketContext.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OAuth/Events/OAuthCreatingTicketContext.cs
@@ -18,26 +18,29 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
         /// <summary>
         /// Initializes a new <see cref="OAuthCreatingTicketContext"/>.
         /// </summary>
-        /// <param name="ticket">The <see cref="AuthenticationTicket"/>.</param>
+        /// <param name="principal">The <see cref="ClaimsPrincipal"/>.</param>
+        /// <param name="properties">The <see cref="AuthenticationProperties"/>.</param>
         /// <param name="context">The HTTP environment.</param>
         /// <param name="scheme">The authentication scheme.</param>
         /// <param name="options">The options used by the authentication middleware.</param>
         /// <param name="backchannel">The HTTP client used by the authentication middleware</param>
         /// <param name="tokens">The tokens returned from the token endpoint.</param>
         public OAuthCreatingTicketContext(
-            AuthenticationTicket ticket,
+            ClaimsPrincipal principal,
+            AuthenticationProperties properties,
             HttpContext context,
             AuthenticationScheme scheme,
             OAuthOptions options,
             HttpClient backchannel,
             OAuthTokenResponse tokens)
-            : this(ticket, context, scheme, options, backchannel, tokens, user: new JObject())
+            : this(principal, properties, context, scheme, options, backchannel, tokens, user: new JObject())
         { }
 
         /// <summary>
         /// Initializes a new <see cref="OAuthCreatingTicketContext"/>.
         /// </summary>
-        /// <param name="ticket">The <see cref="AuthenticationTicket"/>.</param>
+        /// <param name="principal">The <see cref="ClaimsPrincipal"/>.</param>
+        /// <param name="properties">The <see cref="AuthenticationProperties"/>.</param>
         /// <param name="context">The HTTP environment.</param>
         /// <param name="scheme">The authentication scheme.</param>
         /// <param name="options">The options used by the authentication middleware.</param>
@@ -45,7 +48,8 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
         /// <param name="tokens">The tokens returned from the token endpoint.</param>
         /// <param name="user">The JSON-serialized user.</param>
         public OAuthCreatingTicketContext(
-            AuthenticationTicket ticket,
+            ClaimsPrincipal principal,
+            AuthenticationProperties properties,
             HttpContext context,
             AuthenticationScheme scheme,
             OAuthOptions options,
@@ -72,7 +76,8 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
             TokenResponse = tokens;
             Backchannel = backchannel;
             User = user;
-            Ticket = ticket;
+            Principal = principal;
+            Properties = properties;
         }
 
         /// <summary>
@@ -127,7 +132,7 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
         /// Gets the main identity exposed by the authentication ticket.
         /// This property returns <c>null</c> when the ticket is <c>null</c>.
         /// </summary>
-        public ClaimsIdentity Identity => Ticket?.Principal.Identity as ClaimsIdentity;
+        public ClaimsIdentity Identity => Principal?.Identity as ClaimsIdentity;
 
         public void RunClaimActions() => RunClaimActions(User);
 

--- a/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthHandler.cs
@@ -185,10 +185,9 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
 
         protected virtual async Task<AuthenticationTicket> CreateTicketAsync(ClaimsIdentity identity, AuthenticationProperties properties, OAuthTokenResponse tokens)
         {
-            var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), properties, Scheme.Name);
-            var context = new OAuthCreatingTicketContext(ticket, Context, Scheme, Options, Backchannel, tokens);
+            var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens);
             await Events.CreatingTicket(context);
-            return context.Ticket;
+            return new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name);
         }
 
         protected override async Task HandleChallengeAsync(AuthenticationProperties properties)

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/Events/AuthenticationFailedContext.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/Events/AuthenticationFailedContext.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
     public class AuthenticationFailedContext : RemoteAuthenticationContext<OpenIdConnectOptions>
     {
         public AuthenticationFailedContext(HttpContext context, AuthenticationScheme scheme, OpenIdConnectOptions options)
-            : base(context, scheme, options)
+            : base(context, scheme, options, new AuthenticationProperties())
         { }
 
         public OpenIdConnectMessage ProtocolMessage { get; set; }

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/Events/AuthorizationCodeReceivedContext.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/Events/AuthorizationCodeReceivedContext.cs
@@ -19,9 +19,9 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
         public AuthorizationCodeReceivedContext(
             HttpContext context,
             AuthenticationScheme scheme,
-            OpenIdConnectOptions options)
-            : base(context, scheme, options)
-        { }
+            OpenIdConnectOptions options,
+            AuthenticationProperties properties)
+            : base(context, scheme, options, properties) { }
 
         public OpenIdConnectMessage ProtocolMessage { get; set; }
 

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/Events/MessageReceivedContext.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/Events/MessageReceivedContext.cs
@@ -11,9 +11,9 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
         public MessageReceivedContext(
             HttpContext context,
             AuthenticationScheme scheme,
-            OpenIdConnectOptions options)
-            : base(context, scheme, options)
-        { }
+            OpenIdConnectOptions options,
+            AuthenticationProperties properties)
+            : base(context, scheme, options, properties) { }
 
         public OpenIdConnectMessage ProtocolMessage { get; set; }
 

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/Events/RemoteSignoutContext.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/Events/RemoteSignoutContext.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
     public class RemoteSignOutContext : RemoteAuthenticationContext<OpenIdConnectOptions>
     {
         public RemoteSignOutContext(HttpContext context, AuthenticationScheme scheme, OpenIdConnectOptions options, OpenIdConnectMessage message)
-            : base(context, scheme, options)
+            : base(context, scheme, options, new AuthenticationProperties())
             => ProtocolMessage = message;
 
         public OpenIdConnectMessage ProtocolMessage { get; set; }

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/Events/TokenResponseReceivedContext.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/Events/TokenResponseReceivedContext.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
@@ -14,8 +15,9 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
         /// <summary>
         /// Creates a <see cref="TokenResponseReceivedContext"/>
         /// </summary>
-        public TokenResponseReceivedContext(HttpContext context, AuthenticationScheme scheme, OpenIdConnectOptions options)
-            : base(context, scheme, options) { }
+        public TokenResponseReceivedContext(HttpContext context, AuthenticationScheme scheme, OpenIdConnectOptions options, ClaimsPrincipal user, AuthenticationProperties properties)
+            : base(context, scheme, options, properties)
+            => Principal = user;
 
         public OpenIdConnectMessage ProtocolMessage { get; set; }
 

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/Events/TokenValidatedContext.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/Events/TokenValidatedContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
@@ -12,8 +13,9 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
         /// <summary>
         /// Creates a <see cref="TokenValidatedContext"/>
         /// </summary>
-        public TokenValidatedContext(HttpContext context, AuthenticationScheme scheme, OpenIdConnectOptions options)
-            : base(context, scheme, options) { }
+        public TokenValidatedContext(HttpContext context, AuthenticationScheme scheme, OpenIdConnectOptions options, ClaimsPrincipal principal, AuthenticationProperties properties)
+            : base(context, scheme, options, properties)
+            => Principal = principal;
 
         public OpenIdConnectMessage ProtocolMessage { get; set; }
 

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/Events/UserInformationReceivedContext.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/Events/UserInformationReceivedContext.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Newtonsoft.Json.Linq;
@@ -9,8 +10,9 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
 {
     public class UserInformationReceivedContext : RemoteAuthenticationContext<OpenIdConnectOptions>
     {
-        public UserInformationReceivedContext(HttpContext context, AuthenticationScheme scheme, OpenIdConnectOptions options)
-            : base(context, scheme, options) { }
+        public UserInformationReceivedContext(HttpContext context, AuthenticationScheme scheme, OpenIdConnectOptions options, ClaimsPrincipal principal, AuthenticationProperties properties)
+            : base(context, scheme, options, properties)
+            => Principal = principal;
 
         public OpenIdConnectMessage ProtocolMessage { get; set; }
 

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
@@ -474,7 +474,6 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                     return messageReceivedContext.Result;
                 }
                 authorizationResponse = messageReceivedContext.ProtocolMessage;
-                // REVIEW: should we let them set Principal here?
                 properties = messageReceivedContext.Properties;
 
                 if (properties == null)

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
@@ -474,6 +474,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                     return messageReceivedContext.Result;
                 }
                 authorizationResponse = messageReceivedContext.ProtocolMessage;
+                // REVIEW: should we let them set Principal here?
                 properties = messageReceivedContext.Properties;
 
                 if (properties == null)
@@ -528,7 +529,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
 
                 PopulateSessionProperties(authorizationResponse, properties);
 
-                AuthenticationTicket ticket = null;
+                ClaimsPrincipal user = null;
                 JwtSecurityToken jwt = null;
                 string nonce = null;
                 var validationParameters = Options.TokenValidationParameters.Clone();
@@ -537,7 +538,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                 if (!string.IsNullOrEmpty(authorizationResponse.IdToken))
                 {
                     Logger.ReceivedIdToken();
-                    ticket = ValidateToken(authorizationResponse.IdToken, properties, validationParameters, out jwt);
+                    user = ValidateToken(authorizationResponse.IdToken, properties, validationParameters, out jwt);
 
                     nonce = jwt.Payload.Nonce;
                     if (!string.IsNullOrEmpty(nonce))
@@ -545,14 +546,14 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                         nonce = ReadNonceCookie(nonce);
                     }
 
-                    var tokenValidatedContext = await RunTokenValidatedEventAsync(authorizationResponse, null, properties, ticket, jwt, nonce);
+                    var tokenValidatedContext = await RunTokenValidatedEventAsync(authorizationResponse, null, user, properties, jwt, nonce);
                     if (tokenValidatedContext.Result != null)
                     {
                         return tokenValidatedContext.Result;
                     }
                     authorizationResponse = tokenValidatedContext.ProtocolMessage;
+                    user = tokenValidatedContext.Principal;
                     properties = tokenValidatedContext.Properties;
-                    ticket = tokenValidatedContext.Ticket;
                     jwt = tokenValidatedContext.SecurityToken;
                     nonce = tokenValidatedContext.Nonce;
                 }
@@ -570,17 +571,17 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                 // Authorization Code or Hybrid flow
                 if (!string.IsNullOrEmpty(authorizationResponse.Code))
                 {
-                    var authorizationCodeReceivedContext = await RunAuthorizationCodeReceivedEventAsync(authorizationResponse, properties, ticket, jwt);
+                    var authorizationCodeReceivedContext = await RunAuthorizationCodeReceivedEventAsync(authorizationResponse, user, properties, jwt);
                     if (authorizationCodeReceivedContext.Result != null)
                     {
                         return authorizationCodeReceivedContext.Result;
                     }
                     authorizationResponse = authorizationCodeReceivedContext.ProtocolMessage;
+                    user = authorizationCodeReceivedContext.Principal;
                     properties = authorizationCodeReceivedContext.Properties;
                     var tokenEndpointRequest = authorizationCodeReceivedContext.TokenEndpointRequest;
                     // If the developer redeemed the code themselves...
                     tokenEndpointResponse = authorizationCodeReceivedContext.TokenEndpointResponse;
-                    ticket = authorizationCodeReceivedContext.Ticket;
                     jwt = authorizationCodeReceivedContext.JwtSecurityToken;
 
                     if (!authorizationCodeReceivedContext.HandledCodeRedemption)
@@ -588,7 +589,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                         tokenEndpointResponse = await RedeemAuthorizationCodeAsync(tokenEndpointRequest);
                     }
 
-                    var tokenResponseReceivedContext = await RunTokenResponseReceivedEventAsync(authorizationResponse, tokenEndpointResponse, properties, ticket);
+                    var tokenResponseReceivedContext = await RunTokenResponseReceivedEventAsync(authorizationResponse, tokenEndpointResponse, user, properties);
                     if (tokenResponseReceivedContext.Result != null)
                     {
                         return tokenResponseReceivedContext.Result;
@@ -596,6 +597,8 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
 
                     authorizationResponse = tokenResponseReceivedContext.ProtocolMessage;
                     tokenEndpointResponse = tokenResponseReceivedContext.TokenEndpointResponse;
+                    user = tokenResponseReceivedContext.Principal;
+                    properties = tokenResponseReceivedContext.Properties;
 
                     // no need to validate signature when token is received using "code flow" as per spec
                     // [http://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation].
@@ -604,10 +607,10 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                     // At least a cursory validation is required on the new IdToken, even if we've already validated the one from the authorization response.
                     // And we'll want to validate the new JWT in ValidateTokenResponse.
                     JwtSecurityToken tokenEndpointJwt;
-                    var tokenEndpointTicket = ValidateToken(tokenEndpointResponse.IdToken, properties, validationParameters, out tokenEndpointJwt);
+                    var tokenEndpointUser = ValidateToken(tokenEndpointResponse.IdToken, properties, validationParameters, out tokenEndpointJwt);
 
                     // Avoid reading & deleting the nonce cookie, running the event, etc, if it was already done as part of the authorization response validation.
-                    if (ticket == null)
+                    if (user == null)
                     {
                         nonce = tokenEndpointJwt.Payload.Nonce;
                         if (!string.IsNullOrEmpty(nonce))
@@ -615,15 +618,15 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                             nonce = ReadNonceCookie(nonce);
                         }
 
-                        var tokenValidatedContext = await RunTokenValidatedEventAsync(authorizationResponse, tokenEndpointResponse, properties, tokenEndpointTicket, tokenEndpointJwt, nonce);
+                        var tokenValidatedContext = await RunTokenValidatedEventAsync(authorizationResponse, tokenEndpointResponse, tokenEndpointUser, properties, tokenEndpointJwt, nonce);
                         if (tokenValidatedContext.Result != null)
                         {
                             return tokenValidatedContext.Result;
                         }
                         authorizationResponse = tokenValidatedContext.ProtocolMessage;
                         tokenEndpointResponse = tokenValidatedContext.TokenEndpointResponse;
+                        user = tokenValidatedContext.Principal;
                         properties = tokenValidatedContext.Properties;
-                        ticket = tokenValidatedContext.Ticket;
                         jwt = tokenValidatedContext.SecurityToken;
                         nonce = tokenValidatedContext.Nonce;
                     }
@@ -652,23 +655,23 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
 
                 if (Options.SaveTokens)
                 {
-                    SaveTokens(ticket.Properties, tokenEndpointResponse ?? authorizationResponse);
+                    SaveTokens(properties, tokenEndpointResponse ?? authorizationResponse);
                 }
 
                 if (Options.GetClaimsFromUserInfoEndpoint)
                 {
-                    return await GetUserInformationAsync(tokenEndpointResponse ?? authorizationResponse, jwt, ticket);
+                    return await GetUserInformationAsync(tokenEndpointResponse ?? authorizationResponse, jwt, user, properties);
                 }
                 else
                 {
-                    var identity = (ClaimsIdentity)ticket.Principal.Identity;
+                    var identity = (ClaimsIdentity)user.Identity;
                     foreach (var action in Options.ClaimActions)
                     {
                         action.Run(null, identity, ClaimsIssuer);
                     }
                 }
 
-                return HandleRequestResult.Success(ticket);
+                return HandleRequestResult.Success(new AuthenticationTicket(user, properties, Scheme.Name));
             }
             catch (Exception exception)
             {
@@ -759,21 +762,24 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
         /// </summary>
         /// <param name="message">message that is being processed</param>
         /// <param name="jwt">The <see cref="JwtSecurityToken"/>.</param>
-        /// <param name="ticket">authentication ticket with claims principal and identities</param>
-        /// <returns>Authentication ticket with identity with additional claims, if any.</returns>
-        protected virtual async Task<HandleRequestResult> GetUserInformationAsync(OpenIdConnectMessage message, JwtSecurityToken jwt, AuthenticationTicket ticket)
+        /// <param name="principal">The claims principal and identities.</param>
+        /// <param name="properties">The authentication properties.</param>
+        /// <returns><see cref="HandleRequestResult"/> which is used to determine if the remote authentication was successful.</returns>
+        protected virtual async Task<HandleRequestResult> GetUserInformationAsync(
+            OpenIdConnectMessage message, JwtSecurityToken jwt, 
+            ClaimsPrincipal principal, AuthenticationProperties properties)
         {
             var userInfoEndpoint = _configuration?.UserInfoEndpoint;
 
             if (string.IsNullOrEmpty(userInfoEndpoint))
             {
                 Logger.UserInfoEndpointNotSet();
-                return HandleRequestResult.Success(ticket);
+                return HandleRequestResult.Success(new AuthenticationTicket(principal, properties, Scheme.Name));
             }
             if (string.IsNullOrEmpty(message.AccessToken))
             {
                 Logger.AccessTokenNotAvailable();
-                return HandleRequestResult.Success(ticket);
+                return HandleRequestResult.Success(new AuthenticationTicket(principal, properties, Scheme.Name));
             }
             Logger.RetrievingClaims();
             var requestMessage = new HttpRequestMessage(HttpMethod.Get, userInfoEndpoint);
@@ -798,12 +804,13 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                 return HandleRequestResult.Fail("Unknown response type: " + contentType.MediaType);
             }
 
-            var userInformationReceivedContext = await RunUserInformationReceivedEventAsync(ticket, message, user);
+            var userInformationReceivedContext = await RunUserInformationReceivedEventAsync(principal, properties, message, user);
             if (userInformationReceivedContext.Result != null)
             {
                 return userInformationReceivedContext.Result;
             }
-            ticket = userInformationReceivedContext.Ticket;
+            principal = userInformationReceivedContext.Principal;
+            properties = userInformationReceivedContext.Properties;
             user = userInformationReceivedContext.User;
 
             Options.ProtocolValidator.ValidateUserInfoResponse(new OpenIdConnectProtocolValidationContext()
@@ -812,14 +819,14 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                 ValidatedIdToken = jwt,
             });
 
-            var identity = (ClaimsIdentity)ticket.Principal.Identity;
+            var identity = (ClaimsIdentity)principal.Identity;
 
             foreach (var action in Options.ClaimActions)
             {
                 action.Run(user, identity, ClaimsIssuer);
             }
 
-            return HandleRequestResult.Success(ticket);
+            return HandleRequestResult.Success(new AuthenticationTicket(principal, properties, Scheme.Name));
         }
 
         /// <summary>
@@ -976,10 +983,9 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
         private async Task<MessageReceivedContext> RunMessageReceivedEventAsync(OpenIdConnectMessage message, AuthenticationProperties properties)
         {
             Logger.MessageReceived(message.BuildRedirectUrl());
-            var context = new MessageReceivedContext(Context, Scheme, Options)
+            var context = new MessageReceivedContext(Context, Scheme, Options, properties)
             {
                 ProtocolMessage = message,
-                Properties = properties
             };
 
             await Events.MessageReceived(context);
@@ -998,13 +1004,12 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
             return context;
         }
 
-        private async Task<TokenValidatedContext> RunTokenValidatedEventAsync(OpenIdConnectMessage authorizationResponse, OpenIdConnectMessage tokenEndpointResponse, AuthenticationProperties properties, AuthenticationTicket ticket, JwtSecurityToken jwt, string nonce)
+        private async Task<TokenValidatedContext> RunTokenValidatedEventAsync(OpenIdConnectMessage authorizationResponse, OpenIdConnectMessage tokenEndpointResponse, ClaimsPrincipal user, AuthenticationProperties properties, JwtSecurityToken jwt, string nonce)
         {
-            var context = new TokenValidatedContext(Context, Scheme, Options)
+            var context = new TokenValidatedContext(Context, Scheme, Options, user, properties)
             {
                 ProtocolMessage = authorizationResponse,
                 TokenEndpointResponse = tokenEndpointResponse,
-                Ticket = ticket,
                 SecurityToken = jwt,
                 Nonce = nonce,
             };
@@ -1025,7 +1030,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
             return context;
         }
 
-        private async Task<AuthorizationCodeReceivedContext> RunAuthorizationCodeReceivedEventAsync(OpenIdConnectMessage authorizationResponse, AuthenticationProperties properties, AuthenticationTicket ticket, JwtSecurityToken jwt)
+        private async Task<AuthorizationCodeReceivedContext> RunAuthorizationCodeReceivedEventAsync(OpenIdConnectMessage authorizationResponse, ClaimsPrincipal user, AuthenticationProperties properties, JwtSecurityToken jwt)
         {
             Logger.AuthorizationCodeReceived();
 
@@ -1039,12 +1044,11 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                 RedirectUri = properties.Items[OpenIdConnectDefaults.RedirectUriForCodePropertiesKey]
             };
 
-            var context = new AuthorizationCodeReceivedContext(Context, Scheme, Options)
+            var context = new AuthorizationCodeReceivedContext(Context, Scheme, Options, properties)
             {
                 ProtocolMessage = authorizationResponse,
-                Properties = properties,
                 TokenEndpointRequest = tokenEndpointRequest,
-                Ticket = ticket,
+                Principal = user,
                 JwtSecurityToken = jwt,
                 Backchannel = Backchannel
             };
@@ -1068,15 +1072,14 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
         private async Task<TokenResponseReceivedContext> RunTokenResponseReceivedEventAsync(
             OpenIdConnectMessage message,
             OpenIdConnectMessage tokenEndpointResponse,
-            AuthenticationProperties properties,
-            AuthenticationTicket ticket)
+            ClaimsPrincipal user,
+            AuthenticationProperties properties)
         {
             Logger.TokenResponseReceived();
-            var context = new TokenResponseReceivedContext(Context, Scheme, Options)
+            var context = new TokenResponseReceivedContext(Context, Scheme, Options, user, properties)
             {
                 ProtocolMessage = message,
                 TokenEndpointResponse = tokenEndpointResponse,
-                Ticket = ticket
             };
 
             await Events.TokenResponseReceived(context);
@@ -1095,13 +1098,12 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
             return context;
         }
 
-        private async Task<UserInformationReceivedContext> RunUserInformationReceivedEventAsync(AuthenticationTicket ticket, OpenIdConnectMessage message, JObject user)
+        private async Task<UserInformationReceivedContext> RunUserInformationReceivedEventAsync(ClaimsPrincipal principal, AuthenticationProperties properties, OpenIdConnectMessage message, JObject user)
         {
             Logger.UserInformationReceived(user.ToString());
 
-            var context = new UserInformationReceivedContext(Context, Scheme, Options)
+            var context = new UserInformationReceivedContext(Context, Scheme, Options, principal, properties)
             {
-                Ticket = ticket,
                 ProtocolMessage = message,
                 User = user,
             };
@@ -1146,7 +1148,8 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
             return context;
         }
 
-        private AuthenticationTicket ValidateToken(string idToken, AuthenticationProperties properties, TokenValidationParameters validationParameters, out JwtSecurityToken jwt)
+        // Note this modifies properties if Options.UseTokenLifetime
+        private ClaimsPrincipal ValidateToken(string idToken, AuthenticationProperties properties, TokenValidationParameters validationParameters, out JwtSecurityToken jwt)
         {
             if (!Options.SecurityTokenValidator.CanReadToken(idToken))
             {
@@ -1183,24 +1186,22 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                 throw new SecurityTokenException(string.Format(CultureInfo.InvariantCulture, Resources.UnableToValidateToken, idToken));
             }
 
-            var ticket = new AuthenticationTicket(principal, properties, Scheme.Name);
-
             if (Options.UseTokenLifetime)
             {
                 var issued = validatedToken.ValidFrom;
                 if (issued != DateTime.MinValue)
                 {
-                    ticket.Properties.IssuedUtc = issued;
+                    properties.IssuedUtc = issued;
                 }
 
                 var expires = validatedToken.ValidTo;
                 if (expires != DateTime.MinValue)
                 {
-                    ticket.Properties.ExpiresUtc = expires;
+                    properties.ExpiresUtc = expires;
                 }
             }
 
-            return ticket;
+            return principal;
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Authentication.Twitter/Events/TwitterCreatingTicketContext.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/Events/TwitterCreatingTicketContext.cs
@@ -19,7 +19,8 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
         /// <param name="context">The HTTP environment</param>
         /// <param name="scheme">The scheme data</param>
         /// <param name="options">The options for Twitter</param>
-        /// <param name="ticket">AuthenticationTicket.</param>
+        /// <param name="principal">The <see cref="ClaimsPrincipal"/>.</param>
+        /// <param name="properties">The <see cref="AuthenticationProperties"/>.</param>
         /// <param name="userId">Twitter user ID</param>
         /// <param name="screenName">Twitter screen name</param>
         /// <param name="accessToken">Twitter access token</param>
@@ -29,7 +30,8 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
             HttpContext context,
             AuthenticationScheme scheme,
             TwitterOptions options,
-            AuthenticationTicket ticket,
+            ClaimsPrincipal principal,
+            AuthenticationProperties properties,
             string userId,
             string screenName,
             string accessToken,
@@ -42,7 +44,8 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
             AccessToken = accessToken;
             AccessTokenSecret = accessTokenSecret;
             User = user ?? new JObject();
-            Ticket = ticket;
+            Principal = principal;
+            Properties = properties;
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterHandler.cs
@@ -127,12 +127,10 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
                 action.Run(user, identity, ClaimsIssuer);
             }
 
-            var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), properties, Scheme.Name);
-
-            var context = new TwitterCreatingTicketContext(Context, Scheme, Options, ticket, token.UserId, token.ScreenName, token.Token, token.TokenSecret, user);
+            var context = new TwitterCreatingTicketContext(Context, Scheme, Options, new ClaimsPrincipal(identity), properties, token.UserId, token.ScreenName, token.Token, token.TokenSecret, user);
             await Events.CreatingTicket(context);
 
-            return context.Ticket;
+            return new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name);
         }
 
         protected override async Task HandleChallengeAsync(AuthenticationProperties properties)

--- a/src/Microsoft.AspNetCore.Authentication/Events/RemoteAuthenticationContext.cs
+++ b/src/Microsoft.AspNetCore.Authentication/Events/RemoteAuthenticationContext.cs
@@ -18,37 +18,29 @@ namespace Microsoft.AspNetCore.Authentication
         /// <param name="context">The context.</param>
         /// <param name="scheme">The authentication scheme.</param>
         /// <param name="options">The authentication options associated with the scheme.</param>
+        /// <param name="properties">The authentication properties.</param>
         protected RemoteAuthenticationContext(
             HttpContext context,
             AuthenticationScheme scheme,
-            TOptions options)
-            : base(context, scheme, options) { }
-
-        /// <summary>
-        /// Gets or set the <see cref="AuthenticationTicket"/> containing
-        /// the user principal and the authentication properties.
-        /// </summary>
-        public AuthenticationTicket Ticket { get; set; }
+            TOptions options,
+            AuthenticationProperties properties)
+            : base(context, scheme, options)
+            => Properties = properties ?? new AuthenticationProperties();
 
         /// <summary>
         /// Gets the <see cref="ClaimsPrincipal"/> containing the user claims.
         /// </summary>
-        public ClaimsPrincipal Principal => Ticket?.Principal;
+        public ClaimsPrincipal Principal { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="AuthenticationProperties"/>.
         /// </summary>
-        public AuthenticationProperties Properties
-        {
-            get => Ticket?.Properties;
-            set
-            {
-                if (Ticket != null)
-                {
-                    Ticket = new AuthenticationTicket(Principal, value, Scheme.Name);
-                }
-            }
-        }
+        public virtual AuthenticationProperties Properties { get; set; }
+
+        /// <summary>
+        /// Calls success creating a ticket with the <see cref="Principal"/> and <see cref="Properties"/>.
+        /// </summary>
+        public void Success() => Success(new AuthenticationTicket(Principal, Properties, Scheme.Name));
 
         public void Success(AuthenticationTicket ticket) => Result = HandleRequestResult.Success(ticket);
 

--- a/src/Microsoft.AspNetCore.Authentication/Events/RemoteAuthenticationContext.cs
+++ b/src/Microsoft.AspNetCore.Authentication/Events/RemoteAuthenticationContext.cs
@@ -40,9 +40,7 @@ namespace Microsoft.AspNetCore.Authentication
         /// <summary>
         /// Calls success creating a ticket with the <see cref="Principal"/> and <see cref="Properties"/>.
         /// </summary>
-        public void Success() => Success(new AuthenticationTicket(Principal, Properties, Scheme.Name));
-
-        public void Success(AuthenticationTicket ticket) => Result = HandleRequestResult.Success(ticket);
+        public void Success() => Result = HandleRequestResult.Success(new AuthenticationTicket(Principal, Properties, Scheme.Name));
 
         public void Fail(Exception failure) => Result = HandleRequestResult.Fail(failure);
 

--- a/src/Microsoft.AspNetCore.Authentication/Events/ResultContext.cs
+++ b/src/Microsoft.AspNetCore.Authentication/Events/ResultContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Authentication
@@ -21,17 +22,28 @@ namespace Microsoft.AspNetCore.Authentication
             : base(context, scheme, options) { }
 
         /// <summary>
-        /// Gets or set the <see cref="AuthenticationTicket"/> containing
-        /// the user principal and the authentication properties.
+        /// Gets or sets the <see cref="ClaimsPrincipal"/> containing the user claims.
         /// </summary>
-        public AuthenticationTicket Ticket { get; set; }
+        public ClaimsPrincipal Principal { get; set; }
+
+        private AuthenticationProperties _properties;
+        /// <summary>
+        /// Gets or sets the <see cref="AuthenticationProperties"/>.
+        /// </summary>
+        public AuthenticationProperties Properties {
+            get => _properties ?? (_properties = new AuthenticationProperties());
+            set => _properties = value;
+        }
 
         /// <summary>
         /// Gets the <see cref="AuthenticateResult"/> result.
         /// </summary>
         public AuthenticateResult Result { get; private set; }
 
-        public void Success(AuthenticationTicket ticket) => Result = AuthenticateResult.Success(ticket);
+        /// <summary>
+        /// Calls success creating a ticket with the <see cref="Principal"/> and <see cref="Properties"/>.
+        /// </summary>
+        public void Success() => Result = HandleRequestResult.Success(new AuthenticationTicket(Principal, Properties, Scheme.Name));
 
         /// <summary>
         /// Indicates that there was no information returned for this authentication scheme.

--- a/src/Microsoft.AspNetCore.Authentication/Events/ResultContext.cs
+++ b/src/Microsoft.AspNetCore.Authentication/Events/ResultContext.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Authentication
@@ -26,27 +25,6 @@ namespace Microsoft.AspNetCore.Authentication
         /// the user principal and the authentication properties.
         /// </summary>
         public AuthenticationTicket Ticket { get; set; }
-
-        /// <summary>
-        /// Gets the <see cref="ClaimsPrincipal"/> containing the user claims.
-        /// </summary>
-        public ClaimsPrincipal Principal => Ticket?.Principal;
-
-        /// <summary>
-        /// Gets or sets the <see cref="AuthenticationProperties"/>.
-        /// </summary>
-        public AuthenticationProperties Properties
-        {
-            get => Ticket?.Properties;
-
-            set
-            {
-                if (Ticket != null)
-                {
-                    Ticket = new AuthenticationTicket(Principal, value, Scheme.Name);
-                }
-            }
-        }
 
         /// <summary>
         /// Gets the <see cref="AuthenticateResult"/> result.

--- a/src/Microsoft.AspNetCore.Authentication/Events/TicketReceivedContext.cs
+++ b/src/Microsoft.AspNetCore.Authentication/Events/TicketReceivedContext.cs
@@ -3,7 +3,6 @@
 
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Authentication;
 
 namespace Microsoft.AspNetCore.Authentication
 {
@@ -17,10 +16,8 @@ namespace Microsoft.AspNetCore.Authentication
             AuthenticationScheme scheme,
             RemoteAuthenticationOptions options,
             AuthenticationTicket ticket)
-            : base(context, scheme, options)
-        {
-            Ticket = ticket;
-        }
+            : base(context, scheme, options, ticket?.Properties)
+            => Principal = ticket?.Principal;
 
         public string ReturnUri { get; set; }
     }

--- a/test/Microsoft.AspNetCore.Authentication.Test/GoogleTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/GoogleTests.cs
@@ -516,7 +516,7 @@ namespace Microsoft.AspNetCore.Authentication.Google
                     OnCreatingTicket = context =>
                     {
                         var refreshToken = context.RefreshToken;
-                        context.Ticket.Principal.AddIdentity(new ClaimsIdentity(new Claim[] { new Claim("RefreshToken", refreshToken, ClaimValueTypes.String, "Google") }, "Google"));
+                        context.Principal.AddIdentity(new ClaimsIdentity(new Claim[] { new Claim("RefreshToken", refreshToken, ClaimValueTypes.String, "Google") }, "Google"));
                         return Task.FromResult(0);
                     }
                 };

--- a/test/Microsoft.AspNetCore.Authentication.Test/GoogleTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/GoogleTests.cs
@@ -595,7 +595,7 @@ namespace Microsoft.AspNetCore.Authentication.Google
                 {
                     OnTicketReceived = context =>
                     {
-                        context.Ticket.Properties.RedirectUri = null;
+                        context.Properties.RedirectUri = null;
                         return Task.FromResult(0);
                     }
                 };
@@ -985,7 +985,7 @@ namespace Microsoft.AspNetCore.Authentication.Google
                         else if (req.Path == new PathString("/tokens"))
                         {
                             var result = await context.AuthenticateAsync(TestExtensions.CookieAuthenticationScheme);
-                            var tokens = result.Ticket.Properties.GetTokens();
+                            var tokens = result.Properties.GetTokens();
                             res.Describe(tokens);
                         }
                         else if (req.Path == new PathString("/me"))
@@ -995,17 +995,17 @@ namespace Microsoft.AspNetCore.Authentication.Google
                         else if (req.Path == new PathString("/authenticate"))
                         {
                             var result = await context.AuthenticateAsync(TestExtensions.CookieAuthenticationScheme);
-                            res.Describe(result.Ticket.Principal);
+                            res.Describe(result.Principal);
                         }
                         else if (req.Path == new PathString("/authenticateGoogle"))
                         {
                             var result = await context.AuthenticateAsync("Google");
-                            res.Describe(result?.Ticket?.Principal);
+                            res.Describe(result?.Principal);
                         }
                         else if (req.Path == new PathString("/authenticateFacebook"))
                         {
                             var result = await context.AuthenticateAsync("Facebook");
-                            res.Describe(result?.Ticket?.Principal);
+                            res.Describe(result?.Principal);
                         }
                         else if (req.Path == new PathString("/unauthorized"))
                         {

--- a/test/Microsoft.AspNetCore.Authentication.Test/JwtBearerTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/JwtBearerTests.cs
@@ -127,11 +127,8 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
                             new Claim(ClaimsIdentity.DefaultNameClaimType, "bob")
                         };
 
-                        var ticket = new AuthenticationTicket(
-                            new ClaimsPrincipal(new ClaimsIdentity(claims, context.Scheme.Name)),
-                            new AuthenticationProperties(), context.Scheme.Name);
-
-                        context.Success(ticket);
+                        context.Principal = new ClaimsPrincipal(new ClaimsIdentity(claims, context.Scheme.Name));
+                        context.Success();
 
                         return Task.FromResult<object>(null);
                     }
@@ -338,7 +335,7 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
                     {
                         // Retrieve the NameIdentifier claim from the identity
                         // returned by the custom security token validator.
-                        var identity = (ClaimsIdentity)context.Ticket.Principal.Identity;
+                        var identity = (ClaimsIdentity)context.Principal.Identity;
                         var identifier = identity.FindFirst(ClaimTypes.NameIdentifier);
 
                         Assert.Equal("Bob le Tout Puissant", identifier.Value);

--- a/test/Microsoft.AspNetCore.Authentication.Test/MicrosoftAccountTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/MicrosoftAccountTests.cs
@@ -159,7 +159,7 @@ namespace Microsoft.AspNetCore.Authentication.Tests.MicrosoftAccount
                     OnCreatingTicket = context =>
                     {
                         var refreshToken = context.RefreshToken;
-                        context.Ticket.Principal.AddIdentity(new ClaimsIdentity(new Claim[] { new Claim("RefreshToken", refreshToken, ClaimValueTypes.String, "Microsoft") }, "Microsoft"));
+                        context.Principal.AddIdentity(new ClaimsIdentity(new Claim[] { new Claim("RefreshToken", refreshToken, ClaimValueTypes.String, "Microsoft") }, "Microsoft"));
                         return Task.FromResult<object>(null);
                     }
                 };

--- a/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectEventTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectEventTests.cs
@@ -1512,11 +1512,8 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                         new Claim(ClaimsIdentity.DefaultNameClaimType, "bob")
                     };
 
-                    var ticket = new AuthenticationTicket(
-                        new ClaimsPrincipal(new ClaimsIdentity(claims, context.Scheme.Name)),
-                        new AuthenticationProperties(), context.Scheme.Name);
-
-                    context.Success(ticket);
+                    context.Principal = new ClaimsPrincipal(new ClaimsIdentity(claims, context.Scheme.Name));
+                    context.Success();
                     return Task.FromResult(0);
                 },
                 OnRemoteFailure = FailureNotImpl,

--- a/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectEventTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectEventTests.cs
@@ -263,7 +263,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 {
                     tokenValidated = true;
                     context.HandleResponse();
-                    context.Ticket = null;
+                    context.Principal = null;
                     context.Response.StatusCode = StatusCodes.Status202Accepted;
                     return Task.FromResult(0);
                 },
@@ -305,8 +305,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 OnTokenValidated = context =>
                 {
                     tokenValidated = true;
-                    context.Success(context.Ticket);
-                    // context.Ticket = null;
+                    context.Success();
                     return Task.FromResult(0);
                 },
                 OnAuthorizationCodeReceived = CodeNotImpl,
@@ -464,7 +463,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 {
                     codeReceived = true;
                     context.HandleResponse();
-                    context.Ticket = null;
+                    context.Principal = null;
                     context.Response.StatusCode = StatusCodes.Status202Accepted;
                     return Task.FromResult(0);
                 },
@@ -511,8 +510,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 OnAuthorizationCodeReceived = context =>
                 {
                     codeReceived = true;
-                    context.Success(context.Ticket);
-                    // context.Ticket = null;
+                    context.Success();
                     return Task.FromResult(0);
                 },
                 OnTokenResponseReceived = TokenResponseNotImpl,
@@ -687,7 +685,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 OnTokenResponseReceived = context =>
                 {
                     tokenResponseReceived = true;
-                    context.Ticket = null;
+                    context.Principal = null;
                     context.HandleResponse();
                     context.Response.StatusCode = StatusCodes.Status202Accepted;
                     return Task.FromResult(0);
@@ -741,8 +739,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 OnTokenResponseReceived = context =>
                 {
                     tokenResponseReceived = true;
-                    // context.Ticket = null;
-                    context.Success(context.Ticket);
+                    context.Success();
                     return Task.FromResult(0);
                 },
                 OnUserInformationReceived = UserNotImpl,
@@ -917,7 +914,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 OnTokenValidated = context =>
                 {
                     tokenValidated = true;
-                    context.Ticket = null;
+                    context.Principal = null;
                     context.HandleResponse();
                     context.Response.StatusCode = StatusCodes.Status202Accepted;
                     return Task.FromResult(0);
@@ -971,8 +968,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 OnTokenValidated = context =>
                 {
                     tokenValidated = true;
-                    // context.Ticket = null;
-                    context.Success(context.Ticket);
+                    context.Success();
                     return Task.FromResult(0);
                 },
                 OnUserInformationReceived = UserNotImpl,
@@ -1165,7 +1161,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 OnUserInformationReceived = context =>
                 {
                     userInfoReceived = true;
-                    context.Ticket = null;
+                    context.Principal = null;
                     context.HandleResponse();
                     context.Response.StatusCode = StatusCodes.Status202Accepted;
                     return Task.FromResult(0);
@@ -1226,7 +1222,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 {
                     userInfoReceived = true;
                     // context.Ticket = null;
-                    context.Success(context.Ticket);
+                    context.Success();
                     return Task.FromResult(0);
                 },
                 OnAuthenticationFailed = FailedNotImpl,
@@ -1440,7 +1436,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 {
                     authFailed = true;
                     Assert.Equal("TestException", context.Exception.Message);
-                    Assert.Null(context.Ticket);
+                    Assert.Null(context.Principal);
                     context.HandleResponse();
                     context.Response.StatusCode = StatusCodes.Status202Accepted;
                     return Task.FromResult(0);
@@ -1507,7 +1503,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 {
                     authFailed = true;
                     Assert.Equal("TestException", context.Exception.Message);
-                    Assert.Null(context.Ticket);
+                    Assert.Null(context.Principal);
 
                     var claims = new[]
                     {


### PR DESCRIPTION
All the state copying after every event is pretty gross

@Tratcher thoughts?

I added sugar for Success so events can avoid newing up a ticket.