### PR TITLE
Don't throw for partial cookies

### DIFF
--- a/shared/Microsoft.AspNetCore.ChunkingCookieManager.Sources/ChunkingCookieManager.cs
+++ b/shared/Microsoft.AspNetCore.ChunkingCookieManager.Sources/ChunkingCookieManager.cs
@@ -44,7 +44,6 @@ namespace Microsoft.AspNetCore.Internal
             // See http://browsercookielimits.x64.me/.
             // Leave at least 40 in case CookiePolicy tries to add 'secure', 'samesite=strict' and/or 'httponly'.
             ChunkSize = DefaultChunkSize;
-            ThrowForPartialCookies = true;
         }
 
         /// <summary>

--- a/src/Microsoft.Owin.Security.Interop/ChunkingCookieManager.cs
+++ b/src/Microsoft.Owin.Security.Interop/ChunkingCookieManager.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Owin.Security.Interop
             // See http://browsercookielimits.x64.me/.
             // Leave at least 20 in case CookiePolicy tries to add 'secure' and/or 'httponly'.
             ChunkSize = 4070;
-            ThrowForPartialCookies = true;
         }
 
         /// <summary>

--- a/test/Microsoft.AspNetCore.ChunkingCookieManager.Sources.Test/CookieChunkingTests.cs
+++ b/test/Microsoft.AspNetCore.ChunkingCookieManager.Sources.Test/CookieChunkingTests.cs
@@ -81,7 +81,8 @@ namespace Microsoft.AspNetCore.Internal
                 "TestCookieC7=STUVWXYZ"
             };
 
-            Assert.Throws<FormatException>(() => new ChunkingCookieManager().GetRequestCookie(context, "TestCookie"));
+            Assert.Throws<FormatException>(() => new ChunkingCookieManager() { ThrowForPartialCookies = true }
+                .GetRequestCookie(context, "TestCookie"));
         }
 
         [Fact]


### PR DESCRIPTION
#1349 In practice customers end up disabling this option (if they find it).