### PR TITLE
Use a compliant Expires header value for expiration.

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationHandler.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         IAuthenticationSignOutHandler
     {
         private const string HeaderValueNoCache = "no-cache";
-        private const string HeaderValueMinusOne = "-1";
+        private const string HeaderValueEpocDate = "Thu, 01 Jan 1970 00:00:00 GMT";
         private const string SessionIdClaim = "Microsoft.AspNetCore.Authentication.Cookies-SessionId";
 
         private bool _shouldRefresh;
@@ -359,7 +359,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         {
             Response.Headers[HeaderNames.CacheControl] = HeaderValueNoCache;
             Response.Headers[HeaderNames.Pragma] = HeaderValueNoCache;
-            Response.Headers[HeaderNames.Expires] = HeaderValueMinusOne;
+            Response.Headers[HeaderNames.Expires] = HeaderValueEpocDate;
 
             if (shouldRedirectToReturnUrl && Response.StatusCode == 200)
             {

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
@@ -32,6 +32,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
         private const string NonceProperty = "N";
         private const string UriSchemeDelimiter = "://";
 
+        private const string HeaderValueEpocDate = "Thu, 01 Jan 1970 00:00:00 GMT";
         private const string InputTagFormat = @"<input type=""hidden"" name=""{0}"" value=""{1}"" />";
         private const string HtmlFormFormat = @"<!doctype html>
 <html>
@@ -261,7 +262,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                 // Emit Cache-Control=no-cache to prevent client caching.
                 Response.Headers[HeaderNames.CacheControl] = "no-cache";
                 Response.Headers[HeaderNames.Pragma] = "no-cache";
-                Response.Headers[HeaderNames.Expires] = "-1";
+                Response.Headers[HeaderNames.Expires] = HeaderValueEpocDate;
 
                 await Response.Body.WriteAsync(buffer, 0, buffer.Length);
             }
@@ -442,7 +443,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                 // Emit Cache-Control=no-cache to prevent client caching.
                 Response.Headers[HeaderNames.CacheControl] = "no-cache";
                 Response.Headers[HeaderNames.Pragma] = "no-cache";
-                Response.Headers[HeaderNames.Expires] = "-1";
+                Response.Headers[HeaderNames.Expires] = HeaderValueEpocDate;
 
                 await Response.Body.WriteAsync(buffer, 0, buffer.Length);
                 return;


### PR DESCRIPTION
#1353 -1 is an invalid value for the Expires header, it should be a date in the past.