### PR TITLE
Updated logging extension to remove the period on ValidationFailed

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.JwtBearer/LoggingExtensions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.JwtBearer/LoggingExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Extensions.Logging
             _tokenValidationFailed = LoggerMessage.Define<string>(
                 eventId: 1,
                 logLevel: LogLevel.Information,
-                formatString: "Failed to validate the token {Token}.");
+                formatString: "Failed to validate the token {Token}");
             _tokenValidationSucceeded = LoggerMessage.Define(
                 eventId: 2,
                 logLevel: LogLevel.Information,


### PR DESCRIPTION
_tokenValidationFailed format string includes the JWT token followed by a period, which if a dev troubleshooting copies incorrectly to the EOL will make the JWT invalid. (https://github.com/aspnet/Security/blob/a9482d1d03fc22f62e42cf31b8adb32c5550835e/src/Microsoft.AspNetCore.Authentication.JwtBearer/LoggingExtensions.cs#L19)

Current: Failed to validate the token eyJhbGc.......HCwFmw.
Proposed: Failed to validate the token eyJhbGc.......HCwFmw