### PR TITLE
AuthZ: Combine should ignore null policies

### DIFF
--- a/src/Microsoft.AspNetCore.Authorization/AuthorizationPolicyBuilder.cs
+++ b/src/Microsoft.AspNetCore.Authorization/AuthorizationPolicyBuilder.cs
@@ -81,13 +81,11 @@ namespace Microsoft.AspNetCore.Authorization
         /// <returns>A reference to this instance after the operation has completed.</returns>
         public AuthorizationPolicyBuilder Combine(AuthorizationPolicy policy)
         {
-            if (policy == null)
+            if (policy != null)
             {
-                throw new ArgumentNullException(nameof(policy));
+                AddAuthenticationSchemes(policy.AuthenticationSchemes.ToArray());
+                AddRequirements(policy.Requirements.ToArray());
             }
-
-            AddAuthenticationSchemes(policy.AuthenticationSchemes.ToArray());
-            AddRequirements(policy.Requirements.ToArray());
             return this;
         }
 

--- a/test/Microsoft.AspNetCore.Authorization.Test/AuthorizationPolicyFacts.cs
+++ b/test/Microsoft.AspNetCore.Authorization.Test/AuthorizationPolicyFacts.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authorization.Infrastructure;
 using Microsoft.Extensions.Options;
 using Xunit;
@@ -17,6 +16,13 @@ namespace Microsoft.AspNetCore.Authorization.Test
         public void RequireRoleThrowsIfEmpty()
         {
             Assert.Throws<InvalidOperationException>(() => new AuthorizationPolicyBuilder().RequireRole());
+        }
+
+        [Fact]
+        public void CombineIgnoresNullPolicies()
+        {
+            var builder = new AuthorizationPolicyBuilder(policy: null).Combine(policy: null);
+            Assert.Empty(builder.Requirements);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/aspnet/Security/issues/1764 and https://github.com/aspnet/Mvc/issues/7809

cc @Tratcher @ajcvickers 

I'll file a separate PR that adds a test for this scenario in MVC that depends on this PR to pass