### PR TITLE
Don't overwrite pre-authenticated identities.

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication/AuthenticationMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Authentication/AuthenticationMiddleware.cs
@@ -56,10 +56,7 @@ namespace Microsoft.AspNetCore.Authentication
                 {
                     var identities = context.User.Identities;
                     context.User = result.Principal;
-                    if (identities != null)
-                    {
-                        context.User.AddIdentities(identities);
-                    }
+                    context.User.AddIdentities(identities);
                 }
             }
 

--- a/src/Microsoft.AspNetCore.Authentication/AuthenticationMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Authentication/AuthenticationMiddleware.cs
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.Authentication
                 var result = await context.AuthenticateAsync(defaultAuthenticate.Name);
                 if (result?.Principal != null)
                 {
-                    var identities = context.User?.Identities;
+                    var identities = context.User.Identities;
                     context.User = result.Principal;
                     if (identities != null)
                     {

--- a/src/Microsoft.AspNetCore.Authentication/AuthenticationMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Authentication/AuthenticationMiddleware.cs
@@ -54,7 +54,12 @@ namespace Microsoft.AspNetCore.Authentication
                 var result = await context.AuthenticateAsync(defaultAuthenticate.Name);
                 if (result?.Principal != null)
                 {
+                    var identities = context.User?.Identities;
                     context.User = result.Principal;
+                    if (identities != null)
+                    {
+                        context.User.AddIdentities(identities);
+                    }
                 }
             }
 


### PR DESCRIPTION
Seems 2.0 introduced a bug where the Authentication middleware will overwrite any current identities on the user principal.