### PR TITLE
Reacting to ResponseCookie Delete changes

### DIFF
--- a/test/Microsoft.AspNetCore.CookiePolicy.Test/CookiePolicyTests.cs
+++ b/test/Microsoft.AspNetCore.CookiePolicy.Test/CookiePolicyTests.cs
@@ -273,7 +273,7 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
 
             Assert.NotNull(transaction.SetCookie);
             Assert.Equal(1, transaction.SetCookie.Count);
-            Assert.Equal("A=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax", transaction.SetCookie[0]);
+            Assert.Equal("A=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=lax", transaction.SetCookie[0]);
         }
 
         [Fact]


### PR DESCRIPTION
Reacts to https://github.com/aspnet/HttpAbstractions/commit/594f55947f4c1d0a9d3122e3f39bcfa81199b12a
We now preserve Secure, HttpOnly, and SameSite on Delete.
