### PR TITLE
Recommend CookieBuilder.HttpOnly instead of CookieBuilder.SameSite

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationOptions.cs
@@ -196,7 +196,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         /// to script on the page.
         /// </para>
         /// </summary>
-        [Obsolete("This property is obsolete and will be removed in a future version. The recommended alternative is " + nameof(Cookie) + "." + nameof(CookieBuilder.SameSite) + ".")]
+        [Obsolete("This property is obsolete and will be removed in a future version. The recommended alternative is " + nameof(Cookie) + "." + nameof(CookieBuilder.HttpOnly) + ".")]
         public bool CookieHttpOnly { get => Cookie.HttpOnly; set => Cookie.HttpOnly = value; }
 
         /// <summary>


### PR DESCRIPTION
Fix a copy & paste error in an `[Obsolete]` attribute within `CookieAuthenticationOptions.cs`.

/cc: @natemcmaster 