### PR TITLE
Added support for multiple values (arrays) in default claim action

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.OAuth/Claims/JsonKeyClaimAction.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OAuth/Claims/JsonKeyClaimAction.cs
@@ -32,7 +32,22 @@ namespace Microsoft.AspNetCore.Authentication.OAuth.Claims
         /// <inheritdoc />
         public override void Run(JObject userData, ClaimsIdentity identity, string issuer)
         {
-            var value = userData?.Value<string>(JsonKey);
+            var value = userData?[JsonKey];
+            if (value is JValue)
+            {
+                AddClaim(value?.ToString(), identity, issuer);
+            }
+            else if (value is JArray)
+            {
+                foreach (var v in value)
+                {
+                    AddClaim(v?.ToString(), identity, issuer);
+                }
+            }
+        }
+
+        private void AddClaim(string value, ClaimsIdentity identity, string issuer)
+        {
             if (!string.IsNullOrEmpty(value))
             {
                 identity.AddClaim(new Claim(ClaimType, value, ValueType, issuer));

--- a/test/Microsoft.AspNetCore.Authentication.Test/ClaimActionTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/ClaimActionTests.cs
@@ -1,0 +1,55 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Testing.xunit;
+using Xunit;
+using Microsoft.AspNetCore.Authentication.OAuth.Claims;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.AspNetCore.Authentication
+{
+    public class ClaimActionTests
+    {
+        [Fact]
+        public void CanMapSingleValueUserDataToClaim()
+        {
+            var userData = new JObject
+            {
+                ["name"] = "test"
+            };
+
+            var identity = new ClaimsIdentity();
+
+            var action = new JsonKeyClaimAction("name", "name", "name");
+            action.Run(userData, identity, "iss");
+
+            Assert.Equal("name", identity.FindFirst("name").Type);
+            Assert.Equal("test", identity.FindFirst("name").Value);
+        }
+
+        [Fact]
+        public void CanMapArrayValueUserDataToClaims()
+        {
+            var userData = new JObject
+            {
+                ["role"] = new JArray { "role1", "role2" }
+            };
+
+            var identity = new ClaimsIdentity();
+
+            var action = new JsonKeyClaimAction("role", "role", "role");
+            action.Run(userData, identity, "iss");
+
+            var roleClaims = identity.FindAll("role").ToList();
+            Assert.Equal(2, roleClaims.Count);
+            Assert.Equal("role", roleClaims[0].Type);
+            Assert.Equal("role1", roleClaims[0].Value);
+            Assert.Equal("role", roleClaims[1].Type);
+            Assert.Equal("role2", roleClaims[1].Value);
+        }
+    }
+}


### PR DESCRIPTION
Claims like role might come in a form of an array with multiple values. When using the default Oidc MW role option isn't mapped by default, so that mapping has to be added.
```o.ClaimActions.Add(new JsonKeyClaimAction("role", "role", "role"));```

The default mappers only process the single string value claims. This can be useful for any multivalue claim.

In the case of roles, as each claim is mapped to the same key, User.IsInRole works as expected. If you expand the list of claims for ClaimsIdentity it would looks something like this
```
{name: user}
{role: Foo}
{role: Bar}
```


