### PR TITLE
Add TicketSerializer property to CookieAuthenticaitonOptions

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationOptions.cs
@@ -123,6 +123,12 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         public ISecureDataFormat<AuthenticationTicket> TicketDataFormat { get; set; }
 
         /// <summary>
+        /// The TicketSerializer is used to serialize the identity and other properties which are stored in the
+        /// cookie value. If not provided the default from TicketSerializer.Default will be used.
+        /// </summary>
+        public IDataSerializer<AuthenticationTicket> TicketSerializer { get; set; }
+
+        /// <summary>
         /// The component used to get cookies from the request or set them on the response.
         ///
         /// ChunkingCookieManager will be used by default.

--- a/src/Microsoft.AspNetCore.Authentication.Cookies/PostConfigureCookieAuthenticationOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/PostConfigureCookieAuthenticationOptions.cs
@@ -34,9 +34,11 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
             }
             if (options.TicketDataFormat == null)
             {
+                options.TicketSerializer = options.TicketSerializer ?? TicketSerializer.Default;
+
                 // Note: the purpose for the data protector must remain fixed for interop to work.
                 var dataProtector = options.DataProtectionProvider.CreateProtector("Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationMiddleware", name, "v2");
-                options.TicketDataFormat = new TicketDataFormat(dataProtector);
+                options.TicketDataFormat = new SecureDataFormat<AuthenticationTicket>(options.TicketSerializer, dataProtector);
             }
             if (options.CookieManager == null)
             {


### PR DESCRIPTION
Provide the ability to set the TicketSerializer without having to build up TicketDataFormat yourself.

This then allows users to more easily compress cookies. https://github.com/aspnet/Security/issues/589

Would be nice to even have Compression built in, and allow users to opt-in via a boolean option.