### PR TITLE
Added ability to set prompt parameter in OpenIdConnectOptions

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
@@ -317,6 +317,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                 RedirectUri = BuildRedirectUri(Options.CallbackPath),
                 Resource = Options.Resource,
                 ResponseType = Options.ResponseType,
+                Prompt = Options.Prompt,
                 Scope = string.Join(" ", Options.Scope)
             };
 

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectOptions.cs
@@ -212,7 +212,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
         /// <summary>
         /// Gets or sets the 'prompt'.
         /// </summary>
-        public string Prompt { get; set; } = "none";
+        public string Prompt { get; set; }
 
         /// <summary>
         /// Gets the list of permissions to request.

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectOptions.cs
@@ -210,6 +210,11 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
         public string ResponseType { get; set; } = OpenIdConnectResponseType.IdToken;
 
         /// <summary>
+        /// Gets or sets the 'prompt'.
+        /// </summary>
+        public string Prompt { get; set; } = "none";
+
+        /// <summary>
         /// Gets the list of permissions to request.
         /// </summary>
         public ICollection<string> Scope { get; } = new HashSet<string>();


### PR DESCRIPTION
 - Set prompt parameter to value set in Options in OpenIdConnectHandler.HandleChallengeAsync()
 - See http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest for expected behavior

Addresses #1398