### PR TITLE
Revert obsoleting CookieAuthenticationOptions.ExpireTimeSpan

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationHandler.cs
@@ -270,14 +270,14 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
 
             if (!signInContext.Properties.ExpiresUtc.HasValue)
             {
-                signInContext.Properties.ExpiresUtc = issuedUtc.Add(Options.Cookie.Expiration ?? default(TimeSpan));
+                signInContext.Properties.ExpiresUtc = issuedUtc.Add(Options.ExpireTimeSpan);
             }
 
             await Events.SigningIn(signInContext);
 
             if (signInContext.Properties.IsPersistent)
             {
-                var expiresUtc = signInContext.Properties.ExpiresUtc ?? issuedUtc.Add(Options.Cookie.Expiration ?? default(TimeSpan));
+                var expiresUtc = signInContext.Properties.ExpiresUtc ?? issuedUtc.Add(Options.ExpireTimeSpan);
                 signInContext.CookieOptions.Expires = expiresUtc.ToUniversalTime();
             }
 

--- a/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationOptions.cs
@@ -21,7 +21,6 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
             SameSite = SameSiteMode.Lax,
             HttpOnly = true,
             SecurePolicy = CookieSecurePolicy.SameAsRequest,
-            Expiration = TimeSpan.FromDays(14),
         };
 
         /// <summary>
@@ -29,6 +28,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         /// </summary>
         public CookieAuthenticationOptions()
         {
+            ExpireTimeSpan = TimeSpan.FromDays(14);
             ReturnUrlParameter = CookieAuthenticationDefaults.ReturnUrlParameter;
             SlidingExpiration = true;
             Events = new CookieAuthenticationEvents();
@@ -42,7 +42,6 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         /// <seealso cref="CookieBuilder.SameSite"/> defaults to <see cref="SameSiteMode.Lax"/>.
         /// <seealso cref="CookieBuilder.HttpOnly"/> defaults to <c>true</c>.
         /// <seealso cref="CookieBuilder.SecurePolicy"/> defaults to <see cref="CookieSecurePolicy.SameAsRequest"/>.
-        /// <seealso cref="CookieBuilder.Expiration"/> defaults to 14 days.
         /// </para>
         /// </summary>
         /// <remarks>
@@ -60,9 +59,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         /// The default is true, which means the cookie will only be passed to http requests and is not made available to script on the page.
         /// </para>
         /// <para>
-        /// <seealso cref="CookieBuilder.Expiration"/> controls how much time the cookie will remain valid from the point it is created. The expiration
-        /// information is in the protected cookie ticket. Because of that an expired cookie will be ignored
-        /// even if it is passed to the server after the browser should have purged it
+        /// <seealso cref="CookieBuilder.Expiration"/> is currently ignored. Use <see cref="ExpireTimeSpan"/> to control lifetime of cookie authentication.
         /// </para>
         /// </remarks>
         public CookieBuilder Cookie
@@ -140,6 +137,19 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         /// </summary>
         public ITicketStore SessionStore { get; set; }
 
+        /// <summary>
+        /// <para>
+        /// Controls how much time the authentication ticket stored in the cookie will remain valid from the point it is created
+        /// The expiration information is stored in the protected cookie ticket. Because of that an expired cookie will be ignored
+        /// even if it is passed to the server after the browser should have purged it.
+        /// </para>
+        /// <para>
+        /// This is separate from the value of <seealso cref="CookieOptions.Expires"/>, which specifies
+        /// how long the browser will keep the cookie.
+        /// </para>
+        /// </summary>
+        public TimeSpan ExpireTimeSpan { get; set; }
+
         #region Obsolete API
         /// <summary>
         /// <para>
@@ -201,23 +211,6 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         /// </summary>
         [Obsolete("This property is obsolete and will be removed in a future version. The recommended alternative is " + nameof(Cookie) + "." + nameof(CookieBuilder.SecurePolicy) + ".")]
         public CookieSecurePolicy CookieSecure { get => Cookie.SecurePolicy; set => Cookie.SecurePolicy = value; }
-
-        /// <summary>
-        /// <para>
-        /// This property is obsolete and will be removed in a future version. The recommended alternative is <seealso cref="CookieBuilder.Expiration"/> on <see cref="Cookie"/>.
-        /// </para>
-        /// <para>
-        /// Controls how much time the cookie will remain valid from the point it is created. The expiration
-        /// information is in the protected cookie ticket. Because of that an expired cookie will be ignored
-        /// even if it is passed to the server after the browser should have purged it
-        /// </para>
-        /// </summary>
-        [Obsolete("This property is obsolete and will be removed in a future version. The recommended alternative is " + nameof(Cookie) + "." + nameof(CookieBuilder.Expiration) + ".")]
-        public TimeSpan ExpireTimeSpan
-        {
-            get => Cookie.Expiration ?? default(TimeSpan);
-            set => Cookie.Expiration = value;
-        }
         #endregion
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.Cookies/Microsoft.AspNetCore.Authentication.Cookies.csproj
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/Microsoft.AspNetCore.Authentication.Cookies.csproj
@@ -19,8 +19,4 @@
     <ProjectReference Include="..\Microsoft.AspNetCore.Authentication\Microsoft.AspNetCore.Authentication.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
-
 </Project>

--- a/test/Microsoft.AspNetCore.Authentication.Test/CookieTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/CookieTests.cs
@@ -144,6 +144,23 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         }
 
         [Fact]
+        public async Task CookieExpirationOptionIsIgnored()
+        {
+            var server = CreateServerWithServices(s => s.AddAuthentication().AddCookie(o =>
+            {
+                o.Cookie.Name = "TestCookie";
+                // this is currently ignored. Users should set o.ExpireTimeSpan instead
+                o.Cookie.Expiration = TimeSpan.FromDays(10);
+            }), SignInAsAlice);
+
+            var transaction = await SendAsync(server, "http://example.com/testpath");
+
+            var setCookie = transaction.SetCookie;
+            Assert.StartsWith("TestCookie=", setCookie);
+            Assert.DoesNotContain("; expires=", setCookie);
+        }
+
+        [Fact]
         public async Task SignInWrongAuthTypeThrows()
         {
             var server = CreateServer(o =>

--- a/test/Microsoft.AspNetCore.Authentication.Test/CookieTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/CookieTests.cs
@@ -277,7 +277,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         {
             var server = CreateServer(o =>
             {
-                o.Cookie.Expiration = TimeSpan.FromMinutes(10);
+                o.ExpireTimeSpan = TimeSpan.FromMinutes(10);
                 o.SlidingExpiration = false;
             }, SignInAsAlice);
 
@@ -306,7 +306,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         {
             var server = CreateServer(o =>
             {
-                o.Cookie.Expiration = TimeSpan.FromMinutes(10);
+                o.ExpireTimeSpan = TimeSpan.FromMinutes(10);
                 o.SlidingExpiration = false;
             },
             context =>
@@ -339,7 +339,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         {
             var server = CreateServer(o =>
             {
-                o.Cookie.Expiration = TimeSpan.FromMinutes(10);
+                o.ExpireTimeSpan = TimeSpan.FromMinutes(10);
                 o.Events = new CookieAuthenticationEvents
                 {
                     OnValidatePrincipal = ctx =>
@@ -367,7 +367,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         {
             var server = CreateServer(o =>
             {
-                o.Cookie.Expiration = TimeSpan.FromMinutes(10);
+                o.ExpireTimeSpan = TimeSpan.FromMinutes(10);
                 o.SlidingExpiration = false;
                 o.Events = new CookieAuthenticationEvents
                 {
@@ -395,7 +395,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         {
             var server = CreateServer(o =>
             {
-                o.Cookie.Expiration = TimeSpan.FromMinutes(10);
+                o.ExpireTimeSpan = TimeSpan.FromMinutes(10);
                 o.SlidingExpiration = false;
                 o.Events = new CookieAuthenticationEvents
                 {
@@ -431,7 +431,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         {
             var server = CreateServer(o =>
             {
-                o.Cookie.Expiration = TimeSpan.FromMinutes(10);
+                o.ExpireTimeSpan = TimeSpan.FromMinutes(10);
                 o.SlidingExpiration = false;
                 o.Events = new CookieAuthenticationEvents
                 {
@@ -476,7 +476,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         {
             var server = CreateServer(o =>
             {
-                o.Cookie.Expiration = TimeSpan.FromMinutes(10);
+                o.ExpireTimeSpan = TimeSpan.FromMinutes(10);
                 o.Events = new CookieAuthenticationEvents
                 {
                     OnValidatePrincipal = ctx =>
@@ -520,7 +520,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         {
             var server = CreateServer(o =>
             {
-                o.Cookie.Expiration = TimeSpan.FromMinutes(10);
+                o.ExpireTimeSpan = TimeSpan.FromMinutes(10);
                 o.SlidingExpiration = false;
                 o.Events = new CookieAuthenticationEvents
                 {
@@ -569,7 +569,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
             DateTimeOffset? lastExpiresDate = null;
             var server = CreateServer(o =>
             {
-                o.Cookie.Expiration = TimeSpan.FromMinutes(10);
+                o.ExpireTimeSpan = TimeSpan.FromMinutes(10);
                 o.SlidingExpiration = sliding;
                 o.Events = new CookieAuthenticationEvents
                 {
@@ -619,7 +619,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         {
             var server = CreateServer(o =>
             {
-                o.Cookie.Expiration = TimeSpan.FromMinutes(10);
+                o.ExpireTimeSpan = TimeSpan.FromMinutes(10);
                 o.SlidingExpiration = false;
                 o.Events = new CookieAuthenticationEvents()
                 {
@@ -656,7 +656,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         {
             var server = CreateServer(o =>
             {
-                o.Cookie.Expiration = TimeSpan.FromMinutes(10);
+                o.ExpireTimeSpan = TimeSpan.FromMinutes(10);
                 o.SlidingExpiration = true;
             },
             SignInAsAlice);


### PR DESCRIPTION
`CookieAuthenticationOptions.Cookie.Expiration` is conceptually different from `CookieAuthenticationOptions.ExpireTimeSpan`.

Un-oboleting the property and updating xmldocs.