### PR TITLE
Corrected typos in XML Docs in MessageReceivedContext (JwtBearer and OpenIdConnect)

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.JwtBearer/Events/MessageReceivedContext.cs
+++ b/src/Microsoft.AspNetCore.Authentication.JwtBearer/Events/MessageReceivedContext.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
             : base(context, scheme, options) { }
 
         /// <summary>
-        /// Bearer Token. This will give application an opportunity to retrieve token from an alternation location.
+        /// Bearer Token. This will give the application an opportunity to retrieve a token from an alternative location.
         /// </summary>
         public string Token { get; set; }
     }

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/Events/MessageReceivedContext.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/Events/MessageReceivedContext.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
         public OpenIdConnectMessage ProtocolMessage { get; set; }
 
         /// <summary>
-        /// Bearer Token. This will give application an opportunity to retrieve token from an alternation location.
+        /// Bearer Token. This will give the application an opportunity to retrieve a token from an alternative location.
         /// </summary>
         public string Token { get; set; }
     }


### PR DESCRIPTION
My first PR. Correcting a typo in the XML docs of the MessageReceivedContext.Token property. I've used these libraries extensively in recent weeks and this typo was bugging me.