### PR TITLE
Update facebook API version to 2.12

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookDefaults.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookDefaults.cs
@@ -9,10 +9,10 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
 
         public static readonly string DisplayName = "Facebook";
 
-        public static readonly string AuthorizationEndpoint = "https://www.facebook.com/v2.6/dialog/oauth";
+        public static readonly string AuthorizationEndpoint = "https://www.facebook.com/v2.12/dialog/oauth";
 
-        public static readonly string TokenEndpoint = "https://graph.facebook.com/v2.6/oauth/access_token";
+        public static readonly string TokenEndpoint = "https://graph.facebook.com/v2.12/oauth/access_token";
 
-        public static readonly string UserInformationEndpoint = "https://graph.facebook.com/v2.6/me";
+        public static readonly string UserInformationEndpoint = "https://graph.facebook.com/v2.12/me";
     }
 }

--- a/test/Microsoft.AspNetCore.Authentication.Test/FacebookTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/FacebookTests.cs
@@ -585,7 +585,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             var transaction = await server.SendAsync("http://example.com/base/login");
             Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var location = transaction.Response.Headers.Location.AbsoluteUri;
-            Assert.Contains("https://www.facebook.com/v2.6/dialog/oauth", location);
+            Assert.Contains("https://www.facebook.com/v2.12/dialog/oauth", location);
             Assert.Contains("response_type=code", location);
             Assert.Contains("client_id=", location);
             Assert.Contains("redirect_uri=" + UrlEncoder.Default.Encode("http://example.com/base/signin-facebook"), location);
@@ -617,7 +617,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             var transaction = await server.SendAsync("http://example.com/login");
             Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var location = transaction.Response.Headers.Location.AbsoluteUri;
-            Assert.Contains("https://www.facebook.com/v2.6/dialog/oauth", location);
+            Assert.Contains("https://www.facebook.com/v2.12/dialog/oauth", location);
             Assert.Contains("response_type=code", location);
             Assert.Contains("client_id=", location);
             Assert.Contains("redirect_uri="+ UrlEncoder.Default.Encode("http://example.com/signin-facebook"), location);
@@ -652,7 +652,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             var transaction = await server.SendAsync("http://example.com/challenge");
             Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var location = transaction.Response.Headers.Location.AbsoluteUri;
-            Assert.Contains("https://www.facebook.com/v2.6/dialog/oauth", location);
+            Assert.Contains("https://www.facebook.com/v2.12/dialog/oauth", location);
             Assert.Contains("response_type=code", location);
             Assert.Contains("client_id=", location);
             Assert.Contains("redirect_uri=", location);


### PR DESCRIPTION
 #1306 No behavioral changes.
Our current version (2.6) will expire July 13, 2018.


