### PR TITLE
Make all handlers public

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookHandler.cs
@@ -16,7 +16,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNetCore.Authentication.Facebook
 {
-    internal class FacebookHandler : OAuthHandler<FacebookOptions>
+    public class FacebookHandler : OAuthHandler<FacebookOptions>
     {
         public FacebookHandler(IOptionsMonitor<FacebookOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
             : base(options, logger, encoder, clock)

--- a/src/Microsoft.AspNetCore.Authentication.Google/GoogleHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Google/GoogleHandler.cs
@@ -16,7 +16,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNetCore.Authentication.Google
 {
-    internal class GoogleHandler : OAuthHandler<GoogleOptions>
+    public class GoogleHandler : OAuthHandler<GoogleOptions>
     {
         public GoogleHandler(IOptionsMonitor<GoogleOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
             : base(options, logger, encoder, clock)

--- a/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerHandler.cs
@@ -18,7 +18,7 @@ using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Authentication.JwtBearer
 {
-    internal class JwtBearerHandler : AuthenticationHandler<JwtBearerOptions>
+    public class JwtBearerHandler : AuthenticationHandler<JwtBearerOptions>
     {
         private OpenIdConnectConfiguration _configuration;
 

--- a/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountHandler.cs
@@ -13,7 +13,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
 {
-    internal class MicrosoftAccountHandler : OAuthHandler<MicrosoftAccountOptions>
+    public class MicrosoftAccountHandler : OAuthHandler<MicrosoftAccountOptions>
     {
         public MicrosoftAccountHandler(IOptionsMonitor<MicrosoftAccountOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
             : base(options, logger, encoder, clock)

--- a/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterHandler.cs
@@ -19,7 +19,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNetCore.Authentication.Twitter
 {
-    internal class TwitterHandler : RemoteAuthenticationHandler<TwitterOptions>
+    public class TwitterHandler : RemoteAuthenticationHandler<TwitterOptions>
     {
         private static readonly DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         private const string RequestTokenEndpoint = "https://api.twitter.com/oauth/request_token";


### PR DESCRIPTION
Easy half of https://github.com/aspnet/Security/issues/1218

Most are public already, so should be harmless being consistent with these.

Extensibility, aka 

`MyGoogle<MyGoogleOptions> : GoogleHandler` is something we can look at later

@Tratcher 