### PR TITLE
Remove the profile scope

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectOptions.cs
@@ -42,7 +42,6 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
 
             Events = new OpenIdConnectEvents();
             Scope.Add("openid");
-            Scope.Add("profile");
 
             ClaimActions.DeleteClaim("nonce");
             ClaimActions.DeleteClaim("aud");


### PR DESCRIPTION
Remove the profile - because it is optional. If someone wants profile, it should be added explicitly. For most scenarios, profile is not appropriate.