### PR TITLE
Detect remote denails for Twitter accounts

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterHandler.cs
@@ -60,6 +60,12 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
 
             // REVIEW: see which of these are really errors
 
+            var denied = query["denied"];
+            if (!StringValues.IsNullOrEmpty(denied))
+            {
+                return HandleRequestResult.Fail("The user denied permissions.", properties);
+            }
+
             var returnedToken = query["oauth_token"];
             if (StringValues.IsNullOrEmpty(returnedToken))
             {

--- a/test/Microsoft.AspNetCore.Authentication.Test/TwitterTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/TwitterTests.cs
@@ -195,6 +195,7 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
                     OnRemoteFailure = context =>
                     {
                         Assert.NotNull(context.Failure);
+                        Assert.Equal("The user denied permissions.", context.Failure.Message);
                         Assert.NotNull(context.Properties);
                         Assert.Equal("testvalue", context.Properties.Items["testkey"]);
                         context.Response.StatusCode = StatusCodes.Status406NotAcceptable;
@@ -220,7 +221,7 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
             var setCookieValue = setCookieValues.Single();
             var cookie = new CookieHeaderValue(setCookieValue.Name, setCookieValue.Value);
 
-            var request = new HttpRequestMessage(HttpMethod.Get, "/signin-twitter");
+            var request = new HttpRequestMessage(HttpMethod.Get, "/signin-twitter?denied=ABCDEFG");
             request.Headers.Add(HeaderNames.Cookie, cookie.ToString());
             var client = server.CreateClient();
             var response = await client.SendAsync(request);


### PR DESCRIPTION
Replaces https://github.com/aspnet/Security/pull/1582

This is what happens when a new user clicks cancel on Twitter's authorization page.