### PR TITLE
Allow post and basic client authentication mode for OIDC

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/ClientAuthentication/BasicAuthentication.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/ClientAuthentication/BasicAuthentication.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace Microsoft.AspNetCore.Authentication.OpenIdConnect.ClientAuthentication
+{
+    /// <summary>
+    /// Use basic authorization header
+    /// </summary>
+    public class BasicAuthentication : IClientAuthentication
+    {
+        private readonly bool withEscaping;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="withEscaping">allow to do EscapeData on the clientId and clientSecret</param>
+        public BasicAuthentication(bool withEscaping = true)
+        {
+            this.withEscaping = withEscaping;
+        }
+
+        public HttpRequestMessage SetClientAuthentication(HttpRequestMessage message, OpenIdConnectMessage tokenEndpointRequest)
+        {
+            var idAndSecret = withEscaping ? GetUtf8EscapedIdAndSecret(tokenEndpointRequest) : GetIdAndSecret(tokenEndpointRequest);
+            var basicHeader = Convert.ToBase64String(
+                   Encoding.UTF8.GetBytes(idAndSecret));
+            message.Headers.Authorization = new AuthenticationHeaderValue("Basic", basicHeader);
+            tokenEndpointRequest.ClientId = null;
+            tokenEndpointRequest.ClientSecret = null;
+            return message;
+        }
+
+        private string GetUtf8EscapedIdAndSecret(OpenIdConnectMessage tokenEndpointRequest)
+        {
+            return $"{Uri.EscapeDataString(tokenEndpointRequest.ClientId.ToUTF8())}:{Uri.EscapeDataString(tokenEndpointRequest.ClientSecret.ToUTF8())}";
+        }
+
+        private string GetIdAndSecret(OpenIdConnectMessage tokenEndpointRequest)
+        {
+            return $"{tokenEndpointRequest.ClientId}:{tokenEndpointRequest.ClientSecret}";
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/ClientAuthentication/EncodingHelper.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/ClientAuthentication/EncodingHelper.cs
@@ -1,0 +1,13 @@
+﻿using System.Text;
+
+namespace Microsoft.AspNetCore.Authentication.OpenIdConnect.ClientAuthentication
+{
+    internal static class EncodingHelper
+    {
+        internal static string ToUTF8(this string text)
+        {
+            var bytes = Encoding.Default.GetBytes(text);
+            return Encoding.UTF8.GetString(bytes);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/ClientAuthentication/FormPost.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/ClientAuthentication/FormPost.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using System.Net.Http;
+
+namespace Microsoft.AspNetCore.Authentication.OpenIdConnect.ClientAuthentication
+{
+    /// <summary>
+    /// Send client id and client secret in the request body 
+    /// </summary>
+    public class FormPost : IClientAuthentication
+    {
+        public HttpRequestMessage SetClientAuthentication(HttpRequestMessage message, OpenIdConnectMessage tokenEndpointRequest)
+        {
+            return message;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/ClientAuthentication/IClientAuthentication.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/ClientAuthentication/IClientAuthentication.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using System.Net.Http;
+
+namespace Microsoft.AspNetCore.Authentication.OpenIdConnect.ClientAuthentication
+{
+    /// <summary>
+    /// Configure the client authentication mode to call access_token endpoint
+    /// </summary>
+    public interface IClientAuthentication
+    {
+        /// <summary>
+        /// Adapt the request for the client authentication
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="tokenEndpointRequest"></param>
+        /// <returns></returns>
+        HttpRequestMessage SetClientAuthentication(HttpRequestMessage message, OpenIdConnectMessage tokenEndpointRequest);
+    }
+}

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectClientAuthenticationMode.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectClientAuthenticationMode.cs
@@ -1,17 +1,19 @@
-﻿namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
+﻿using Microsoft.AspNetCore.Authentication.OpenIdConnect.ClientAuthentication;
+
+namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
 {
     /// <summary>
     /// Configure the client authentication mode to call access_token endpoint
     /// </summary>
-    public enum OpenIdConnectClientAuthenticationMode
+    public class OpenIdConnectClientAuthenticationMode
     {
         /// <summary>
         /// Send client id and client secret in the request body 
         /// </summary>
-        Post,
+        public static IClientAuthentication Post { get; } = new FormPost();
         /// <summary>
         /// Use basic authorization header
         /// </summary>
-        Basic
+        public static IClientAuthentication Basic { get; } = new BasicAuthentication();
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectClientAuthenticationMode.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectClientAuthenticationMode.cs
@@ -1,0 +1,17 @@
+﻿namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
+{
+    /// <summary>
+    /// Configure the client authentication mode to call access_token endpoint
+    /// </summary>
+    public enum OpenIdConnectClientAuthenticationMode
+    {
+        /// <summary>
+        /// Send client id and client secret in the request body 
+        /// </summary>
+        Post,
+        /// <summary>
+        /// Use basic authorization header
+        /// </summary>
+        Basic
+    }
+}

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
@@ -741,7 +741,9 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
 
             if (this.Options.ClientAuthenticationMode == OpenIdConnectClientAuthenticationMode.Basic)
             {
-                requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes(tokenEndpointRequest.ClientId+":"+tokenEndpointRequest.ClientSecret)));
+                var basicHeader = Convert.ToBase64String(
+                    Encoding.UTF8.GetBytes($"{tokenEndpointRequest.ClientId}:{tokenEndpointRequest.ClientSecret}"));
+                requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Basic", basicHeader);
                 tokenEndpointRequest.ClientId = null;
                 tokenEndpointRequest.ClientSecret = null;
             }

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
@@ -738,6 +738,14 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
             Logger.RedeemingCodeForTokens();
 
             var requestMessage = new HttpRequestMessage(HttpMethod.Post, _configuration.TokenEndpoint);
+
+            if (this.Options.ClientAuthenticationMode == OpenIdConnectClientAuthenticationMode.Basic)
+            {
+                requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes(tokenEndpointRequest.ClientId+":"+tokenEndpointRequest.ClientSecret)));
+                tokenEndpointRequest.ClientId = null;
+                tokenEndpointRequest.ClientSecret = null;
+            }
+
             requestMessage.Content = new FormUrlEncodedContent(tokenEndpointRequest.Parameters);
 
             var responseMessage = await Backchannel.SendAsync(requestMessage);

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectHandler.cs
@@ -739,15 +739,8 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
 
             var requestMessage = new HttpRequestMessage(HttpMethod.Post, _configuration.TokenEndpoint);
 
-            if (this.Options.ClientAuthenticationMode == OpenIdConnectClientAuthenticationMode.Basic)
-            {
-                var basicHeader = Convert.ToBase64String(
-                    Encoding.UTF8.GetBytes($"{tokenEndpointRequest.ClientId}:{tokenEndpointRequest.ClientSecret}"));
-                requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Basic", basicHeader);
-                tokenEndpointRequest.ClientId = null;
-                tokenEndpointRequest.ClientSecret = null;
-            }
-
+            this.Options.ClientAuthenticationMode.SetClientAuthentication(requestMessage, tokenEndpointRequest);
+            
             requestMessage.Content = new FormUrlEncodedContent(tokenEndpointRequest.Parameters);
 
             var responseMessage = await Backchannel.SendAsync(requestMessage);

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectOptions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using Microsoft.AspNetCore.Authentication.Internal;
 using Microsoft.AspNetCore.Authentication.OAuth.Claims;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect.ClientAuthentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -127,7 +128,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
         /// Configure the way the client authenticate on the server
         /// https://tools.ietf.org/html/rfc6749#section-2.3.1
         /// </summary>
-        public OpenIdConnectClientAuthenticationMode ClientAuthenticationMode { get; set; }
+        public IClientAuthentication ClientAuthenticationMode { get; set; }
         /// <summary>
         /// Configuration provided directly by the developer. If provided, then MetadataAddress and the Backchannel properties
         /// will not be used. This information should not be updated during request processing.

--- a/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectOptions.cs
@@ -41,6 +41,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
             RemoteSignOutPath = new PathString("/signout-oidc");
 
             Events = new OpenIdConnectEvents();
+            ClientAuthenticationMode = OpenIdConnectClientAuthenticationMode.Post;
             Scope.Add("openid");
             Scope.Add("profile");
 
@@ -122,6 +123,11 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
         /// </summary>
         public string ClientSecret { get; set; }
 
+        /// <summary>
+        /// Configure the way the client authenticate on the server
+        /// https://tools.ietf.org/html/rfc6749#section-2.3.1
+        /// </summary>
+        public OpenIdConnectClientAuthenticationMode ClientAuthenticationMode { get; set; }
         /// <summary>
         /// Configuration provided directly by the developer. If provided, then MetadataAddress and the Backchannel properties
         /// will not be used. This information should not be updated during request processing.

--- a/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectEventTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectEventTests.cs
@@ -7,6 +7,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text;
 using System.Threading;
@@ -703,6 +704,78 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
         }
 
         [Fact]
+        public async Task When_Client_authentication_mode_is_post_then_the_request_message_body_should_contains_client_id_and_client_secret()
+        {
+            var events = new ExpectedOidcEvents()
+            {
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTokenResponseReceived = true,
+                ExpectUserInfoReceived = true,
+            };
+            
+            string token_request = null;
+            var server = CreateServer(events, AppWritePath,
+                option =>
+                {
+                    option.ClientId = "a-test-client";
+                    option.ClientSecret = "asecret";
+                    option.ClientAuthenticationMode = OpenIdConnectClientAuthenticationMode.Post;
+                },
+                message =>
+                {
+                    if (string.Equals("/tokens", message.RequestUri.AbsolutePath, StringComparison.Ordinal))
+                    {
+                        token_request = message.Content.ReadAsStringAsync().Result;
+                        
+                    }
+                }
+                );
+
+            await PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state&code=my_code");
+            Assert.Contains("client_id=a-test-client",token_request);
+            Assert.Contains("client_secret=asecret",token_request);
+        }
+
+        [Fact]
+        public async Task When_Client_authentication_mode_is_basic_then_the_request_message_header_should_contains_a_basic_authorization_header_with_clientid_and_client_secret()
+        {
+            var events = new ExpectedOidcEvents()
+            {
+                ExpectMessageReceived = true,
+                ExpectTokenValidated = true,
+                ExpectAuthorizationCodeReceived = true,
+                ExpectTokenResponseReceived = true,
+                ExpectUserInfoReceived = true,
+            };
+
+            var clientId = "a-test-client";
+            var clientSecret = "asecret";
+            AuthenticationHeaderValue authorization = null;
+            var server = CreateServer(events, AppWritePath,
+                option =>
+                {
+                    option.ClientId = clientId;
+                    option.ClientSecret = clientSecret;
+                    option.ClientAuthenticationMode = OpenIdConnectClientAuthenticationMode.Basic;
+                },
+                message =>
+                {
+                    if (string.Equals("/tokens", message.RequestUri.AbsolutePath, StringComparison.Ordinal))
+                    {
+                        authorization = message.Headers.Authorization;
+                    }
+                }
+            );
+
+            await PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state&code=my_code");
+            
+            Assert.Equal("Basic",authorization.Scheme);
+            Assert.Equal(Convert.ToBase64String(Encoding.UTF8.GetBytes(clientId+":"+clientSecret)),authorization.Parameter);
+        }
+
+        [Fact]
         public async Task OnAuthenticationFailed_HandledWithoutTicket_NoMoreEventsRun()
         {
             var events = new ExpectedOidcEvents()
@@ -1208,7 +1281,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
             }
         }
 
-        private TestServer CreateServer(OpenIdConnectEvents events, RequestDelegate appCode)
+        private TestServer CreateServer(OpenIdConnectEvents events, RequestDelegate appCode, Action<OpenIdConnectOptions> option = null, Action<HttpRequestMessage> validateRequest = null)
         {
             var builder = new WebHostBuilder()
                 .ConfigureServices(services =>
@@ -1224,6 +1297,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                         o.Events = events;
                         o.ClientId = "ClientId";
                         o.GetClaimsFromUserInfoEndpoint = true;
+
                         o.Configuration = new OpenIdConnectConfiguration()
                         {
                             TokenEndpoint = "http://testhost/tokens",
@@ -1233,7 +1307,8 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                         o.StateDataFormat = new TestStateDataFormat();
                         o.SecurityTokenValidator = new TestTokenValidator();
                         o.ProtocolValidator = new TestProtocolValidator();
-                        o.BackchannelHttpHandler = new TestBackchannel();
+                        o.BackchannelHttpHandler = new TestBackchannel(validateRequest);
+                        option?.Invoke(o);
                     });
                 })
                 .Configure(app =>
@@ -1328,8 +1403,15 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
 
         private class TestBackchannel : HttpMessageHandler
         {
+            public TestBackchannel(Action<HttpRequestMessage> validateRequest)
+            {
+                this.verifyRequest = validateRequest ?? (message =>  {});
+            }
+
+            private readonly Action<HttpRequestMessage> verifyRequest;
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
+                this.verifyRequest(request);
                 if (string.Equals("/tokens", request.RequestUri.AbsolutePath, StringComparison.Ordinal))
                 {
                     return Task.FromResult(new HttpResponseMessage() { Content =

--- a/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectEventTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/OpenIdConnect/OpenIdConnectEventTests.cs
@@ -750,8 +750,8 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 ExpectUserInfoReceived = true,
             };
 
-            var clientId = "a-test-client";
-            var clientSecret = "asecret";
+            var clientId = "@!12AD!0008!6D30.23D7";
+            var clientSecret = "P@55W0rd!";
             AuthenticationHeaderValue authorization = null;
             var server = CreateServer(events, AppWritePath,
                 option =>
@@ -772,7 +772,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
             await PostAsync(server, "signin-oidc", "id_token=my_id_token&state=protected_state&code=my_code");
             
             Assert.Equal("Basic",authorization.Scheme);
-            Assert.Equal(Convert.ToBase64String(Encoding.UTF8.GetBytes(clientId+":"+clientSecret)),authorization.Parameter);
+            Assert.Equal("JTQwJTIxMTJBRCUyMTAwMDglMjE2RDMwLjIzRDc6UCU0MDU1VzByZCUyMQ==",authorization.Parameter);
         }
 
         [Fact]


### PR DESCRIPTION
Introduce the possibility to configure the client authentication mode on access_token endpoint https://tools.ietf.org/html/rfc6749#section-2.3.1

this is another proposal that not break the current behavior and allow basic auth for 
Encode ClientId/Secret in Basic Authorization Header per OIDC Spec #1738