### PR TITLE
Rework WsFed RemoteSignOutPath logic to work with ADFS 

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.WsFederation/WsFederationOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.WsFederation/WsFederationOptions.cs
@@ -33,7 +33,10 @@ namespace Microsoft.AspNetCore.Authentication.WsFederation
         public WsFederationOptions()
         {
             CallbackPath = "/signin-wsfed";
-            RemoteSignOutPath = "/signout-wsfed";
+            // In ADFS the cleanup messages are sent to the same callback path as the initial login.
+            // In AAD it sends the cleanup message to a random Reply Url and there's no deterministic way to configure it.
+            //  If you manage to get it configured, then you can set RemoteSignOutPath accordingly.
+            RemoteSignOutPath = "/signin-wsfed";
             Events = new WsFederationEvents();
         }
 
@@ -163,7 +166,7 @@ namespace Microsoft.AspNetCore.Authentication.WsFederation
         public bool AllowUnsolicitedLogins { get; set; }
 
         /// <summary>
-        /// Requests received on this path will cause the handler to invoke SignOut using the SignInScheme.
+        /// Requests received on this path will cause the handler to invoke SignOut using the SignOutScheme.
         /// </summary>
         public PathString RemoteSignOutPath { get; set; }
 

--- a/test/Microsoft.AspNetCore.Authentication.WsFederation.Test/WsFederationTest.cs
+++ b/test/Microsoft.AspNetCore.Authentication.WsFederation.Test/WsFederationTest.cs
@@ -117,7 +117,7 @@ namespace Microsoft.AspNetCore.Authentication.WsFederation
         {
             var httpClient = CreateClient();
 
-            var response = await httpClient.GetAsync("/signout-wsfed?wa=wsignoutcleanup1.0");
+            var response = await httpClient.GetAsync("/signin-wsfed?wa=wsignoutcleanup1.0");
             response.EnsureSuccessStatusCode();
 
             var cookie = response.Headers.GetValues(HeaderNames.SetCookie).Single();


### PR DESCRIPTION
#1581 @brockallen can you build this branch and try it? I don't expect to ship another preview.

The prior design and defaults were set up for AAD but didn't work for ADFS. ADFS usage is more likely so we'll use defaults that work there.

Also AAD's single sign out doesn't work right if you have multiple reply urls, the cleanup messages get sent to a random reply url. 