### PR TITLE
Enable using a Cookie Session Store from DI

### DIFF
--- a/samples/CookieSessionSample/MemoryCacheTicketStore.cs
+++ b/samples/CookieSessionSample/MemoryCacheTicketStore.cs
@@ -11,9 +11,9 @@ namespace CookieSessionSample
         private const string KeyPrefix = "AuthSessionStore-";
         private IMemoryCache _cache;
 
-        public MemoryCacheTicketStore()
+        public MemoryCacheTicketStore(IMemoryCache cache)
         {
-            _cache = new MemoryCache(new MemoryCacheOptions());
+            _cache = cache ?? new MemoryCache(new MemoryCacheOptions());
         }
 
         public async Task<string> StoreAsync(AuthenticationTicket ticket)

--- a/samples/CookieSessionSample/Startup.cs
+++ b/samples/CookieSessionSample/Startup.cs
@@ -14,12 +14,14 @@ namespace CookieSessionSample
     {
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddMemoryCache();
+            services.AddSingleton<ITicketStore, MemoryCacheTicketStore>();
             // This can be removed after https://github.com/aspnet/IISIntegration/issues/371
             services.AddAuthentication(options =>
             {
                 options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                 options.DefaultChallengeScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-            }).AddCookie(o => o.SessionStore = new MemoryCacheTicketStore());
+            }).AddCookie(o => o.UseSessionStoreFromDI = true);
         }
 
         public void Configure(IApplicationBuilder app)

--- a/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationOptions.cs
@@ -136,6 +136,17 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
         public ITicketStore SessionStore { get; set; }
 
         /// <summary>
+        /// A value that indicates whether the <see cref="ITicketStore"/> instance to use as a session store should be 
+        /// requested from the Dependency Injection container instead of the <see cref="SessionStore"/> property value.
+        /// </summary>
+        /// <seealso cref="SessionStore"/>
+        /// <remarks>
+        /// Use of a session store from DI requires an <see cref="ITicketStore"/> service to be registered in the 
+        /// DI container.
+        /// </remarks>
+        public bool UseSessionStoreFromDI { get; set; }
+
+        /// <summary>
         /// <para>
         /// Controls how much time the authentication ticket stored in the cookie will remain valid from the point it is created
         /// The expiration information is stored in the protected cookie ticket. Because of that an expired cookie will be ignored


### PR DESCRIPTION
A `CookieAuthenticationHandler` will use a `ITicketStore` from DI if and only if the following conditions are met:
1. The `UseSessionStoreFromDI` property of the handler's `CookieAuthenticationOptions` is `true`.
2. The DI container has a registered service for the `ITicketStore` interface, and the returned instance is non-`null`.

Since `UseSessionStoreFromDI` is a new property and new behaviour only is applied when its value is `true`, these changes remain fully backwards compatible.

Code Changes:
* Adds a new boolean property `UseSessionStoreFromDI` to `Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationOptions`.
* `Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationHandler` requests an `ITicketStore` in its constructor with an optional argument.  
   Because the argument is optional, DI can provide the argument as `null` if no `ITicketStore` service is registered. This will ensure backwards-compatability.
* In every case where `CookieAuthenticationHandler` previously got the `ITicketStore` from its `Options.SessionStore`, it now first checks the new `Options.UseSessionStoreFromDI` property and uses the non-null DI-injected `ITicketStore` instance if `UseSessionStoreFromDI` is `true`.

fixes https://github.com/aspnet/Security/issues/581