### PR TITLE
Implement ITrackingConsentFeature.CreateConsentCookie()

### DIFF
--- a/Security.sln
+++ b/Security.sln
@@ -68,6 +68,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		build\Key.snk = build\Key.snk
 		NuGet.config = NuGet.config
 		build\repo.props = build\repo.props
+		build\sources.props = build\sources.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Authorization.Policy", "src\Microsoft.AspNetCore.Authorization.Policy\Microsoft.AspNetCore.Authorization.Policy.csproj", "{58194599-F07D-47A3-9DF2-E21A22C5EF9E}"


### PR DESCRIPTION
 #1590 @DamianEdwards 
This reduces the amount of work that needs to be done in the template when they want to set the consent cookie on the client via javascript.

See https://github.com/aspnet/templating/pull/213/files#diff-947841bf97b345569d23143ef4af84af

This requires https://github.com/aspnet/HttpAbstractions/commit/ce6934126513f1da9e46b8d695fedb2ddf261ae1
  