### PR TITLE
Redirect remote failures to /home/error

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OAuth/OAuthHandler.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
                     failureMessage.Append(";Uri=").Append(errorUri);
                 }
 
-                return HandleRequestResult.Fail(failureMessage.ToString(), properties);
+                return HandleRequestResult.Fail(failureMessage.ToString(), error, errorDescription, properties);
             }
 
             var code = query["code"];

--- a/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterHandler.cs
@@ -60,6 +60,12 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
 
             // REVIEW: see which of these are really errors
 
+            var denied = query["denied"];
+            if (!StringValues.IsNullOrEmpty(denied))
+            {
+                return HandleRequestResult.Fail("The user denied permissions.", "denied", "The user denied permissions", properties);
+            }
+
             var returnedToken = query["oauth_token"];
             if (StringValues.IsNullOrEmpty(returnedToken))
             {

--- a/src/Microsoft.AspNetCore.Authentication/HandleRequestResult.cs
+++ b/src/Microsoft.AspNetCore.Authentication/HandleRequestResult.cs
@@ -23,6 +23,16 @@ namespace Microsoft.AspNetCore.Authentication
         public bool Skipped { get; private set; }
 
         /// <summary>
+        /// The error category name.
+        /// </summary>
+        public string ErrorTitle { get; private set; }
+
+        /// <summary>
+        /// A detailed description of the error.
+        /// </summary>
+        public string ErrorDescription { get; private set; }
+
+        /// <summary>
         /// Indicates that authentication was successful.
         /// </summary>
         /// <param name="ticket">The ticket representing the authentication result.</param>
@@ -73,6 +83,31 @@ namespace Microsoft.AspNetCore.Authentication
         /// <returns>The result.</returns>
         public static new HandleRequestResult Fail(string failureMessage, AuthenticationProperties properties)
             => Fail(new Exception(failureMessage), properties);
+
+        /// <summary>
+        /// Indicates that there was a failure during authentication and supplies an appropriate error title and description.
+        /// </summary>
+        /// <param name="failureMessage">The failure message.</param>
+        /// <param name="errorTitle">The error category name.</param>
+        /// <param name="errorDescription">A detailed description of the error.</param>
+        /// <param name="properties">Additional state values for the authentication session.</param>
+        /// <returns></returns>
+        public static HandleRequestResult Fail(string failureMessage, string errorTitle, string errorDescription, AuthenticationProperties properties)
+            => Fail(new Exception(failureMessage), errorTitle, errorDescription, properties);
+
+
+        /// <summary>
+        /// Indicates that there was a failure during authentication and supplies an appropriate error title and description.
+        /// </summary>
+        /// <param name="failure">The failure.</param>
+        /// <param name="errorTitle">The error category name.</param>
+        /// <param name="errorDescription">A detailed description of the error.</param>
+        /// <param name="properties">Additional state values for the authentication session.</param>
+        /// <returns></returns>
+        public static HandleRequestResult Fail(Exception failure, string errorTitle, string errorDescription, AuthenticationProperties properties)
+        {
+            return new HandleRequestResult() { Failure = failure, ErrorTitle = errorTitle, ErrorDescription = errorDescription, Properties = properties };
+        }
 
         /// <summary>
         /// Discontinue all processing for this request and return to the client.

--- a/src/Microsoft.AspNetCore.Authentication/RemoteAuthenticationOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication/RemoteAuthenticationOptions.cs
@@ -56,6 +56,11 @@ namespace Microsoft.AspNetCore.Authentication
             {
                 throw new ArgumentException(Resources.FormatException_OptionMustBeProvided(nameof(CallbackPath)), nameof(CallbackPath));
             }
+
+            if (RemoteFailureRedirect == null || !RemoteFailureRedirect.HasValue)
+            {
+                throw new ArgumentException(Resources.FormatException_OptionMustBeProvided(nameof(RemoteFailureRedirect)), nameof(RemoteFailureRedirect));
+            }
         }
 
         /// <summary>
@@ -88,6 +93,11 @@ namespace Microsoft.AspNetCore.Authentication
         /// The middleware will process this request when it arrives.
         /// </summary>
         public PathString CallbackPath { get; set; }
+
+        /// <summary>
+        /// Remote protocol errors reported to the CallbackPath will be redirected to this path. The default value is "/Home/Error".
+        /// </summary>
+        public PathString RemoteFailureRedirect { get; set; } = "/Home/Error";
 
         /// <summary>
         /// Gets or sets the authentication scheme corresponding to the middleware


### PR DESCRIPTION
#1165 The remote auth components like Facebook or OIDC have never handled remote failures gracefully. E.g. if a user declines permissions to your app then an exception is thrown and the client gets a 500 error.

OAuth and OIDC define some standard error fields and we currently use these to generate a detailed exception message. This takes that one step further and generates a redirect to /home/error with those error fields as query parameters.

Sending this initial PR to see if this is a change we're willing to take for 2.1. If so then I'll add a few more tests and clean it up.

Here are some notes on the behavior of individual providers:

Google
         - Doesn't even ask for consent? It only ask you to select an account.

Facebook
	- https://www.facebook.com/settings?tab=applications
	- GET /signin-facebook?
	- error=access_denied&
	- error_code=200&
	- error_description=Permissions%20error&
	- error_reason=user_denied&
	- state=CfDJ8JQ7RNKCadBHk4_sI5UNfETy2xdPTigkm_jCBShuc9asO__-yHcEa_3dizjzX2PVb2IAPdODytGjkySQsU8HxmWRI3i3PO-9tXRQEocO8mkCz16pxAqdcdOdWpsfx2i9EMqMdpnCeTwmHjHvhlRqZ5IBqgTbbFQWhBHkhbILKzECS8lZ6DYJneLziBS-Fn10PrLe4w_EGLO1_dr5a5qp2MI HTTP/1.1

Twitter
	- https://twitter.com/settings/applications
	-  GET /signin-twitter?denied=vBzGPQAAAAAAu4omAAABYKRNrBY HTTP/1.1

Microsoft
	- https://account.live.com/consent/Manage
	- GET /signin-microsoft?
	- error=access_denied&
	- error_description=The%20user%20has%20denied%20access%20to%20the%20scope%20requested%20by%20the%20client%20application.&
	- state=CfDJ8JQ7RNKCadBHk4_sI5UNfESFOFwEQvoQNcB5iKIYymQ9rjkvRwSlJQIwMbFv59pAQEXo8Nrs1KSLKQUBaSQ7d1rPMgTZUnr8RGap2Ej5npXBDTHQtEgeBMJyzjOT2YTHvJqQGu0KLT0yHZFsI912UDqY8tsWEyXIp_9pdzxPj9mKWF1fXvI-5fG3vvElWSslNI_jInsFUIAtRPYspbGkTTc HTTP/1.1

Github 
     - No cancel button
     - https://github.com/settings/applications

@PinpointTownes how well do the other providers you've seen map to this?