### PR TITLE
Replace configure method on TwitterOptions and OpenIdConnectOptions with CookieBuilder

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication/Internal/RequestPathBaseCookieBuilder.cs
+++ b/src/Microsoft.AspNetCore.Authentication/Internal/RequestPathBaseCookieBuilder.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Authentication.Internal
+{
+    /// <summary>
+    /// A cookie builder that sets <see cref="CookieOptions.Path"/> to the request path base.
+    /// </summary>
+    public class RequestPathBaseCookieBuilder : CookieBuilder
+    {
+        /// <summary>
+        /// Gets an optional value that is appended to the request path base.
+        /// </summary>
+        protected virtual string AdditionalPath { get; }
+
+        public override CookieOptions Build(HttpContext context, DateTimeOffset expiresFrom)
+        {
+            // check if the user has overridden the default value of path. If so, use that instead of our default value.
+            var path = Path;
+            if (path == null)
+            {
+                var originalPathBase = context.Features.Get<IAuthenticationFeature>()?.OriginalPathBase ?? context.Request.PathBase;
+                path = originalPathBase + AdditionalPath;
+            }
+
+            var options = base.Build(context, expiresFrom);
+
+            options.Path = !string.IsNullOrEmpty(path)
+                ? path
+                : "/";
+
+            return options;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Authentication.Test/OAuthTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/OAuthTests.cs
@@ -190,7 +190,7 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
                         opt.AuthorizationEndpoint = "https://example.com/provider/login";
                         opt.TokenEndpoint = "https://example.com/provider/token";
                         opt.CallbackPath = "/oauth-callback";
-                        opt.ConfigureCorrelationIdCookie = (ctx, options) => options.Path = "/";
+                        opt.CorrelationCookie.Path = "/";
                     }),
                 ctx =>
                 {

--- a/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 {
                     AuthorizationEndpoint = "https://example.com/provider/login"
                 };
-                opt.ConfigureNonceCookie = (ctx, options) => options.Path = "/";
+                opt.NonceCookie.Path = "/";
             });
 
             var server = setting.CreateTestServer();
@@ -143,7 +143,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 {
                     AuthorizationEndpoint = "https://example.com/provider/login"
                 };
-                opt.ConfigureCorrelationIdCookie = (ctx, options) => options.Path = "/";
+                opt.CorrelationCookie.Path = "/";
             });
 
             var server = setting.CreateTestServer();


### PR DESCRIPTION
Addresses https://github.com/aspnet/HttpAbstractions/issues/853.

Uses the new CookieBuilder API added here: https://github.com/aspnet/HttpAbstractions/pull/882

Part 1- look for a separate PR to remove duplication from CookieAuthenticationOptions.