### PR TITLE
Add AuthenticationProperties to HandleRequestResult and RemoteFailureContext

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterHandler.cs
@@ -46,7 +46,6 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
 
         protected override async Task<HandleRequestResult> HandleRemoteAuthenticateAsync()
         {
-            AuthenticationProperties properties = null;
             var query = Request.Query;
             var protectedRequestToken = Request.Cookies[Options.StateCookie.Name];
 
@@ -57,25 +56,25 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
                 return HandleRequestResult.Fail("Invalid state cookie.");
             }
 
-            properties = requestToken.Properties;
+            var properties = requestToken.Properties;
 
             // REVIEW: see which of these are really errors
 
             var returnedToken = query["oauth_token"];
             if (StringValues.IsNullOrEmpty(returnedToken))
             {
-                return HandleRequestResult.Fail("Missing oauth_token");
+                return HandleRequestResult.Fail("Missing oauth_token", properties);
             }
 
             if (!string.Equals(returnedToken, requestToken.Token, StringComparison.Ordinal))
             {
-                return HandleRequestResult.Fail("Unmatched token");
+                return HandleRequestResult.Fail("Unmatched token", properties);
             }
 
             var oauthVerifier = query["oauth_verifier"];
             if (StringValues.IsNullOrEmpty(oauthVerifier))
             {
-                return HandleRequestResult.Fail("Missing or blank oauth_verifier");
+                return HandleRequestResult.Fail("Missing or blank oauth_verifier", properties);
             }
 
             var cookieOptions = Options.StateCookie.Build(Context, Clock.UtcNow);

--- a/src/Microsoft.AspNetCore.Authentication/Events/RemoteFailureContext.cs
+++ b/src/Microsoft.AspNetCore.Authentication/Events/RemoteFailureContext.cs
@@ -25,5 +25,10 @@ namespace Microsoft.AspNetCore.Authentication
         /// User friendly error message for the error.
         /// </summary>
         public Exception Failure { get; set; }
+
+        /// <summary>
+        /// Additional state values for the authentication session.
+        /// </summary>
+        public AuthenticationProperties Properties { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication/HandleRequestResult.cs
+++ b/src/Microsoft.AspNetCore.Authentication/HandleRequestResult.cs
@@ -49,12 +49,30 @@ namespace Microsoft.AspNetCore.Authentication
         /// <summary>
         /// Indicates that there was a failure during authentication.
         /// </summary>
+        /// <param name="failure">The failure exception.</param>
+        /// <param name="properties">Additional state values for the authentication session.</param>
+        /// <returns>The result.</returns>
+        public static new HandleRequestResult Fail(Exception failure, AuthenticationProperties properties)
+        {
+            return new HandleRequestResult() { Failure = failure, Properties = properties };
+        }
+
+        /// <summary>
+        /// Indicates that there was a failure during authentication.
+        /// </summary>
         /// <param name="failureMessage">The failure message.</param>
         /// <returns>The result.</returns>
         public static new HandleRequestResult Fail(string failureMessage)
-        {
-            return new HandleRequestResult() { Failure = new Exception(failureMessage) };
-        }
+            => Fail(new Exception(failureMessage));
+
+        /// <summary>
+        /// Indicates that there was a failure during authentication.
+        /// </summary>
+        /// <param name="failureMessage">The failure message.</param>
+        /// <param name="properties">Additional state values for the authentication session.</param>
+        /// <returns>The result.</returns>
+        public static new HandleRequestResult Fail(string failureMessage, AuthenticationProperties properties)
+            => Fail(new Exception(failureMessage), properties);
 
         /// <summary>
         /// Discontinue all processing for this request and return to the client.

--- a/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectEventTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectEventTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 return PostAsync(server, "signin-oidc", "");
             });
 
-            Assert.Equal("Authentication was aborted from user code.", exception.Message);
+            Assert.Equal("Authentication was aborted from user code.", exception.InnerException.Message);
 
             Assert.True(messageReceived);
             Assert.True(remoteFailure);
@@ -191,7 +191,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 return PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state");
             });
 
-            Assert.Equal("Authentication was aborted from user code.", exception.Message);
+            Assert.Equal("Authentication was aborted from user code.", exception.InnerException.Message);
 
             Assert.True(messageReceived);
             Assert.True(tokenValidated);
@@ -348,7 +348,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 return PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state&code=my_code");
             });
 
-            Assert.Equal("Authentication was aborted from user code.", exception.Message);
+            Assert.Equal("Authentication was aborted from user code.", exception.InnerException.Message);
 
             Assert.True(messageReceived);
             Assert.True(tokenValidated);
@@ -532,7 +532,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 return PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state&code=my_code");
             });
 
-            Assert.Equal("Authentication was aborted from user code.", exception.Message);
+            Assert.Equal("Authentication was aborted from user code.", exception.InnerException.Message);
 
             Assert.True(messageReceived);
             Assert.True(tokenValidated);
@@ -731,7 +731,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 return PostAsync(server, "signin-oidc", "state=protected_state&code=my_code");
             });
 
-            Assert.Equal("Authentication was aborted from user code.", exception.Message);
+            Assert.Equal("Authentication was aborted from user code.", exception.InnerException.Message);
 
             Assert.True(messageReceived);
             Assert.True(codeReceived);
@@ -943,7 +943,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 return PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state&code=my_code");
             });
 
-            Assert.Equal("Authentication was aborted from user code.", exception.Message);
+            Assert.Equal("Authentication was aborted from user code.", exception.InnerException.Message);
 
             Assert.True(messageReceived);
             Assert.True(tokenValidated);
@@ -1186,7 +1186,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 return PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state&code=my_code");
             });
 
-            Assert.Equal("Authentication was aborted from user code.", exception.Message);
+            Assert.Equal("Authentication was aborted from user code.", exception.InnerException.Message);
 
             Assert.True(messageReceived);
             Assert.True(tokenValidated);
@@ -1450,6 +1450,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 {
                     remoteFailure = true;
                     Assert.Equal("TestException", context.Failure.Message);
+                    Assert.Equal("testvalue", context.Properties.Items["testkey"]);
                     context.HandleResponse();
                     context.Response.StatusCode = StatusCodes.Status202Accepted;
                     return Task.FromResult(0);
@@ -1877,7 +1878,8 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 var properties = new AuthenticationProperties(new Dictionary<string, string>()
                 {
                     { ".xsrf", "corrilationId" },
-                    { OpenIdConnectDefaults.RedirectUriForCodePropertiesKey, "redirect_uri" }
+                    { OpenIdConnectDefaults.RedirectUriForCodePropertiesKey, "redirect_uri" },
+                    { "testkey", "testvalue" }
                 });
                 properties.RedirectUri = "http://testhost/redirect";
                 return properties;


### PR DESCRIPTION
#1188 Requires https://github.com/aspnet/HttpAbstractions/pull/889
User state for the login is flown via auth properties, but these aren't available in the OnRemoteFailure event. To add them we need to flow them via the AuthResult.

If this works out then we may use it to flow additional data for #1178. The difference is that the data in #1178 isn't a consistent data structure across handlers.

/cc: @brockallen 