### PR TITLE
Add OIDC SecondaryTokenValidated event. Refactor tests.

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/Events/OpenIdConnectEvents.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/Events/OpenIdConnectEvents.cs
@@ -59,6 +59,12 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
         public Func<TokenValidatedContext, Task> OnTokenValidated { get; set; } = context => Task.CompletedTask;
 
         /// <summary>
+        /// Invoked when an IdToken from the token endpoint (in addition to the one from the authorization endpoint)
+        /// has been validated and produced an AuthenticationTicket.
+        /// </summary>
+        public Func<SecondaryTokenValidatedContext, Task> OnSecondaryTokenValidated { get; set; } = context => Task.CompletedTask;
+
+        /// <summary>
         /// Invoked when user information is retrieved from the UserInfoEndpoint.
         /// </summary>
         public Func<UserInformationReceivedContext, Task> OnUserInformationReceived { get; set; } = context => Task.CompletedTask;
@@ -80,6 +86,8 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
         public virtual Task TokenResponseReceived(TokenResponseReceivedContext context) => OnTokenResponseReceived(context);
 
         public virtual Task TokenValidated(TokenValidatedContext context) => OnTokenValidated(context);
+
+        public virtual Task SecondaryTokenValidated(SecondaryTokenValidatedContext context) => OnSecondaryTokenValidated(context);
 
         public virtual Task UserInformationReceived(UserInformationReceivedContext context) => OnUserInformationReceived(context);
     }

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/Events/SecondaryTokenValidatedContext.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/Events/SecondaryTokenValidatedContext.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
+{
+    public class SecondaryTokenValidatedContext : TokenValidatedContext
+    {
+        /// <summary>
+        /// Creates a <see cref="TokenValidatedContext"/>
+        /// </summary>
+        public SecondaryTokenValidatedContext(HttpContext context, AuthenticationScheme scheme, OpenIdConnectOptions options, ClaimsPrincipal principal, AuthenticationProperties properties)
+            : base(context, scheme, options, principal, properties) { }
+
+        /// <summary>
+        /// Gets the <see cref="ClaimsPrincipal"/> containing additional user claims.
+        /// </summary>
+        public ClaimsPrincipal SecondaryPrincipal { get; set; }
+
+    }
+}

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/LoggingExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/LoggingExtensions.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Extensions.Logging
         private static Action<ILogger, Exception> _tokenResponseReceived;
         private static Action<ILogger, Exception> _tokenValidatedHandledResponse;
         private static Action<ILogger, Exception> _tokenValidatedSkipped;
+        private static Action<ILogger, Exception> _secondaryTokenValidatedHandledResponse;
+        private static Action<ILogger, Exception> _secondaryTokenValidatedSkipped;
         private static Action<ILogger, Exception> _authenticationFailedContextHandledResponse;
         private static Action<ILogger, Exception> _authenticationFailedContextSkipped;
         private static Action<ILogger, Exception> _authorizationCodeReceivedContextHandledResponse;
@@ -258,6 +260,14 @@ namespace Microsoft.Extensions.Logging
                 eventId: 51,
                 logLevel: LogLevel.Debug,
                 formatString: "RedirectToSignedOutRedirectUri.Skipped");
+            _secondaryTokenValidatedHandledResponse = LoggerMessage.Define(
+                eventId: 52,
+                logLevel: LogLevel.Debug,
+                formatString: "SecondaryTokenValidated.HandledResponse");
+            _secondaryTokenValidatedSkipped = LoggerMessage.Define(
+                eventId: 53,
+                logLevel: LogLevel.Debug,
+                formatString: "SecondaryTokenValidated.Skipped");
         }
 
         public static void UpdatingConfiguration(this ILogger logger)
@@ -298,6 +308,16 @@ namespace Microsoft.Extensions.Logging
         public static void TokenValidatedSkipped(this ILogger logger)
         {
             _tokenValidatedSkipped(logger, null);
+        }
+
+        public static void SecondaryTokenValidatedHandledResponse(this ILogger logger)
+        {
+            _secondaryTokenValidatedHandledResponse(logger, null);
+        }
+
+        public static void SecondaryTokenValidatedSkipped(this ILogger logger)
+        {
+            _secondaryTokenValidatedSkipped(logger, null);
         }
 
         public static void AuthorizationCodeReceivedContextHandledResponse(this ILogger logger)

--- a/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectEventTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectEventTests.cs
@@ -28,67 +28,46 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
 {
     public class OpenIdConnectEventTests
     {
-        private readonly Func<MessageReceivedContext, Task> MessageNotImpl = context => { throw new NotImplementedException("Message"); };
-        private readonly Func<TokenValidatedContext, Task> TokenNotImpl = context => { throw new NotImplementedException("Token"); };
-        private readonly Func<AuthorizationCodeReceivedContext, Task> CodeNotImpl = context => { throw new NotImplementedException("Code"); };
-        private readonly Func<TokenResponseReceivedContext, Task> TokenResponseNotImpl = context => { throw new NotImplementedException("TokenResponse"); };
-        private readonly Func<UserInformationReceivedContext, Task> UserNotImpl = context => { throw new NotImplementedException("User"); };
-        private readonly Func<AuthenticationFailedContext, Task> FailedNotImpl = context => { throw new NotImplementedException("Failed", context.Exception); };
-        private readonly Func<TicketReceivedContext, Task> TicketNotImpl = context => { throw new NotImplementedException("Ticket"); };
-        private readonly Func<RemoteFailureContext, Task> FailureNotImpl = context => { throw new NotImplementedException("Failure", context.Failure); };
-        private readonly Func<RedirectContext, Task> RedirectNotImpl = context => { throw new NotImplementedException("Redirect"); };
-        private readonly Func<RemoteSignOutContext, Task> RemoteSignOutNotImpl = context => { throw new NotImplementedException("Remote"); };
-        private readonly Func<RemoteSignOutContext, Task> SignedOutCallbackNotImpl = context => { throw new NotImplementedException("SingedOut"); };
+        private readonly RequestDelegate AppWritePath = context => context.Response.WriteAsync(context.Request.Path);
         private readonly RequestDelegate AppNotImpl = context => { throw new NotImplementedException("App"); };
 
         [Fact]
         public async Task OnMessageReceived_Skip_NoMoreEventsRun()
         {
-            var messageReceived = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    context.SkipHandler();
-                    return Task.FromResult(0);
-                };
-            }),
-            context =>
+                ExpectMessageReceived = true,
+            };
+            events.OnMessageReceived = context =>
             {
-                return context.Response.WriteAsync(context.Request.Path);
-            });
+                events.InvokedMessageReceived = true;
+                context.SkipHandler();
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppWritePath);
 
             var response = await PostAsync(server, "signin-oidc", "");
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal("/signin-oidc", await response.Content.ReadAsStringAsync());
-            Assert.True(messageReceived);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnMessageReceived_Fail_NoMoreEventsRun()
         {
-            var messageReceived = false;
-            var remoteFailure = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    context.Fail("Authentication was aborted from user code.");
-                    return Task.FromResult(0);
-                };
-                events.OnRemoteFailure = context =>
-                {
-                    remoteFailure = true;
-                    return Task.FromResult(0);
-                };
-            }),
-            context =>
+                ExpectMessageReceived = true,
+                ExpectRemoteFailure = true,
+            };
+            events.OnMessageReceived = context =>
             {
-                return context.Response.WriteAsync(context.Request.Path);
-            });
+                events.InvokedMessageReceived = true;
+                context.Fail("Authentication was aborted from user code.");
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppWritePath);
 
             var exception = await Assert.ThrowsAsync<Exception>(delegate
             {
@@ -96,95 +75,71 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
             });
 
             Assert.Equal("Authentication was aborted from user code.", exception.InnerException.Message);
-
-            Assert.True(messageReceived);
-            Assert.True(remoteFailure);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnMessageReceived_Handled_NoMoreEventsRun()
         {
-            var messageReceived = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    context.HandleResponse();
-                    context.Response.StatusCode = StatusCodes.Status202Accepted;
-                    return Task.FromResult(0);
-                };
-            }),
-            AppNotImpl);
+                ExpectMessageReceived = true,
+            };
+            events.OnMessageReceived = context =>
+            {
+                events.InvokedMessageReceived = true;
+                context.HandleResponse();
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppNotImpl);
 
             var response = await PostAsync(server, "signin-oidc", "");
 
             Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
             Assert.Equal("", await response.Content.ReadAsStringAsync());
-            Assert.True(messageReceived);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnTokenValidated_Skip_NoMoreEventsRun()
         {
-            var messageReceived = false;
-            var tokenValidated = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    context.SkipHandler();
-                    return Task.FromResult(0);
-                };
-            }),
-            context =>
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+            };
+            events.OnTokenValidated = context =>
             {
-                return context.Response.WriteAsync(context.Request.Path);
-            });
+                events.InvokedTokenValidated = true;
+                context.SkipHandler();
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppWritePath);
 
             var response = await PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state");
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal("/signin-oidc", await response.Content.ReadAsStringAsync());
-            Assert.True(messageReceived);
-            Assert.True(tokenValidated);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnTokenValidated_Fail_NoMoreEventsRun()
         {
-            var messageReceived = false;
-            var tokenValidated = false;
-            var remoteFailure = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    context.Fail("Authentication was aborted from user code.");
-                    return Task.FromResult(0);
-                };
-                events.OnRemoteFailure = context =>
-                {
-                    remoteFailure = true;
-                    return Task.FromResult(0);
-                };
-            }),
-            context =>
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectRemoteFailure = true,
+            };
+            events.OnTokenValidated = context =>
             {
-                return context.Response.WriteAsync(context.Request.Path);
-            });
+                events.InvokedTokenValidated = true;
+                context.Fail("Authentication was aborted from user code.");
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppWritePath);
 
             var exception = await Assert.ThrowsAsync<Exception>(delegate
             {
@@ -192,156 +147,114 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
             });
 
             Assert.Equal("Authentication was aborted from user code.", exception.InnerException.Message);
-
-            Assert.True(messageReceived);
-            Assert.True(tokenValidated);
-            Assert.True(remoteFailure);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnTokenValidated_HandledWithoutTicket_NoMoreEventsRun()
         {
-            var messageReceived = false;
-            var tokenValidated = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    context.HandleResponse();
-                    context.Principal = null;
-                    context.Response.StatusCode = StatusCodes.Status202Accepted;
-                    return Task.FromResult(0);
-                };
-            }),
-            AppNotImpl);
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+            };
+            events.OnTokenValidated = context =>
+            {
+                events.InvokedTokenValidated = true;
+                context.HandleResponse();
+                context.Principal = null;
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppNotImpl);
 
             var response = await PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state");
 
             Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
             Assert.Equal("", await response.Content.ReadAsStringAsync());
-            Assert.True(messageReceived);
-            Assert.True(tokenValidated);
+            events.ValidateExpectations();
         }
 
-        // TODO: Do any other events depend on the presence of the ticket? It's strange we have to double handle this event.
         [Fact]
         public async Task OnTokenValidated_HandledWithTicket_SkipToTicketReceived()
         {
-            var messageReceived = false;
-            var tokenValidated = false;
-            var ticketReceived = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    context.Success();
-                    return Task.FromResult(0);
-                };
-                events.OnTicketReceived = context =>
-                {
-                    ticketReceived = true;
-                    context.HandleResponse();
-                    context.Response.StatusCode = StatusCodes.Status202Accepted;
-                    return Task.FromResult(0);
-                };
-            }),
-            AppNotImpl);
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectTicketReceived = true,
+            };
+            events.OnTokenValidated = context =>
+            {
+                events.InvokedTokenValidated = true;
+                context.HandleResponse();
+                context.Principal = null;
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
+                return Task.FromResult(0);
+            };
+            events.OnTokenValidated = context =>
+            {
+                events.InvokedTokenValidated = true;
+                context.Success();
+                return Task.FromResult(0);
+            };
+            events.OnTicketReceived = context =>
+            {
+                events.InvokedTicketReceived = true;
+                context.HandleResponse();
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppNotImpl);
 
             var response = await PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state");
 
             Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
             Assert.Equal("", await response.Content.ReadAsStringAsync());
-            Assert.True(messageReceived);
-            Assert.True(tokenValidated);
-            Assert.True(ticketReceived);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnAuthorizationCodeReceived_Skip_NoMoreEventsRun()
         {
-            var messageReceived = false;
-            var tokenValidated = false;
-            var codeReceived = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    return Task.FromResult(0);
-                };
-                events.OnAuthorizationCodeReceived = context =>
-                {
-                    codeReceived = true;
-                    context.SkipHandler();
-                    return Task.FromResult(0);
-                };
-            }),
-            context =>
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+            };
+            events.OnAuthorizationCodeReceived = context =>
             {
-                return context.Response.WriteAsync(context.Request.Path);
-            });
+                events.InvokedAuthorizationCodeReceived = true;
+                context.SkipHandler();
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppWritePath);
 
             var response = await PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state&code=my_code");
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal("/signin-oidc", await response.Content.ReadAsStringAsync());
-            Assert.True(messageReceived);
-            Assert.True(tokenValidated);
-            Assert.True(codeReceived);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnAuthorizationCodeReceived_Fail_NoMoreEventsRun()
         {
-            var messageReceived = false;
-            var tokenValidated = false;
-            var codeReceived = false;
-            var remoteFailure = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    return Task.FromResult(0);
-                };
-                events.OnAuthorizationCodeReceived = context =>
-                {
-                    codeReceived = true;
-                    context.Fail("Authentication was aborted from user code.");
-                    return Task.FromResult(0);
-                };
-                events.OnRemoteFailure = context =>
-                {
-                    remoteFailure = true;
-                    return Task.FromResult(0);
-                };
-            }),
-            context =>
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectRemoteFailure = true,
+            };
+            events.OnAuthorizationCodeReceived = context =>
             {
-                return context.Response.WriteAsync(context.Request.Path);
-            });
+                events.InvokedAuthorizationCodeReceived = true;
+                context.Fail("Authentication was aborted from user code.");
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppWritePath);
 
             var exception = await Assert.ThrowsAsync<Exception>(delegate
             {
@@ -349,183 +262,110 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
             });
 
             Assert.Equal("Authentication was aborted from user code.", exception.InnerException.Message);
-
-            Assert.True(messageReceived);
-            Assert.True(tokenValidated);
-            Assert.True(codeReceived);
-            Assert.True(remoteFailure);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnAuthorizationCodeReceived_HandledWithoutTicket_NoMoreEventsRun()
         {
-            var messageReceived = false;
-            var tokenValidated = false;
-            var codeReceived = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    return Task.FromResult(0);
-                };
-                events.OnAuthorizationCodeReceived = context =>
-                {
-                    codeReceived = true;
-                    context.HandleResponse();
-                    context.Principal = null;
-                    context.Response.StatusCode = StatusCodes.Status202Accepted;
-                    return Task.FromResult(0);
-                };
-            }),
-            AppNotImpl);
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+            };
+            events.OnAuthorizationCodeReceived = context =>
+            {
+                events.InvokedAuthorizationCodeReceived = true;
+                context.HandleResponse();
+                context.Principal = null;
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppNotImpl);
 
             var response = await PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state&code=my_code");
 
             Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
             Assert.Equal("", await response.Content.ReadAsStringAsync());
-            Assert.True(messageReceived);
-            Assert.True(tokenValidated);
-            Assert.True(codeReceived);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnAuthorizationCodeReceived_HandledWithTicket_SkipToTicketReceived()
         {
-            var messageReceived = false;
-            var tokenValidated = false;
-            var codeReceived = false;
-            var ticketReceived = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    return Task.FromResult(0);
-                };
-                events.OnAuthorizationCodeReceived = context =>
-                {
-                    codeReceived = true;
-                    context.Success();
-                    return Task.FromResult(0);
-                };
-                events.OnTicketReceived = context =>
-                {
-                    ticketReceived = true;
-                    context.HandleResponse();
-                    context.Response.StatusCode = StatusCodes.Status202Accepted;
-                    return Task.FromResult(0);
-                };
-            }),
-            AppNotImpl);
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTicketReceived = true,
+            };
+            events.OnAuthorizationCodeReceived = context =>
+            {
+                events.InvokedAuthorizationCodeReceived = true;
+                context.Success();
+                return Task.FromResult(0);
+            };
+            events.OnTicketReceived = context =>
+            {
+                events.InvokedTicketReceived = true;
+                context.HandleResponse();
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppNotImpl);
 
             var response = await PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state&code=my_code");
 
             Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
             Assert.Equal("", await response.Content.ReadAsStringAsync());
-            Assert.True(messageReceived);
-            Assert.True(tokenValidated);
-            Assert.True(codeReceived);
-            Assert.True(ticketReceived);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnTokenResponseReceived_Skip_NoMoreEventsRun()
         {
-            var messageReceived = false;
-            var tokenValidated = false;
-            var codeReceived = false;
-            var tokenResponseReceived = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    return Task.FromResult(0);
-                };
-                events.OnAuthorizationCodeReceived = context =>
-                {
-                    codeReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenResponseReceived = context =>
-                {
-                    tokenResponseReceived = true;
-                    context.SkipHandler();
-                    return Task.FromResult(0);
-                };
-            }),
-            context =>
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTokenResponseReceived = true,
+            };
+            events.OnTokenResponseReceived = context =>
             {
-                return context.Response.WriteAsync(context.Request.Path);
-            });
+                events.InvokedTokenResponseReceived = true;
+                context.SkipHandler();
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppWritePath);
 
             var response = await PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state&code=my_code");
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal("/signin-oidc", await response.Content.ReadAsStringAsync());
-            Assert.True(messageReceived);
-            Assert.True(tokenValidated);
-            Assert.True(codeReceived);
-            Assert.True(tokenResponseReceived);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnTokenResponseReceived_Fail_NoMoreEventsRun()
         {
-            var messageReceived = false;
-            var tokenValidated = false;
-            var codeReceived = false;
-            var tokenResponseReceived = false;
-            var remoteFailure = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    return Task.FromResult(0);
-                };
-                events.OnAuthorizationCodeReceived = context =>
-                {
-                    codeReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenResponseReceived = context =>
-                {
-                    tokenResponseReceived = true;
-                    context.Fail("Authentication was aborted from user code.");
-                    return Task.FromResult(0);
-                };
-                events.OnRemoteFailure = context =>
-                {
-                    remoteFailure = true;
-                    return Task.FromResult(0);
-                };
-            }),
-            context =>
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTokenResponseReceived = true,
+                ExpectRemoteFailure = true,
+            };
+            events.OnTokenResponseReceived = context =>
             {
-                return context.Response.WriteAsync(context.Request.Path);
-            });
+                events.InvokedTokenResponseReceived = true;
+                context.Fail("Authentication was aborted from user code.");
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppWritePath);
 
             var exception = await Assert.ThrowsAsync<Exception>(delegate
             {
@@ -533,198 +373,112 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
             });
 
             Assert.Equal("Authentication was aborted from user code.", exception.InnerException.Message);
-
-            Assert.True(messageReceived);
-            Assert.True(tokenValidated);
-            Assert.True(codeReceived);
-            Assert.True(tokenResponseReceived);
-            Assert.True(remoteFailure);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnTokenResponseReceived_HandledWithoutTicket_NoMoreEventsRun()
         {
-            var messageReceived = false;
-            var tokenValidated = false;
-            var codeReceived = false;
-            var tokenResponseReceived = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    return Task.FromResult(0);
-                };
-                events.OnAuthorizationCodeReceived = context =>
-                {
-                    codeReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenResponseReceived = context =>
-                {
-                    tokenResponseReceived = true;
-                    context.Principal = null;
-                    context.HandleResponse();
-                    context.Response.StatusCode = StatusCodes.Status202Accepted;
-                    return Task.FromResult(0);
-                };
-            }),
-            AppNotImpl);
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTokenResponseReceived = true,
+            };
+            events.OnTokenResponseReceived = context =>
+            {
+                events.InvokedTokenResponseReceived = true;
+                context.Principal = null;
+                context.HandleResponse();
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppNotImpl);
 
             var response = await PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state&code=my_code");
 
             Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
             Assert.Equal("", await response.Content.ReadAsStringAsync());
-            Assert.True(messageReceived);
-            Assert.True(tokenValidated);
-            Assert.True(codeReceived);
-            Assert.True(tokenResponseReceived);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnTokenResponseReceived_HandledWithTicket_SkipToTicketReceived()
         {
-            var messageReceived = false;
-            var tokenValidated = false;
-            var codeReceived = false;
-            var ticketReceived = false;
-            var tokenResponseReceived = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    return Task.FromResult(0);
-                };
-                events.OnAuthorizationCodeReceived = context =>
-                {
-                    codeReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenResponseReceived = context =>
-                {
-                    tokenResponseReceived = true;
-                    context.Success();
-                    return Task.FromResult(0);
-                };
-                events.OnTicketReceived = context =>
-                {
-                    ticketReceived = true;
-                    context.HandleResponse();
-                    context.Response.StatusCode = StatusCodes.Status202Accepted;
-                    return Task.FromResult(0);
-                };
-            }),
-            AppNotImpl);
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTokenResponseReceived = true,
+                ExpectTicketReceived = true,
+            };
+            events.OnTokenResponseReceived = context =>
+            {
+                events.InvokedTokenResponseReceived = true;
+                context.Success();
+                return Task.FromResult(0);
+            };
+            events.OnTicketReceived = context =>
+            {
+                events.InvokedTicketReceived = true;
+                context.HandleResponse();
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppNotImpl);
 
             var response = await PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state&code=my_code");
 
             Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
             Assert.Equal("", await response.Content.ReadAsStringAsync());
-            Assert.True(messageReceived);
-            Assert.True(tokenValidated);
-            Assert.True(codeReceived);
-            Assert.True(tokenResponseReceived);
-            Assert.True(ticketReceived);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnTokenValidatedBackchannel_Skip_NoMoreEventsRun()
         {
-            var messageReceived = false;
-            var codeReceived = false;
-            var tokenResponseReceived = false;
-            var tokenValidated = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnAuthorizationCodeReceived = context =>
-                {
-                    codeReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenResponseReceived = context =>
-                {
-                    tokenResponseReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    context.SkipHandler();
-                    return Task.FromResult(0);
-                };
-            }),
-            context =>
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTokenResponseReceived = true,
+            };
+            events.OnTokenValidated = context =>
             {
-                return context.Response.WriteAsync(context.Request.Path);
-            });
+                events.InvokedTokenValidated = true;
+                context.SkipHandler();
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppWritePath);
 
             var response = await PostAsync(server, "signin-oidc", "state=protected_state&code=my_code");
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal("/signin-oidc", await response.Content.ReadAsStringAsync());
-            Assert.True(messageReceived);
-            Assert.True(codeReceived);
-            Assert.True(tokenResponseReceived);
-            Assert.True(tokenValidated);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnTokenValidatedBackchannel_Fail_NoMoreEventsRun()
         {
-            var messageReceived = false;
-            var codeReceived = false;
-            var tokenResponseReceived = false;
-            var tokenValidated = false;
-            var remoteFailure = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnAuthorizationCodeReceived = context =>
-                {
-                    codeReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenResponseReceived = context =>
-                {
-                    tokenResponseReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    context.Fail("Authentication was aborted from user code.");
-                    return Task.FromResult(0);
-                };
-                events.OnRemoteFailure = context =>
-                {
-                    remoteFailure = true;
-                    return Task.FromResult(0);
-                };
-            }),
-            context =>
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTokenResponseReceived = true,
+                ExpectRemoteFailure = true,
+            };
+            events.OnTokenValidated = context =>
             {
-                return context.Response.WriteAsync(context.Request.Path);
-            });
+                events.InvokedTokenValidated = true;
+                context.Fail("Authentication was aborted from user code.");
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppWritePath);
 
             var exception = await Assert.ThrowsAsync<Exception>(delegate
             {
@@ -732,211 +486,207 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
             });
 
             Assert.Equal("Authentication was aborted from user code.", exception.InnerException.Message);
-
-            Assert.True(messageReceived);
-            Assert.True(codeReceived);
-            Assert.True(tokenResponseReceived);
-            Assert.True(tokenValidated);
-            Assert.True(remoteFailure);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnTokenValidatedBackchannel_HandledWithoutTicket_NoMoreEventsRun()
         {
-            var messageReceived = false;
-            var codeReceived = false;
-            var tokenResponseReceived = false;
-            var tokenValidated = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnAuthorizationCodeReceived = context =>
-                {
-                    codeReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenResponseReceived = context =>
-                {
-                    tokenResponseReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    context.Principal = null;
-                    context.HandleResponse();
-                    context.Response.StatusCode = StatusCodes.Status202Accepted;
-                    return Task.FromResult(0);
-                };
-            }),
-            AppNotImpl);
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTokenResponseReceived = true,
+            };
+            events.OnTokenValidated = context =>
+            {
+                events.InvokedTokenValidated = true;
+                context.Principal = null;
+                context.HandleResponse();
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppNotImpl);
 
             var response = await PostAsync(server, "signin-oidc", "state=protected_state&code=my_code");
 
             Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
             Assert.Equal("", await response.Content.ReadAsStringAsync());
-            Assert.True(messageReceived);
-            Assert.True(codeReceived);
-            Assert.True(tokenResponseReceived);
-            Assert.True(tokenValidated);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnTokenValidatedBackchannel_HandledWithTicket_SkipToTicketReceived()
         {
-            var messageReceived = false;
-            var codeReceived = false;
-            var ticketReceived = false;
-            var tokenResponseReceived = false;
-            var tokenValidated = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnAuthorizationCodeReceived = context =>
-                {
-                    codeReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenResponseReceived = context =>
-                {
-                    tokenResponseReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    context.Success();
-                    return Task.FromResult(0);
-                };
-                events.OnTicketReceived = context =>
-                {
-                    ticketReceived = true;
-                    context.HandleResponse();
-                    context.Response.StatusCode = StatusCodes.Status202Accepted;
-                    return Task.FromResult(0);
-                };
-            }),
-            AppNotImpl);
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTokenResponseReceived = true,
+                ExpectTicketReceived = true,
+            };
+            events.OnTokenValidated = context =>
+            {
+                events.InvokedTokenValidated = true;
+                context.Success();
+                return Task.FromResult(0);
+            };
+            events.OnTicketReceived = context =>
+            {
+                events.InvokedTicketReceived = true;
+                context.HandleResponse();
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppNotImpl);
 
             var response = await PostAsync(server, "signin-oidc", "state=protected_state&code=my_code");
 
             Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
             Assert.Equal("", await response.Content.ReadAsStringAsync());
-            Assert.True(messageReceived);
-            Assert.True(codeReceived);
-            Assert.True(tokenResponseReceived);
-            Assert.True(tokenValidated);
-            Assert.True(ticketReceived);
+            events.ValidateExpectations();
+        }
+
+        [Fact]
+        public async Task OnSecondaryTokenValidated_Fail_NoMoreEventsRun()
+        {
+            var events = new ExpectedOidcEvents()
+            {
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTokenResponseReceived = true,
+                ExpectSecondaryTokenValidated = true,
+                ExpectRemoteFailure = true,
+            };
+            events.OnSecondaryTokenValidated = context =>
+            {
+                events.InvokedSecondaryTokenValidated = true;
+                context.Fail("Authentication was aborted from user code.");
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppWritePath);
+
+            var exception = await Assert.ThrowsAsync<Exception>(delegate
+            {
+                return PostAsync(server, "signin-oidc", "state=protected_state&id_token=my_id_token&code=my_code");
+            });
+
+            Assert.Equal("Authentication was aborted from user code.", exception.InnerException.Message);
+            events.ValidateExpectations();
+        }
+
+        [Fact]
+        public async Task OnSecondaryTokenValidated_HandledWithoutTicket_NoMoreEventsRun()
+        {
+            var events = new ExpectedOidcEvents()
+            {
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTokenResponseReceived = true,
+                ExpectSecondaryTokenValidated = true,
+            };
+            events.OnSecondaryTokenValidated = context =>
+            {
+                events.InvokedSecondaryTokenValidated = true;
+                context.Principal = null;
+                context.HandleResponse();
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppNotImpl);
+
+            var response = await PostAsync(server, "signin-oidc", "state=protected_state&id_token=my_id_token&code=my_code");
+
+            Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+            Assert.Equal("", await response.Content.ReadAsStringAsync());
+            events.ValidateExpectations();
+        }
+
+        [Fact]
+        public async Task OnSecondaryTokenValidated_HandledWithTicket_SkipToTicketReceived()
+        {
+            var events = new ExpectedOidcEvents()
+            {
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTokenResponseReceived = true,
+                ExpectSecondaryTokenValidated = true,
+                ExpectTicketReceived = true,
+            };
+            events.OnSecondaryTokenValidated = context =>
+            {
+                events.InvokedSecondaryTokenValidated = true;
+                context.Success();
+                return Task.FromResult(0);
+            };
+            events.OnTicketReceived = context =>
+            {
+                events.InvokedTicketReceived = true;
+                context.HandleResponse();
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppNotImpl);
+
+            var response = await PostAsync(server, "signin-oidc", "state=protected_state&id_token=my_id_token&code=my_code");
+
+            Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+            Assert.Equal("", await response.Content.ReadAsStringAsync());
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnUserInformationReceived_Skip_NoMoreEventsRun()
         {
-            var messageReceived = false;
-            var tokenValidated = false;
-            var codeReceived = false;
-            var tokenResponseReceived = false;
-            var userInfoReceived = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    return Task.FromResult(0);
-                };
-                events.OnAuthorizationCodeReceived = context =>
-                {
-                    codeReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenResponseReceived = context =>
-                {
-                    tokenResponseReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnUserInformationReceived = context =>
-                {
-                    userInfoReceived = true;
-                    context.SkipHandler();
-                    return Task.FromResult(0);
-                };
-            }),
-            context =>
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTokenResponseReceived = true,
+                ExpectSecondaryTokenValidated = true,
+                ExpectUserInfoReceived = true,
+            };
+            events.OnUserInformationReceived = context =>
             {
-                return context.Response.WriteAsync(context.Request.Path);
-            });
+                events.InvokedUserInfoReceived = true;
+                context.SkipHandler();
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppWritePath);
 
             var response = await PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state&code=my_code");
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal("/signin-oidc", await response.Content.ReadAsStringAsync());
-            Assert.True(messageReceived);
-            Assert.True(tokenValidated);
-            Assert.True(codeReceived);
-            Assert.True(tokenResponseReceived);
-            Assert.True(userInfoReceived);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnUserInformationReceived_Fail_NoMoreEventsRun()
         {
-            var messageReceived = false;
-            var tokenValidated = false;
-            var codeReceived = false;
-            var tokenResponseReceived = false;
-            var userInfoReceived = false;
-            var remoteFailure = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    return Task.FromResult(0);
-                };
-                events.OnAuthorizationCodeReceived = context =>
-                {
-                    codeReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenResponseReceived = context =>
-                {
-                    tokenResponseReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnUserInformationReceived = context =>
-                {
-                    userInfoReceived = true;
-                    context.Fail("Authentication was aborted from user code.");
-                    return Task.FromResult(0);
-                };
-                events.OnRemoteFailure = context =>
-                {
-                    remoteFailure = true;
-                    return Task.FromResult(0);
-                };
-            }),
-            context =>
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTokenResponseReceived = true,
+                ExpectSecondaryTokenValidated = true,
+                ExpectUserInfoReceived = true,
+                ExpectRemoteFailure = true,
+            };
+            events.OnUserInformationReceived = context =>
             {
-                return context.Response.WriteAsync(context.Request.Path);
-            });
+                events.InvokedUserInfoReceived = true;
+                context.Fail("Authentication was aborted from user code.");
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppWritePath);
 
             var exception = await Assert.ThrowsAsync<Exception>(delegate
             {
@@ -944,242 +694,134 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
             });
 
             Assert.Equal("Authentication was aborted from user code.", exception.InnerException.Message);
-
-            Assert.True(messageReceived);
-            Assert.True(tokenValidated);
-            Assert.True(codeReceived);
-            Assert.True(tokenResponseReceived);
-            Assert.True(userInfoReceived);
-            Assert.True(remoteFailure);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnUserInformationReceived_HandledWithoutTicket_NoMoreEventsRun()
         {
-            var messageReceived = false;
-            var tokenValidated = false;
-            var codeReceived = false;
-            var tokenResponseReceived = false;
-            var userInfoReceived = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    return Task.FromResult(0);
-                };
-                events.OnAuthorizationCodeReceived = context =>
-                {
-                    codeReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenResponseReceived = context =>
-                {
-                    tokenResponseReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnUserInformationReceived = context =>
-                {
-                    userInfoReceived = true;
-                    context.Principal = null;
-                    context.HandleResponse();
-                    context.Response.StatusCode = StatusCodes.Status202Accepted;
-                    return Task.FromResult(0);
-                };
-            }),
-            AppNotImpl);
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTokenResponseReceived = true,
+                ExpectSecondaryTokenValidated = true,
+                ExpectUserInfoReceived = true,
+            };
+            events.OnUserInformationReceived = context =>
+            {
+                events.InvokedUserInfoReceived = true;
+                context.Principal = null;
+                context.HandleResponse();
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppNotImpl);
 
             var response = await PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state&code=my_code");
 
             Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
             Assert.Equal("", await response.Content.ReadAsStringAsync());
-            Assert.True(messageReceived);
-            Assert.True(tokenValidated);
-            Assert.True(codeReceived);
-            Assert.True(tokenResponseReceived);
-            Assert.True(userInfoReceived);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnUserInformationReceived_HandledWithTicket_SkipToTicketReceived()
         {
-            var messageReceived = false;
-            var tokenValidated = false;
-            var codeReceived = false;
-            var ticketReceived = false;
-            var tokenResponseReceived = false;
-            var userInfoReceived = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    return Task.FromResult(0);
-                };
-                events.OnAuthorizationCodeReceived = context =>
-                {
-                    codeReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenResponseReceived = context =>
-                {
-                    tokenResponseReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnUserInformationReceived = context =>
-                {
-                    userInfoReceived = true;
-                    // context.Ticket = null;
-                    context.Success();
-                    return Task.FromResult(0);
-                };
-                events.OnTicketReceived = context =>
-                {
-                    ticketReceived = true;
-                    context.HandleResponse();
-                    context.Response.StatusCode = StatusCodes.Status202Accepted;
-                    return Task.FromResult(0);
-                };
-            }),
-            AppNotImpl);
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTokenResponseReceived = true,
+                ExpectSecondaryTokenValidated = true,
+                ExpectUserInfoReceived = true,
+                ExpectTicketReceived = true,
+            };
+            events.OnUserInformationReceived = context =>
+            {
+                events.InvokedUserInfoReceived = true;
+                context.Success();
+                return Task.FromResult(0);
+            };
+            events.OnTicketReceived = context =>
+            {
+                events.InvokedTicketReceived = true;
+                context.HandleResponse();
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppNotImpl);
 
             var response = await PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state&code=my_code");
 
             Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
             Assert.Equal("", await response.Content.ReadAsStringAsync());
-            Assert.True(messageReceived);
-            Assert.True(tokenValidated);
-            Assert.True(codeReceived);
-            Assert.True(tokenResponseReceived);
-            Assert.True(userInfoReceived);
-            Assert.True(ticketReceived);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnAuthenticationFailed_Skip_NoMoreEventsRun()
         {
-            var messageReceived = false;
-            var tokenValidated = false;
-            var codeReceived = false;
-            var tokenResponseReceived = false;
-            var userInfoReceived = false;
-            var authFailed = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    return Task.FromResult(0);
-                };
-                events.OnAuthorizationCodeReceived = context =>
-                {
-                    codeReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenResponseReceived = context =>
-                {
-                    tokenResponseReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnUserInformationReceived = context =>
-                {
-                    userInfoReceived = true;
-                    throw new NotImplementedException("TestException");
-                };
-                events.OnAuthenticationFailed = context =>
-                {
-                    authFailed = true;
-                    Assert.Equal("TestException", context.Exception.Message);
-                    context.SkipHandler();
-                    return Task.FromResult(0);
-                };
-            }),
-            context =>
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTokenResponseReceived = true,
+                ExpectSecondaryTokenValidated = true,
+                ExpectUserInfoReceived = true,
+                ExpectAuthenticationFailed = true,
+            };
+            events.OnUserInformationReceived = context =>
             {
-                return context.Response.WriteAsync(context.Request.Path);
-            });
+                events.InvokedUserInfoReceived = true;
+                throw new NotImplementedException("TestException");
+            };
+            events.OnAuthenticationFailed = context =>
+            {
+                events.InvokeAuthenticationFailed = true;
+                Assert.Equal("TestException", context.Exception.Message);
+                context.SkipHandler();
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppWritePath);
 
             var response = await PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state&code=my_code");
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal("/signin-oidc", await response.Content.ReadAsStringAsync());
-            Assert.True(messageReceived);
-            Assert.True(tokenValidated);
-            Assert.True(codeReceived);
-            Assert.True(tokenResponseReceived);
-            Assert.True(userInfoReceived);
-            Assert.True(authFailed);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnAuthenticationFailed_Fail_NoMoreEventsRun()
         {
-            var messageReceived = false;
-            var tokenValidated = false;
-            var codeReceived = false;
-            var tokenResponseReceived = false;
-            var userInfoReceived = false;
-            var authFailed = false;
-            var remoteFailure = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    return Task.FromResult(0);
-                };
-                events.OnAuthorizationCodeReceived = context =>
-                {
-                    codeReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenResponseReceived = context =>
-                {
-                    tokenResponseReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnUserInformationReceived = context =>
-                {
-                    userInfoReceived = true;
-                    throw new NotImplementedException("TestException");
-                };
-                events.OnAuthenticationFailed = context =>
-                {
-                    authFailed = true;
-                    Assert.Equal("TestException", context.Exception.Message);
-                    context.Fail("Authentication was aborted from user code.");
-                    return Task.FromResult(0);
-                };
-                events.OnRemoteFailure = context =>
-                {
-                    remoteFailure = true;
-                    return Task.FromResult(0);
-                };
-            }),
-            context =>
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTokenResponseReceived = true,
+                ExpectSecondaryTokenValidated = true,
+                ExpectUserInfoReceived = true,
+                ExpectAuthenticationFailed = true,
+                ExpectRemoteFailure = true,
+            };
+            events.OnUserInformationReceived = context =>
             {
-                return context.Response.WriteAsync(context.Request.Path);
-            });
+                events.InvokedUserInfoReceived = true;
+                throw new NotImplementedException("TestException");
+            };
+            events.OnAuthenticationFailed = context =>
+            {
+                events.InvokeAuthenticationFailed = true;
+                Assert.Equal("TestException", context.Exception.Message);
+                context.Fail("Authentication was aborted from user code.");
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppWritePath);
 
             var exception = await Assert.ThrowsAsync<Exception>(delegate
             {
@@ -1187,420 +829,240 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
             });
 
             Assert.Equal("Authentication was aborted from user code.", exception.InnerException.Message);
-
-            Assert.True(messageReceived);
-            Assert.True(tokenValidated);
-            Assert.True(codeReceived);
-            Assert.True(tokenResponseReceived);
-            Assert.True(userInfoReceived);
-            Assert.True(authFailed);
-            Assert.True(remoteFailure);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnAuthenticationFailed_HandledWithoutTicket_NoMoreEventsRun()
         {
-            var messageReceived = false;
-            var tokenValidated = false;
-            var codeReceived = false;
-            var tokenResponseReceived = false;
-            var userInfoReceived = false;
-            var authFailed = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    return Task.FromResult(0);
-                };
-                events.OnAuthorizationCodeReceived = context =>
-                {
-                    codeReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenResponseReceived = context =>
-                {
-                    tokenResponseReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnUserInformationReceived = context =>
-                {
-                    userInfoReceived = true;
-                    throw new NotImplementedException("TestException");
-                };
-                events.OnAuthenticationFailed = context =>
-                {
-                    authFailed = true;
-                    Assert.Equal("TestException", context.Exception.Message);
-                    Assert.Null(context.Principal);
-                    context.HandleResponse();
-                    context.Response.StatusCode = StatusCodes.Status202Accepted;
-                    return Task.FromResult(0);
-                };
-            }),
-            AppNotImpl);
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTokenResponseReceived = true,
+                ExpectSecondaryTokenValidated = true,
+                ExpectUserInfoReceived = true,
+                ExpectAuthenticationFailed = true,
+            };
+            events.OnUserInformationReceived = context =>
+            {
+                events.InvokedUserInfoReceived = true;
+                throw new NotImplementedException("TestException");
+            };
+            events.OnAuthenticationFailed = context =>
+            {
+                events.InvokeAuthenticationFailed = true;
+                Assert.Equal("TestException", context.Exception.Message);
+                Assert.Null(context.Principal);
+                context.HandleResponse();
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppNotImpl);
 
             var response = await PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state&code=my_code");
 
             Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
             Assert.Equal("", await response.Content.ReadAsStringAsync());
-            Assert.True(messageReceived);
-            Assert.True(tokenValidated);
-            Assert.True(codeReceived);
-            Assert.True(tokenResponseReceived);
-            Assert.True(userInfoReceived);
-            Assert.True(authFailed);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnAuthenticationFailed_HandledWithTicket_SkipToTicketReceived()
         {
-            var messageReceived = false;
-            var tokenValidated = false;
-            var codeReceived = false;
-            var ticketReceived = false;
-            var tokenResponseReceived = false;
-            var userInfoReceived = false;
-            var authFailed = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    return Task.FromResult(0);
-                };
-                events.OnAuthorizationCodeReceived = context =>
-                {
-                    codeReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenResponseReceived = context =>
-                {
-                    tokenResponseReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnUserInformationReceived = context =>
-                {
-                    userInfoReceived = true;
-                    throw new NotImplementedException("TestException");
-                };
-                events.OnAuthenticationFailed = context =>
-                {
-                    authFailed = true;
-                    Assert.Equal("TestException", context.Exception.Message);
-                    Assert.Null(context.Principal);
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTokenResponseReceived = true,
+                ExpectSecondaryTokenValidated = true,
+                ExpectUserInfoReceived = true,
+                ExpectAuthenticationFailed = true,
+                ExpectTicketReceived = true,
+            };
+            events.OnUserInformationReceived = context =>
+            {
+                events.InvokedUserInfoReceived = true;
+                throw new NotImplementedException("TestException");
+            };
+            events.OnAuthenticationFailed = context =>
+            {
+                events.InvokeAuthenticationFailed = true;
+                Assert.Equal("TestException", context.Exception.Message);
+                Assert.Null(context.Principal);
 
-                    var claims = new[]
-                    {
-                        new Claim(ClaimTypes.NameIdentifier, "Bob le Magnifique"),
-                        new Claim(ClaimTypes.Email, "bob@contoso.com"),
-                        new Claim(ClaimsIdentity.DefaultNameClaimType, "bob")
-                    };
-
-                    context.Principal = new ClaimsPrincipal(new ClaimsIdentity(claims, context.Scheme.Name));
-                    context.Success();
-                    return Task.FromResult(0);
-                };
-                events.OnTicketReceived = context =>
+                var claims = new[]
                 {
-                    ticketReceived = true;
-                    context.HandleResponse();
-                    context.Response.StatusCode = StatusCodes.Status202Accepted;
-                    return Task.FromResult(0);
+                    new Claim(ClaimTypes.NameIdentifier, "Bob le Magnifique"),
+                    new Claim(ClaimTypes.Email, "bob@contoso.com"),
+                    new Claim(ClaimsIdentity.DefaultNameClaimType, "bob")
                 };
-            }),
-            AppNotImpl);
+
+                context.Principal = new ClaimsPrincipal(new ClaimsIdentity(claims, context.Scheme.Name));
+                context.Success();
+                return Task.FromResult(0);
+            };
+            events.OnTicketReceived = context =>
+            {
+                events.InvokedTicketReceived = true;
+                context.HandleResponse();
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppNotImpl);
 
             var response = await PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state&code=my_code");
 
             Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
             Assert.Equal("", await response.Content.ReadAsStringAsync());
-            Assert.True(messageReceived);
-            Assert.True(tokenValidated);
-            Assert.True(codeReceived);
-            Assert.True(tokenResponseReceived);
-            Assert.True(userInfoReceived);
-            Assert.True(authFailed);
-            Assert.True(ticketReceived);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnRemoteFailure_Skip_NoMoreEventsRun()
         {
-            var messageReceived = false;
-            var tokenValidated = false;
-            var codeReceived = false;
-            var tokenResponseReceived = false;
-            var userInfoReceived = false;
-            var authFailed = false;
-            var remoteFailure = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    return Task.FromResult(0);
-                };
-                events.OnAuthorizationCodeReceived = context =>
-                {
-                    codeReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenResponseReceived = context =>
-                {
-                    tokenResponseReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnUserInformationReceived = context =>
-                {
-                    userInfoReceived = true;
-                    throw new NotImplementedException("TestException");
-                };
-                events.OnAuthenticationFailed = context =>
-                {
-                    authFailed = true;
-                    Assert.Equal("TestException", context.Exception.Message);
-                    return Task.FromResult(0);
-                };
-                events.OnRemoteFailure = context =>
-                {
-                    remoteFailure = true;
-                    Assert.Equal("TestException", context.Failure.Message);
-                    context.SkipHandler();
-                    return Task.FromResult(0);
-                };
-            }),
-            context =>
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTokenResponseReceived = true,
+                ExpectSecondaryTokenValidated = true,
+                ExpectUserInfoReceived = true,
+                ExpectAuthenticationFailed = true,
+                ExpectRemoteFailure = true,
+            };
+            events.OnUserInformationReceived = context =>
             {
-                return context.Response.WriteAsync(context.Request.Path);
-            });
+                events.InvokedUserInfoReceived = true;
+                throw new NotImplementedException("TestException");
+            };
+            events.OnAuthenticationFailed = context =>
+            {
+                events.InvokeAuthenticationFailed = true;
+                Assert.Equal("TestException", context.Exception.Message);
+                return Task.FromResult(0);
+            };
+            events.OnRemoteFailure = context =>
+            {
+                events.InvokedRemoteFailure = true;
+                Assert.Equal("TestException", context.Failure.Message);
+                context.SkipHandler();
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppWritePath);
 
             var response = await PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state&code=my_code");
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal("/signin-oidc", await response.Content.ReadAsStringAsync());
-            Assert.True(messageReceived);
-            Assert.True(tokenValidated);
-            Assert.True(codeReceived);
-            Assert.True(tokenResponseReceived);
-            Assert.True(userInfoReceived);
-            Assert.True(authFailed);
-            Assert.True(remoteFailure);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnRemoteFailure_Handled_NoMoreEventsRun()
         {
-            var messageReceived = false;
-            var tokenValidated = false;
-            var codeReceived = false;
-            var tokenResponseReceived = false;
-            var userInfoReceived = false;
-            var authFailed = false;
-            var remoteFailure = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    return Task.FromResult(0);
-                };
-                events.OnAuthorizationCodeReceived = context =>
-                {
-                    codeReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenResponseReceived = context =>
-                {
-                    tokenResponseReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnUserInformationReceived = context =>
-                {
-                    userInfoReceived = true;
-                    throw new NotImplementedException("TestException");
-                };
-                events.OnAuthenticationFailed = context =>
-                {
-                    authFailed = true;
-                    Assert.Equal("TestException", context.Exception.Message);
-                    return Task.FromResult(0);
-                };
-                events.OnRemoteFailure = context =>
-                {
-                    remoteFailure = true;
-                    Assert.Equal("TestException", context.Failure.Message);
-                    Assert.Equal("testvalue", context.Properties.Items["testkey"]);
-                    context.HandleResponse();
-                    context.Response.StatusCode = StatusCodes.Status202Accepted;
-                    return Task.FromResult(0);
-                };
-            }),
-            AppNotImpl);
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTokenResponseReceived = true,
+                ExpectSecondaryTokenValidated = true,
+                ExpectUserInfoReceived = true,
+                ExpectAuthenticationFailed = true,
+                ExpectRemoteFailure = true,
+            };
+            events.OnUserInformationReceived = context =>
+            {
+                events.InvokedUserInfoReceived = true;
+                throw new NotImplementedException("TestException");
+            };
+            events.OnRemoteFailure = context =>
+            {
+                events.InvokedRemoteFailure = true;
+                Assert.Equal("TestException", context.Failure.Message);
+                Assert.Equal("testvalue", context.Properties.Items["testkey"]);
+                context.HandleResponse();
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppNotImpl);
 
             var response = await PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state&code=my_code");
 
             Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
             Assert.Equal("", await response.Content.ReadAsStringAsync());
-            Assert.True(messageReceived);
-            Assert.True(tokenValidated);
-            Assert.True(codeReceived);
-            Assert.True(tokenResponseReceived);
-            Assert.True(userInfoReceived);
-            Assert.True(authFailed);
-            Assert.True(remoteFailure);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnTicketReceived_Skip_NoMoreEventsRun()
         {
-            var messageReceived = false;
-            var tokenValidated = false;
-            var codeReceived = false;
-            var tokenResponseReceived = false;
-            var userInfoReceived = false;
-            var ticektReceived = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    return Task.FromResult(0);
-                };
-                events.OnAuthorizationCodeReceived = context =>
-                {
-                    codeReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenResponseReceived = context =>
-                {
-                    tokenResponseReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnUserInformationReceived = context =>
-                {
-                    userInfoReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTicketReceived = context =>
-                {
-                    ticektReceived = true;
-                    context.SkipHandler();
-                    return Task.FromResult(0);
-                };
-            }),
-            context =>
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTokenResponseReceived = true,
+                ExpectSecondaryTokenValidated = true,
+                ExpectUserInfoReceived = true,
+                ExpectTicketReceived = true,
+            };
+            events.OnTicketReceived = context =>
             {
-                return context.Response.WriteAsync(context.Request.Path);
-            });
+                events.InvokedTicketReceived = true;
+                context.SkipHandler();
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppWritePath);
 
             var response = await PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state&code=my_code");
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal("/signin-oidc", await response.Content.ReadAsStringAsync());
-            Assert.True(messageReceived);
-            Assert.True(tokenValidated);
-            Assert.True(codeReceived);
-            Assert.True(tokenResponseReceived);
-            Assert.True(userInfoReceived);
-            Assert.True(ticektReceived);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnTicketReceived_Handled_NoMoreEventsRun()
         {
-            var messageReceived = false;
-            var tokenValidated = false;
-            var codeReceived = false;
-            var tokenResponseReceived = false;
-            var userInfoReceived = false;
-            var ticektReceived = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnMessageReceived = context =>
-                {
-                    messageReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenValidated = context =>
-                {
-                    tokenValidated = true;
-                    return Task.FromResult(0);
-                };
-                events.OnAuthorizationCodeReceived = context =>
-                {
-                    codeReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTokenResponseReceived = context =>
-                {
-                    tokenResponseReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnUserInformationReceived = context =>
-                {
-                    userInfoReceived = true;
-                    return Task.FromResult(0);
-                };
-                events.OnTicketReceived = context =>
-                {
-                    ticektReceived = true;
-                    context.HandleResponse();
-                    context.Response.StatusCode = StatusCodes.Status202Accepted;
-                    return Task.FromResult(0);
-                };
-            }),
-            AppNotImpl);
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTokenResponseReceived = true,
+                ExpectSecondaryTokenValidated = true,
+                ExpectUserInfoReceived = true,
+                ExpectTicketReceived = true,
+            };
+            events.OnTicketReceived = context =>
+            {
+                events.InvokedTicketReceived = true;
+                context.HandleResponse();
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
+                return Task.FromResult(0);
+            };
+            var server = CreateServer(events, AppNotImpl);
 
             var response = await PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state&code=my_code");
 
             Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
             Assert.Equal("", await response.Content.ReadAsStringAsync());
-            Assert.True(messageReceived);
-            Assert.True(tokenValidated);
-            Assert.True(codeReceived);
-            Assert.True(tokenResponseReceived);
-            Assert.True(userInfoReceived);
-            Assert.True(ticektReceived);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnRedirectToIdentityProviderForSignOut_Invoked()
         {
-            var forSignOut = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnRedirectToIdentityProviderForSignOut = context =>
-                {
-                    forSignOut = true;
-                    return Task.CompletedTask;
-                };
-            }),
+                ExpectRedirectForSignOut = true,
+            };
+            var server = CreateServer(events,
             context =>
             {
                 return context.SignOutAsync(OpenIdConnectDefaults.AuthenticationScheme);
@@ -1611,23 +1073,24 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
 
             Assert.Equal(HttpStatusCode.Found, response.StatusCode);
             Assert.Equal("http://testhost/end", response.Headers.Location.GetLeftPart(UriPartial.Path));
-            Assert.True(forSignOut);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnRedirectToIdentityProviderForSignOut_Handled_RedirectNotInvoked()
         {
-            var forSignOut = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnRedirectToIdentityProviderForSignOut = context =>
-                {
-                    forSignOut = true;
-                    context.Response.StatusCode = StatusCodes.Status202Accepted;
-                    context.HandleResponse();
-                    return Task.CompletedTask;
-                };
-            }),
+                ExpectRedirectForSignOut = true,
+            };
+            events.OnRedirectToIdentityProviderForSignOut = context =>
+            {
+                events.InvokedRedirectForSignOut = true;
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
+                context.HandleResponse();
+                return Task.CompletedTask;
+            };
+            var server = CreateServer(events,
             context =>
             {
                 return context.SignOutAsync(OpenIdConnectDefaults.AuthenticationScheme);
@@ -1638,28 +1101,23 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
 
             Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
             Assert.Null(response.Headers.Location);
-            Assert.True(forSignOut);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnRemoteSignOut_Invoked()
         {
-            var forSignOut = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnRemoteSignOut = context =>
-                {
-                    forSignOut = true;
-                    return Task.CompletedTask;
-                };
-            }),
-            AppNotImpl);
+                ExpectRemoteSignOut = true,
+            };
+            var server = CreateServer(events, AppNotImpl);
 
             var client = server.CreateClient();
             var response = await client.GetAsync("/signout-oidc");
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.True(forSignOut);
+            events.ValidateExpectations();
             Assert.True(response.Headers.TryGetValues(HeaderNames.SetCookie, out var values));
             Assert.True(SetCookieHeaderValue.TryParseStrictList(values.ToList(), out var parsedValues));
             Assert.Equal(1, parsedValues.Count);
@@ -1669,41 +1127,41 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
         [Fact]
         public async Task OnRemoteSignOut_Handled_NoSignout()
         {
-            var forSignOut = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnRemoteSignOut = context =>
-                {
-                    forSignOut = true;
-                    context.Response.StatusCode = StatusCodes.Status202Accepted;
-                    context.HandleResponse();
-                    return Task.CompletedTask;
-                };
-            }),
-            AppNotImpl);
+                ExpectRemoteSignOut = true,
+            };
+            events.OnRemoteSignOut = context =>
+            {
+                events.InvokedRemoteSignOut = true;
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
+                context.HandleResponse();
+                return Task.CompletedTask;
+            };
+            var server = CreateServer(events, AppNotImpl);
 
             var client = server.CreateClient();
             var response = await client.GetAsync("/signout-oidc");
 
             Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
-            Assert.True(forSignOut);
+            events.ValidateExpectations();
             Assert.False(response.Headers.TryGetValues(HeaderNames.SetCookie, out var values));
         }
 
         [Fact]
         public async Task OnRemoteSignOut_Skip_NoSignout()
         {
-            var forSignOut = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnRemoteSignOut = context =>
-                {
-                    forSignOut = true;
-                    context.SkipHandler();
-                    return Task.CompletedTask;
-                };
-            }),
-            context =>
+                ExpectRemoteSignOut = true,
+            };
+            events.OnRemoteSignOut = context =>
+            {
+                events.InvokedRemoteSignOut = true;
+                context.SkipHandler();
+                return Task.CompletedTask;
+            };
+            var server = CreateServer(events, context =>
             {
                 context.Response.StatusCode = StatusCodes.Status202Accepted;
                 return Task.CompletedTask;
@@ -1713,69 +1171,65 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
             var response = await client.GetAsync("/signout-oidc");
 
             Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
-            Assert.True(forSignOut);
+            events.ValidateExpectations();
             Assert.False(response.Headers.TryGetValues(HeaderNames.SetCookie, out var values));
         }
 
         [Fact]
         public async Task OnRedirectToSignedOutRedirectUri_Invoked()
         {
-            var forSignOut = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnSignedOutCallbackRedirect = context =>
-                {
-                    forSignOut = true;
-                    return Task.CompletedTask;
-                };
-            }),
-            AppNotImpl);
+                ExpectRedirectToSignedOut = true,
+            };
+            var server = CreateServer(events, AppNotImpl);
 
             var client = server.CreateClient();
             var response = await client.GetAsync("/signout-callback-oidc?state=protected_state");
 
             Assert.Equal(HttpStatusCode.Found, response.StatusCode);
             Assert.Equal("http://testhost/redirect", response.Headers.Location.AbsoluteUri);
-            Assert.True(forSignOut);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnRedirectToSignedOutRedirectUri_Handled_NoRedirect()
         {
-            var forSignOut = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnSignedOutCallbackRedirect = context =>
-                {
-                    forSignOut = true;
-                    context.Response.StatusCode = StatusCodes.Status202Accepted;
-                    context.HandleResponse();
-                    return Task.CompletedTask;
-                };
-            }),
-            AppNotImpl);
+                ExpectRedirectToSignedOut = true,
+            };
+            events.OnSignedOutCallbackRedirect = context =>
+            {
+                events.InvokedRedirectToSignedOut = true;
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
+                context.HandleResponse();
+                return Task.CompletedTask;
+            };
+            var server = CreateServer(events, AppNotImpl);
 
             var client = server.CreateClient();
             var response = await client.GetAsync("/signout-callback-oidc?state=protected_state");
 
             Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
             Assert.Null(response.Headers.Location);
-            Assert.True(forSignOut);
+            events.ValidateExpectations();
         }
 
         [Fact]
         public async Task OnRedirectToSignedOutRedirectUri_Skipped_NoRedirect()
         {
-            var forSignOut = false;
-            var server = CreateServer(CreateNotImpEvents(events =>
+            var events = new ExpectedOidcEvents()
             {
-                events.OnSignedOutCallbackRedirect = context =>
-                {
-                    forSignOut = true;
-                    context.SkipHandler();
-                    return Task.CompletedTask;
-                };
-            }),
+                ExpectRedirectToSignedOut = true,
+            };
+            events.OnSignedOutCallbackRedirect = context =>
+            {
+                events.InvokedRedirectToSignedOut = true;
+                context.SkipHandler();
+                return Task.CompletedTask;
+            };
+            var server = CreateServer(events,
             context =>
             {
                 context.Response.StatusCode = StatusCodes.Status202Accepted;
@@ -1787,29 +1241,126 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
 
             Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
             Assert.Null(response.Headers.Location);
-            Assert.True(forSignOut);
+            events.ValidateExpectations();
         }
 
-        private OpenIdConnectEvents CreateNotImpEvents(Action<OpenIdConnectEvents> configureEvents)
+        private class ExpectedOidcEvents : OpenIdConnectEvents
         {
-            var events = new OpenIdConnectEvents()
-            {
-                OnMessageReceived = MessageNotImpl,
-                OnTokenValidated = TokenNotImpl,
-                OnAuthorizationCodeReceived = CodeNotImpl,
-                OnTokenResponseReceived = TokenResponseNotImpl,
-                OnUserInformationReceived = UserNotImpl,
-                OnAuthenticationFailed = FailedNotImpl,
-                OnTicketReceived = TicketNotImpl,
-                OnRemoteFailure = FailureNotImpl,
+            public bool ExpectMessageReceived { get; set; }
+            public bool InvokedMessageReceived { get; set; }
 
-                OnRedirectToIdentityProvider = RedirectNotImpl,
-                OnRedirectToIdentityProviderForSignOut = RedirectNotImpl,
-                OnRemoteSignOut = RemoteSignOutNotImpl,
-                OnSignedOutCallbackRedirect = SignedOutCallbackNotImpl,
-            };
-            configureEvents(events);
-            return events;
+            public bool ExpectTokenValidated { get; set; }
+            public bool InvokedTokenValidated { get; set; }
+
+            public bool ExpectRemoteFailure { get; set; }
+            public bool InvokedRemoteFailure { get; set; }
+
+            public bool ExpectTicketReceived { get; set; }
+            public bool InvokedTicketReceived { get; set; }
+
+            public bool ExpectAuthorizationCodeReceived { get; set; }
+            public bool InvokedAuthorizationCodeReceived { get; set; }
+
+            public bool ExpectTokenResponseReceived { get; set; }
+            public bool InvokedTokenResponseReceived { get; set; }
+
+            public bool ExpectSecondaryTokenValidated { get; set; }
+            public bool InvokedSecondaryTokenValidated { get; set; }
+
+            public bool ExpectUserInfoReceived { get; set; }
+            public bool InvokedUserInfoReceived { get; set; }
+
+            public bool ExpectAuthenticationFailed { get; set; }
+            public bool InvokeAuthenticationFailed { get; set; }
+
+            public bool ExpectRedirectForSignOut { get; set; }
+            public bool InvokedRedirectForSignOut { get; set; }
+
+            public bool ExpectRemoteSignOut { get; set; }
+            public bool InvokedRemoteSignOut { get; set; }
+
+            public bool ExpectRedirectToSignedOut { get; set; }
+            public bool InvokedRedirectToSignedOut { get; set; }
+
+            public ExpectedOidcEvents()
+            {
+                OnMessageReceived = c =>
+                {
+                    InvokedMessageReceived = true;
+                    return Task.CompletedTask;
+                };
+                OnTokenValidated = c =>
+                {
+                    InvokedTokenValidated = true;
+                    return Task.CompletedTask;
+                };
+                OnAuthorizationCodeReceived = c =>
+                {
+                    InvokedAuthorizationCodeReceived = true;
+                    return Task.CompletedTask;
+                };
+                OnTokenResponseReceived = c =>
+                {
+                    InvokedTokenResponseReceived = true;
+                    return Task.CompletedTask;
+                };
+                OnSecondaryTokenValidated = c =>
+                {
+                    InvokedSecondaryTokenValidated = true;
+                    return Task.CompletedTask;
+                };
+                OnUserInformationReceived = c =>
+                {
+                    InvokedUserInfoReceived = true;
+                    return Task.CompletedTask;
+                };
+                OnAuthenticationFailed = c =>
+                {
+                    InvokeAuthenticationFailed = true;
+                    return Task.CompletedTask;
+                };
+                OnTicketReceived = c =>
+                {
+                    InvokedTicketReceived = true;
+                    return Task.CompletedTask;
+                };
+                OnRemoteFailure = c =>
+                {
+                    InvokedRemoteFailure = true;
+                    return Task.CompletedTask;
+                };
+                OnRedirectToIdentityProviderForSignOut = c =>
+                {
+                    InvokedRedirectForSignOut = true;
+                    return Task.CompletedTask;
+                };
+                OnRemoteSignOut = context =>
+                {
+                    InvokedRemoteSignOut = true;
+                    return Task.CompletedTask;
+                };
+                OnSignedOutCallbackRedirect = context =>
+                {
+                    InvokedRedirectToSignedOut = true;
+                    return Task.CompletedTask;
+                };
+            }
+
+            public void ValidateExpectations()
+            {
+                Assert.Equal(ExpectMessageReceived, InvokedMessageReceived);
+                Assert.Equal(ExpectTokenValidated, InvokedTokenValidated);
+                Assert.Equal(ExpectAuthorizationCodeReceived, InvokedAuthorizationCodeReceived);
+                Assert.Equal(ExpectTokenResponseReceived, InvokedTokenResponseReceived);
+                Assert.Equal(ExpectSecondaryTokenValidated, InvokedSecondaryTokenValidated);
+                Assert.Equal(ExpectUserInfoReceived, InvokedUserInfoReceived);
+                Assert.Equal(ExpectAuthenticationFailed, InvokeAuthenticationFailed);
+                Assert.Equal(ExpectTicketReceived, InvokedTicketReceived);
+                Assert.Equal(ExpectRemoteFailure, InvokedRemoteFailure);
+                Assert.Equal(ExpectRedirectForSignOut, InvokedRedirectForSignOut);
+                Assert.Equal(ExpectRemoteSignOut, InvokedRemoteSignOut);
+                Assert.Equal(ExpectRedirectToSignedOut, InvokedRedirectToSignedOut);
+            }
         }
 
         private TestServer CreateServer(OpenIdConnectEvents events, RequestDelegate appCode)


### PR DESCRIPTION
#1027 This adds a new event for a previous gap. If you received an id_token and code from the authorization endpoint then you would not get an event where you could examine the validated id_token output from the token endpoint. No functional changes have been made, we're only exposing additional information that the user can take advantage of.

I've also refactored the event tests to reduce redundancy.

@PinpointTownes 
