### PR TITLE
Add CookiePolicy logging 

### DIFF
--- a/samples/CookiePolicySample/Program.cs
+++ b/samples/CookiePolicySample/Program.cs
@@ -12,7 +12,7 @@ namespace CookiePolicySample
                 .ConfigureLogging(factory =>
                 {
                     factory.AddConsole();
-                    factory.AddFilter("Console", level => level >= LogLevel.Information);
+                    factory.AddFilter("Microsoft", LogLevel.Trace);
                 })
                 .UseKestrel()
                 .UseContentRoot(Directory.GetCurrentDirectory())

--- a/src/Microsoft.AspNetCore.CookiePolicy/CookiePolicyMiddleware.cs
+++ b/src/Microsoft.AspNetCore.CookiePolicy/CookiePolicyMiddleware.cs
@@ -1,10 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.CookiePolicy
@@ -12,13 +15,20 @@ namespace Microsoft.AspNetCore.CookiePolicy
     public class CookiePolicyMiddleware
     {
         private readonly RequestDelegate _next;
+        private readonly ILogger _logger;
 
-        public CookiePolicyMiddleware(
-            RequestDelegate next,
-            IOptions<CookiePolicyOptions> options)
+        public CookiePolicyMiddleware(RequestDelegate next, IOptions<CookiePolicyOptions> options, ILoggerFactory factory)
+        {
+            Options = options.Value;
+            _next = next ?? throw new ArgumentNullException(nameof(next));
+            _logger = factory.CreateLogger<CookiePolicyMiddleware>();
+        }
+
+        public CookiePolicyMiddleware(RequestDelegate next, IOptions<CookiePolicyOptions> options)
         {
             Options = options.Value;
             _next = next;
+            _logger = NullLogger.Instance;
         }
 
         public CookiePolicyOptions Options { get; set; }
@@ -26,7 +36,7 @@ namespace Microsoft.AspNetCore.CookiePolicy
         public Task Invoke(HttpContext context)
         {
             var feature = context.Features.Get<IResponseCookiesFeature>() ?? new ResponseCookiesFeature(context.Features);
-            var wrapper = new ResponseCookiesWrapper(context, Options, feature);
+            var wrapper = new ResponseCookiesWrapper(context, Options, feature, _logger);
             context.Features.Set<IResponseCookiesFeature>(new CookiesWrapperFeature(wrapper));
             context.Features.Set<ITrackingConsentFeature>(wrapper);
 

--- a/src/Microsoft.AspNetCore.CookiePolicy/LoggingExtensions.cs
+++ b/src/Microsoft.AspNetCore.CookiePolicy/LoggingExtensions.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Extensions.Logging
+{
+    internal static class LoggingExtensions
+    {
+        private static Action<ILogger, bool, Exception> _needsConsent;
+        private static Action<ILogger, bool, Exception> _hasConsent;
+        private static Action<ILogger, Exception> _consentGranted;
+        private static Action<ILogger, Exception> _consentWithdrawn;
+        private static Action<ILogger, string, Exception> _cookieSuppressed;
+        private static Action<ILogger, string, Exception> _deleteCookieSuppressed;
+        private static Action<ILogger, string, Exception> _upgradedToSecure;
+        private static Action<ILogger, string, string, Exception> _upgradedSameSite;
+        private static Action<ILogger, string, Exception> _upgradedToHttpOnly;
+
+        static LoggingExtensions()
+        {
+            _needsConsent = LoggerMessage.Define<bool>(
+                eventId: 1,
+                logLevel: LogLevel.Trace,
+                formatString: "Needs consent: {needsConsent}.");
+            _hasConsent = LoggerMessage.Define<bool>(
+                eventId: 2,
+                logLevel: LogLevel.Trace,
+                formatString: "Has consent: {hasConsent}.");
+            _consentGranted = LoggerMessage.Define(
+                eventId: 3,
+                logLevel: LogLevel.Debug,
+                formatString: "Consent granted.");
+            _consentWithdrawn = LoggerMessage.Define(
+                eventId: 4,
+                logLevel: LogLevel.Debug,
+                formatString: "Consent withdrawn.");
+            _cookieSuppressed = LoggerMessage.Define<string>(
+                eventId: 5,
+                logLevel: LogLevel.Debug,
+                formatString: "Cookie '{key}' suppressed due to consent policy.");
+            _deleteCookieSuppressed = LoggerMessage.Define<string>(
+                eventId: 6,
+                logLevel: LogLevel.Debug,
+                formatString: "Delete cookie '{key}' suppressed due to developer policy.");
+            _upgradedToSecure = LoggerMessage.Define<string>(
+                eventId: 7,
+                logLevel: LogLevel.Debug,
+                formatString: "Cookie '{key}' upgraded to 'secure'.");
+            _upgradedSameSite = LoggerMessage.Define<string, string>(
+                eventId: 8,
+                logLevel: LogLevel.Debug,
+                formatString: "Cookie '{key}' same site mode upgraded to '{mode}'.");
+            _upgradedToHttpOnly = LoggerMessage.Define<string>(
+                eventId: 9,
+                logLevel: LogLevel.Debug,
+                formatString: "Cookie '{key}' upgraded to 'httponly'.");
+        }
+
+        public static void NeedsConsent(this ILogger logger, bool needsConsent)
+        {
+            _needsConsent(logger, needsConsent, null);
+        }
+
+        public static void HasConsent(this ILogger logger, bool hasConsent)
+        {
+            _hasConsent(logger, hasConsent, null);
+        }
+
+        public static void ConsentGranted(this ILogger logger)
+        {
+            _consentGranted(logger, null);
+        }
+
+        public static void ConsentWithdrawn(this ILogger logger)
+        {
+            _consentWithdrawn(logger, null);
+        }
+
+        public static void CookieSuppressed(this ILogger logger, string key)
+        {
+            _cookieSuppressed(logger, key, null);
+        }
+
+        public static void DeleteCookieSuppressed(this ILogger logger, string key)
+        {
+            _deleteCookieSuppressed(logger, key, null);
+        }
+
+        public static void CookieUpgradedToSecure(this ILogger logger, string key)
+        {
+            _upgradedToSecure(logger, key, null);
+        }
+
+        public static void CookieSameSiteUpgraded(this ILogger logger, string key, string mode)
+        {
+            _upgradedSameSite(logger, key, mode, null);
+        }
+
+        public static void CookieUpgradedToHttpOnly(this ILogger logger, string key)
+        {
+            _upgradedToHttpOnly(logger, key, null);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.CookiePolicy/Microsoft.AspNetCore.CookiePolicy.csproj
+++ b/src/Microsoft.AspNetCore.CookiePolicy/Microsoft.AspNetCore.CookiePolicy.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="$(MicrosoftAspNetCoreHttpPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsPackageVersion)" />
   </ItemGroup>
 

--- a/test/Microsoft.AspNetCore.CookiePolicy.Test/CookiePolicyTests.cs
+++ b/test/Microsoft.AspNetCore.CookiePolicy.Test/CookiePolicyTests.cs
@@ -102,7 +102,7 @@ namespace Microsoft.AspNetCore.CookiePolicy.Test
                         Assert.Equal("A=A; path=/; samesite=lax", transaction.SetCookie[0]);
                         Assert.Equal("B=B; path=/; samesite=lax", transaction.SetCookie[1]);
                         Assert.Equal("C=C; path=/; samesite=lax", transaction.SetCookie[2]);
-                        Assert.Equal("D=D; path=/; samesite=lax", transaction.SetCookie[3]);
+                        Assert.Equal("D=D; path=/; secure; samesite=lax", transaction.SetCookie[3]);
                     }),
                 new RequestTest("https://example.com/secureSame",
                     transaction =>


### PR DESCRIPTION
#1588
I had to work around https://github.com/aspnet/Home/issues/2871 by putting the constructors in a specific order.

@blowdart I did find an is issue where a CookieSecurePolicy.SameAsRequest policy would cause a Secure cookie to be downgraded if it was being sent over HTTP rather than HTTPS. However, users shouldn't be sending secure cookies over HTTP anyways. I changed it to make sure it never downgrades.