### PR TITLE
Update WsFed to use the 2.0 event structure

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.WsFederation/Events/WsFederationEvents.cs
+++ b/src/Microsoft.AspNetCore.Authentication.WsFederation/Events/WsFederationEvents.cs
@@ -14,26 +14,51 @@ namespace Microsoft.AspNetCore.Authentication.WsFederation
         /// <summary>
         /// Invoked if exceptions are thrown during request processing. The exceptions will be re-thrown after this event unless suppressed.
         /// </summary>
-        public Func<AuthenticationFailedContext, Task> AuthenticationFailed { get; set; } = context => Task.CompletedTask;
+        public Func<AuthenticationFailedContext, Task> OnAuthenticationFailed { get; set; } = context => Task.CompletedTask;
 
         /// <summary>
         /// Invoked when a protocol message is first received.
         /// </summary>
-        public Func<MessageReceivedContext, Task> MessageReceived { get; set; } = context => Task.CompletedTask;
+        public Func<MessageReceivedContext, Task> OnMessageReceived { get; set; } = context => Task.CompletedTask;
 
         /// <summary>
         /// Invoked to manipulate redirects to the identity provider for SignIn, SignOut, or Challenge.
         /// </summary>
-        public Func<RedirectContext, Task> RedirectToIdentityProvider { get; set; } = context => Task.CompletedTask;
+        public Func<RedirectContext, Task> OnRedirectToIdentityProvider { get; set; } = context => Task.CompletedTask;
 
         /// <summary>
         /// Invoked with the security token that has been extracted from the protocol message.
         /// </summary>
-        public Func<SecurityTokenReceivedContext, Task> SecurityTokenReceived { get; set; } = context => Task.CompletedTask;
+        public Func<SecurityTokenReceivedContext, Task> OnSecurityTokenReceived { get; set; } = context => Task.CompletedTask;
 
         /// <summary>
         /// Invoked after the security token has passed validation and a ClaimsIdentity has been generated.
         /// </summary>
-        public Func<SecurityTokenValidatedContext, Task> SecurityTokenValidated { get; set; } = context => Task.CompletedTask;
+        public Func<SecurityTokenValidatedContext, Task> OnSecurityTokenValidated { get; set; } = context => Task.CompletedTask;
+
+        /// <summary>
+        /// Invoked if exceptions are thrown during request processing. The exceptions will be re-thrown after this event unless suppressed.
+        /// </summary>
+        public virtual Task AuthenticationFailed(AuthenticationFailedContext context) => OnAuthenticationFailed(context);
+
+        /// <summary>
+        /// Invoked when a protocol message is first received.
+        /// </summary>
+        public virtual Task MessageReceived(MessageReceivedContext context) => OnMessageReceived(context);
+
+        /// <summary>
+        /// Invoked to manipulate redirects to the identity provider for SignIn, SignOut, or Challenge.
+        /// </summary>
+        public virtual Task RedirectToIdentityProvider(RedirectContext context) => OnRedirectToIdentityProvider(context);
+
+        /// <summary>
+        /// Invoked with the security token that has been extracted from the protocol message.
+        /// </summary>
+        public virtual Task SecurityTokenReceived(SecurityTokenReceivedContext context) => OnSecurityTokenReceived(context);
+
+        /// <summary>
+        /// Invoked after the security token has passed validation and a ClaimsIdentity has been generated.
+        /// </summary>
+        public virtual Task SecurityTokenValidated(SecurityTokenValidatedContext context) => OnSecurityTokenValidated(context);
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.WsFederation/WsFederationHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.WsFederation/WsFederationHandler.cs
@@ -36,6 +36,22 @@ namespace Microsoft.AspNetCore.Authentication.WsFederation
         }
 
         /// <summary>
+        /// The handler calls methods on the events which give the application control at certain points where processing is occurring.
+        /// If it is not provided a default instance is supplied which does nothing when the methods are called.
+        /// </summary>
+        protected new WsFederationEvents Events
+        {
+            get { return (WsFederationEvents)base.Events; }
+            set { base.Events = value; }
+        }
+
+        /// <summary>
+        /// Creates a new instance of the events instance.
+        /// </summary>
+        /// <returns>A new instance of the events instance.</returns>
+        protected override Task<object> CreateEventsAsync() => Task.FromResult<object>(new WsFederationEvents());
+
+        /// <summary>
         /// Handles Challenge
         /// </summary>
         /// <returns></returns>
@@ -85,7 +101,7 @@ namespace Microsoft.AspNetCore.Authentication.WsFederation
             {
                 ProtocolMessage = wsFederationMessage
             };
-            await Options.Events.RedirectToIdentityProvider(redirectContext);
+            await Events.RedirectToIdentityProvider(redirectContext);
 
             if (redirectContext.Handled)
             {
@@ -165,7 +181,7 @@ namespace Microsoft.AspNetCore.Authentication.WsFederation
                 {
                     ProtocolMessage = wsFederationMessage
                 };
-                await Options.Events.MessageReceived(messageReceivedContext);
+                await Events.MessageReceived(messageReceivedContext);
                 if (messageReceivedContext.Result != null)
                 {
                     return messageReceivedContext.Result;
@@ -197,7 +213,7 @@ namespace Microsoft.AspNetCore.Authentication.WsFederation
                 {
                     ProtocolMessage = wsFederationMessage
                 };
-                await Options.Events.SecurityTokenReceived(securityTokenReceivedContext);
+                await Events.SecurityTokenReceived(securityTokenReceivedContext);
                 if (securityTokenReceivedContext.Result != null)
                 {
                     return securityTokenReceivedContext.Result;
@@ -254,7 +270,7 @@ namespace Microsoft.AspNetCore.Authentication.WsFederation
                     SecurityToken = parsedToken,
                 };
 
-                await Options.Events.SecurityTokenValidated(securityTokenValidatedContext);
+                await Events.SecurityTokenValidated(securityTokenValidatedContext);
                 if (securityTokenValidatedContext.Result != null)
                 {
                     return securityTokenValidatedContext.Result;
@@ -281,7 +297,7 @@ namespace Microsoft.AspNetCore.Authentication.WsFederation
                     ProtocolMessage = wsFederationMessage,
                     Exception = exception
                 };
-                await Options.Events.AuthenticationFailed(authenticationFailedContext);
+                await Events.AuthenticationFailed(authenticationFailedContext);
                 if (authenticationFailedContext.Result != null)
                 {
                     return authenticationFailedContext.Result;
@@ -330,7 +346,7 @@ namespace Microsoft.AspNetCore.Authentication.WsFederation
             {
                 ProtocolMessage = wsFederationMessage
             };
-            await Options.Events.RedirectToIdentityProvider(redirectContext);
+            await Events.RedirectToIdentityProvider(redirectContext);
 
             if (!redirectContext.Handled)
             {


### PR DESCRIPTION
#1520 Auth 2.0 introduce the ability to resolve the events class from DI. This change adds that to the WsFed handler. It also adds virtual methods to the event class to support overriding.
@PinpointTownes @lzandman