### PR TITLE
Fix regression in Cookies

### DIFF
--- a/.vsts-pipelines/builds/ci-internal.yml
+++ b/.vsts-pipelines/builds/ci-internal.yml
@@ -1,0 +1,13 @@
+trigger:
+- dev
+- release/*
+
+resources:
+  repositories:
+  - repository: buildtools
+    type: git
+    name: aspnet-BuildTools
+    ref: refs/heads/dev
+
+phases:
+- template: .vsts-pipelines/templates/project-ci.yml@buildtools

--- a/.vsts-pipelines/builds/ci-public.yml
+++ b/.vsts-pipelines/builds/ci-public.yml
@@ -1,0 +1,15 @@
+trigger:
+- dev
+- release/*
+
+# See https://github.com/aspnet/BuildTools
+resources:
+  repositories:
+  - repository: buildtools
+    type: github
+    endpoint: DotNet-Bot GitHub Connection
+    name: aspnet/BuildTools
+    ref: refs/heads/dev
+    
+phases:
+- template: .vsts-pipelines/templates/project-ci.yml@buildtools

--- a/run.sh
+++ b/run.sh
@@ -14,10 +14,12 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 [ -z "${DOTNET_HOME:-}" ] && DOTNET_HOME="$HOME/.dotnet"
 verbose=false
 update=false
+reinstall=false
 repo_path="$DIR"
 channel=''
 tools_source=''
 tools_source_suffix=''
+ci=false
 
 #
 # Functions
@@ -38,6 +40,8 @@ __usage() {
     echo "    -s|--tools-source|-ToolsSource <URL>                  The base url where build tools can be downloaded. Overrides the value from the config file."
     echo "    --tools-source-suffix|-ToolsSourceSuffix <SUFFIX>     The suffix to append to tools-source. Useful for query strings."
     echo "    -u|--update                                           Update to the latest KoreBuild even if the lock file is present."
+    echo "    --reinstall                                           Reinstall KoreBuild."
+    echo "    --ci                                                  Apply CI specific settings and environment variables."
     echo ""
     echo "Description:"
     echo "    This function will create a file \$DIR/korebuild-lock.txt. This lock file can be committed to source, but does not have to be."
@@ -61,6 +65,10 @@ get_korebuild() {
     fi
     version="$(echo "${version#version:}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
     local korebuild_path="$DOTNET_HOME/buildtools/korebuild/$version"
+
+    if [ "$reinstall" = true ] && [ -d "$korebuild_path" ]; then
+        rm -rf "$korebuild_path"
+    fi
 
     {
         if [ ! -d "$korebuild_path" ]; then
@@ -175,6 +183,12 @@ while [[ $# -gt 0 ]]; do
         -u|--update|-Update)
             update=true
             ;;
+        --reinstall|-[Rr]einstall)
+            reinstall=true
+            ;;
+        --ci|-[Cc][Ii])
+            ci=true
+            ;;
         --verbose|-Verbose)
             verbose=true
             ;;
@@ -206,17 +220,28 @@ if [ -f "$config_file" ]; then
             config_channel="$(jq -r 'select(.channel!=null) | .channel' "$config_file")"
             config_tools_source="$(jq -r 'select(.toolsSource!=null) | .toolsSource' "$config_file")"
         else
-            __warn "$config_file is invalid JSON. Its settings will be ignored."
+            _error "$config_file contains invalid JSON."
+            exit 1
         fi
     elif __machine_has python ; then
         if python -c "import json,codecs;obj=json.load(codecs.open('$config_file', 'r', 'utf-8-sig'))" >/dev/null ; then
             config_channel="$(python -c "import json,codecs;obj=json.load(codecs.open('$config_file', 'r', 'utf-8-sig'));print(obj['channel'] if 'channel' in obj else '')")"
             config_tools_source="$(python -c "import json,codecs;obj=json.load(codecs.open('$config_file', 'r', 'utf-8-sig'));print(obj['toolsSource'] if 'toolsSource' in obj else '')")"
         else
-            __warn "$config_file is invalid JSON. Its settings will be ignored."
+            _error "$config_file contains invalid JSON."
+            exit 1
+        fi
+    elif __machine_has python3 ; then
+        if python3 -c "import json,codecs;obj=json.load(codecs.open('$config_file', 'r', 'utf-8-sig'))" >/dev/null ; then
+            config_channel="$(python3 -c "import json,codecs;obj=json.load(codecs.open('$config_file', 'r', 'utf-8-sig'));print(obj['channel'] if 'channel' in obj else '')")"
+            config_tools_source="$(python3 -c "import json,codecs;obj=json.load(codecs.open('$config_file', 'r', 'utf-8-sig'));print(obj['toolsSource'] if 'toolsSource' in obj else '')")"
+        else
+            _error "$config_file contains invalid JSON."
+            exit 1
         fi
     else
-        __warn 'Missing required command: jq or pyton. Could not parse the JSON file. Its settings will be ignored.'
+        _error 'Missing required command: jq or python. Could not parse the JSON file.'
+        exit 1
     fi
 
     [ ! -z "${config_channel:-}" ] && channel="$config_channel"
@@ -227,5 +252,5 @@ fi
 [ -z "$tools_source" ] && tools_source='https://aspnetcore.blob.core.windows.net/buildtools'
 
 get_korebuild
-set_korebuildsettings "$tools_source" "$DOTNET_HOME" "$repo_path" "$config_file"
+set_korebuildsettings "$tools_source" "$DOTNET_HOME" "$repo_path" "$config_file" "$ci"
 invoke_korebuild_command "$command" "$@"

--- a/samples/CookiePolicySample/Startup.cs
+++ b/samples/CookiePolicySample/Startup.cs
@@ -58,6 +58,13 @@ namespace CookiePolicySample
                     case "/RemoveTempCookie":
                         context.Response.Cookies.Delete("Temp");
                         break;
+                    case "/CreateEssentialCookie":
+                        context.Response.Cookies.Append("EssentialCookie", "2",
+                            new CookieOptions() { IsEssential = true });
+                        break;
+                    case "/RemoveEssentialCookie":
+                        context.Response.Cookies.Delete("EssentialCookie");
+                        break;
                     case "/GrantConsent":
                         context.Features.Get<ITrackingConsentFeature>().GrantConsent();
                         break;
@@ -84,6 +91,8 @@ namespace CookiePolicySample
             await response.WriteAsync($"<a href=\"{context.Request.PathBase}/Logout\">Logout</a><br>\r\n");
             await response.WriteAsync($"<a href=\"{context.Request.PathBase}/CreateTempCookie\">Create Temp Cookie</a><br>\r\n");
             await response.WriteAsync($"<a href=\"{context.Request.PathBase}/RemoveTempCookie\">Remove Temp Cookie</a><br>\r\n");
+            await response.WriteAsync($"<a href=\"{context.Request.PathBase}/CreateEssentialCookie\">Create Essential Cookie</a><br>\r\n");
+            await response.WriteAsync($"<a href=\"{context.Request.PathBase}/RemoveEssentialCookie\">Remove Essential Cookie</a><br>\r\n");
             await response.WriteAsync($"<a href=\"{context.Request.PathBase}/GrantConsent\">Grant Consent</a><br>\r\n");
             await response.WriteAsync($"<a href=\"{context.Request.PathBase}/WithdrawConsent\">Withdraw Consent</a><br>\r\n");
             await response.WriteAsync("<br>\r\n");

--- a/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.JwtBearer/JwtBearerHandler.cs
@@ -32,8 +32,8 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
         /// </summary>
         protected new JwtBearerEvents Events
         {
-            get { return (JwtBearerEvents)base.Events; }
-            set { base.Events = value; }
+            get => (JwtBearerEvents)base.Events;
+            set => base.Events = value;
         }
 
         protected override Task<object> CreateEventsAsync() => Task.FromResult<object>(new JwtBearerEvents());
@@ -267,9 +267,8 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
         private static string CreateErrorDescription(Exception authFailure)
         {
             IEnumerable<Exception> exceptions;
-            if (authFailure is AggregateException)
+            if (authFailure is AggregateException agEx)
             {
-                var agEx = authFailure as AggregateException;
                 exceptions = agEx.InnerExceptions;
             }
             else
@@ -283,37 +282,32 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
             {
                 // Order sensitive, some of these exceptions derive from others
                 // and we want to display the most specific message possible.
-                if (ex is SecurityTokenInvalidAudienceException)
+                switch (ex)
                 {
-                    messages.Add("The audience is invalid");
-                }
-                else if (ex is SecurityTokenInvalidIssuerException)
-                {
-                    messages.Add("The issuer is invalid");
-                }
-                else if (ex is SecurityTokenNoExpirationException)
-                {
-                    messages.Add("The token has no expiration");
-                }
-                else if (ex is SecurityTokenInvalidLifetimeException)
-                {
-                    messages.Add("The token lifetime is invalid");
-                }
-                else if (ex is SecurityTokenNotYetValidException)
-                {
-                    messages.Add("The token is not valid yet");
-                }
-                else if (ex is SecurityTokenExpiredException)
-                {
-                    messages.Add("The token is expired");
-                }
-                else if (ex is SecurityTokenSignatureKeyNotFoundException)
-                {
-                    messages.Add("The signature key was not found");
-                }
-                else if (ex is SecurityTokenInvalidSignatureException)
-                {
-                    messages.Add("The signature is invalid");
+                    case SecurityTokenInvalidAudienceException _:
+                        messages.Add("The audience is invalid");
+                        break;
+                    case SecurityTokenInvalidIssuerException _:
+                        messages.Add("The issuer is invalid");
+                        break;
+                    case SecurityTokenNoExpirationException _:
+                        messages.Add("The token has no expiration");
+                        break;
+                    case SecurityTokenInvalidLifetimeException _:
+                        messages.Add("The token lifetime is invalid");
+                        break;
+                    case SecurityTokenNotYetValidException _:
+                        messages.Add("The token is not valid yet");
+                        break;
+                    case SecurityTokenExpiredException _:
+                        messages.Add("The token is expired");
+                        break;
+                    case SecurityTokenSignatureKeyNotFoundException _:
+                        messages.Add("The signature key was not found");
+                        break;
+                    case SecurityTokenInvalidSignatureException _:
+                        messages.Add("The signature is invalid");
+                        break;
                 }
             }
 

--- a/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterHandler.cs
@@ -148,53 +148,92 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
             await Events.RedirectToAuthorizationEndpoint(redirectContext);
         }
 
-        private async Task<RequestToken> ObtainRequestTokenAsync(string callBackUri, AuthenticationProperties properties)
+        private async Task<HttpResponseMessage> ExecuteRequestAsync(string url, HttpMethod httpMethod, RequestToken accessToken = null, Dictionary<string, string> extraOAuthPairs = null, Dictionary<string, string> queryParameters = null, Dictionary<string, string> formData = null)
         {
-            Logger.ObtainRequestToken();
-
-            var nonce = Guid.NewGuid().ToString("N");
-
-            var authorizationParts = new SortedDictionary<string, string>
+            var authorizationParts = new SortedDictionary<string, string>(extraOAuthPairs ?? new Dictionary<string, string>())
             {
-                { "oauth_callback", callBackUri },
                 { "oauth_consumer_key", Options.ConsumerKey },
-                { "oauth_nonce", nonce },
+                { "oauth_nonce", Guid.NewGuid().ToString("N") },
                 { "oauth_signature_method", "HMAC-SHA1" },
                 { "oauth_timestamp", GenerateTimeStamp() },
                 { "oauth_version", "1.0" }
             };
 
-            var parameterBuilder = new StringBuilder();
-            foreach (var authorizationKey in authorizationParts)
+            if (accessToken != null)
             {
-                parameterBuilder.AppendFormat("{0}={1}&", UrlEncoder.Encode(authorizationKey.Key), UrlEncoder.Encode(authorizationKey.Value));
+                authorizationParts.Add("oauth_token", accessToken.Token);
+            }
+
+            var signatureParts = new SortedDictionary<string, string>(authorizationParts);
+            if (queryParameters != null)
+            {
+                foreach (var queryParameter in queryParameters)
+                {
+                    signatureParts.Add(queryParameter.Key, queryParameter.Value);
+                }
+            }
+            if (formData != null)
+            {
+                foreach (var formItem in formData)
+                {
+                    signatureParts.Add(formItem.Key, formItem.Value);
+                }
+            }
+
+            var parameterBuilder = new StringBuilder();
+            foreach (var signaturePart in signatureParts)
+            {
+                parameterBuilder.AppendFormat("{0}={1}&", Uri.EscapeDataString(signaturePart.Key), Uri.EscapeDataString(signaturePart.Value));
             }
             parameterBuilder.Length--;
             var parameterString = parameterBuilder.ToString();
 
             var canonicalizedRequestBuilder = new StringBuilder();
-            canonicalizedRequestBuilder.Append(HttpMethod.Post.Method);
+            canonicalizedRequestBuilder.Append(httpMethod.Method);
             canonicalizedRequestBuilder.Append("&");
-            canonicalizedRequestBuilder.Append(UrlEncoder.Encode(RequestTokenEndpoint));
+            canonicalizedRequestBuilder.Append(Uri.EscapeDataString(url));
             canonicalizedRequestBuilder.Append("&");
-            canonicalizedRequestBuilder.Append(UrlEncoder.Encode(parameterString));
+            canonicalizedRequestBuilder.Append(Uri.EscapeDataString(parameterString));
 
-            var signature = ComputeSignature(Options.ConsumerSecret, null, canonicalizedRequestBuilder.ToString());
+            var signature = ComputeSignature(Options.ConsumerSecret, accessToken?.TokenSecret, canonicalizedRequestBuilder.ToString());
             authorizationParts.Add("oauth_signature", signature);
+
+            var queryString = "";
+            if (queryParameters != null)
+            {
+                var queryStringBuilder = new StringBuilder("?");
+                foreach (var queryParam in queryParameters)
+                {
+                    queryStringBuilder.AppendFormat("{0}={1}&", queryParam.Key, queryParam.Value);
+                }
+                queryStringBuilder.Length--;
+                queryString = queryStringBuilder.ToString();
+            }
 
             var authorizationHeaderBuilder = new StringBuilder();
             authorizationHeaderBuilder.Append("OAuth ");
             foreach (var authorizationPart in authorizationParts)
             {
-                authorizationHeaderBuilder.AppendFormat(
-                    "{0}=\"{1}\", ", authorizationPart.Key, UrlEncoder.Encode(authorizationPart.Value));
+                authorizationHeaderBuilder.AppendFormat("{0}=\"{1}\",", authorizationPart.Key, Uri.EscapeDataString(authorizationPart.Value));
             }
-            authorizationHeaderBuilder.Length = authorizationHeaderBuilder.Length - 2;
+            authorizationHeaderBuilder.Length--;
 
-            var request = new HttpRequestMessage(HttpMethod.Post, RequestTokenEndpoint);
+            var request = new HttpRequestMessage(httpMethod, url + queryString);
             request.Headers.Add("Authorization", authorizationHeaderBuilder.ToString());
 
-            var response = await Backchannel.SendAsync(request, Context.RequestAborted);
+            if (formData != null)
+            {
+                request.Content = new FormUrlEncodedContent(formData);
+            }
+
+            return await Backchannel.SendAsync(request, Context.RequestAborted);
+        }
+
+        private async Task<RequestToken> ObtainRequestTokenAsync(string callBackUri, AuthenticationProperties properties)
+        {
+            Logger.ObtainRequestToken();
+
+            var response = await ExecuteRequestAsync(RequestTokenEndpoint, HttpMethod.Post, extraOAuthPairs: new Dictionary<string, string>() { { "oauth_callback", callBackUri } });
             response.EnsureSuccessStatusCode();
             var responseText = await response.Content.ReadAsStringAsync();
 
@@ -213,58 +252,8 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
 
             Logger.ObtainAccessToken();
 
-            var nonce = Guid.NewGuid().ToString("N");
-
-            var authorizationParts = new SortedDictionary<string, string>
-            {
-                { "oauth_consumer_key", Options.ConsumerKey },
-                { "oauth_nonce", nonce },
-                { "oauth_signature_method", "HMAC-SHA1" },
-                { "oauth_token", token.Token },
-                { "oauth_timestamp", GenerateTimeStamp() },
-                { "oauth_verifier", verifier },
-                { "oauth_version", "1.0" },
-            };
-
-            var parameterBuilder = new StringBuilder();
-            foreach (var authorizationKey in authorizationParts)
-            {
-                parameterBuilder.AppendFormat("{0}={1}&", UrlEncoder.Encode(authorizationKey.Key), UrlEncoder.Encode(authorizationKey.Value));
-            }
-            parameterBuilder.Length--;
-            var parameterString = parameterBuilder.ToString();
-
-            var canonicalizedRequestBuilder = new StringBuilder();
-            canonicalizedRequestBuilder.Append(HttpMethod.Post.Method);
-            canonicalizedRequestBuilder.Append("&");
-            canonicalizedRequestBuilder.Append(UrlEncoder.Encode(AccessTokenEndpoint));
-            canonicalizedRequestBuilder.Append("&");
-            canonicalizedRequestBuilder.Append(UrlEncoder.Encode(parameterString));
-
-            var signature = ComputeSignature(Options.ConsumerSecret, token.TokenSecret, canonicalizedRequestBuilder.ToString());
-            authorizationParts.Add("oauth_signature", signature);
-            authorizationParts.Remove("oauth_verifier");
-
-            var authorizationHeaderBuilder = new StringBuilder();
-            authorizationHeaderBuilder.Append("OAuth ");
-            foreach (var authorizationPart in authorizationParts)
-            {
-                authorizationHeaderBuilder.AppendFormat(
-                    "{0}=\"{1}\", ", authorizationPart.Key, UrlEncoder.Encode(authorizationPart.Value));
-            }
-            authorizationHeaderBuilder.Length = authorizationHeaderBuilder.Length - 2;
-
-            var request = new HttpRequestMessage(HttpMethod.Post, AccessTokenEndpoint);
-            request.Headers.Add("Authorization", authorizationHeaderBuilder.ToString());
-
-            var formPairs = new Dictionary<string, string>()
-            {
-                { "oauth_verifier", verifier },
-            };
-
-            request.Content = new FormUrlEncodedContent(formPairs);
-
-            var response = await Backchannel.SendAsync(request, Context.RequestAborted);
+            var formPost = new Dictionary<string, string> { { "oauth_verifier", verifier } };
+            var response = await ExecuteRequestAsync(AccessTokenEndpoint, HttpMethod.Post, token, formData: formPost);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -289,53 +278,8 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
         {
             Logger.RetrieveUserDetails();
 
-            var nonce = Guid.NewGuid().ToString("N");
+            var response = await ExecuteRequestAsync("https://api.twitter.com/1.1/account/verify_credentials.json", HttpMethod.Get, accessToken, queryParameters: new Dictionary<string, string>() { { "include_email", "true" } });
 
-            var authorizationParts = new SortedDictionary<string, string>
-                        {
-                            { "oauth_consumer_key", Options.ConsumerKey },
-                            { "oauth_nonce", nonce },
-                            { "oauth_signature_method", "HMAC-SHA1" },
-                            { "oauth_timestamp", GenerateTimeStamp() },
-                            { "oauth_token", accessToken.Token },
-                            { "oauth_version", "1.0" }
-                        };
-
-            var parameterBuilder = new StringBuilder();
-            foreach (var authorizationKey in authorizationParts)
-            {
-                parameterBuilder.AppendFormat("{0}={1}&", UrlEncoder.Encode(authorizationKey.Key), UrlEncoder.Encode(authorizationKey.Value));
-            }
-            parameterBuilder.Length--;
-            var parameterString = parameterBuilder.ToString();
-
-            var resource_url = "https://api.twitter.com/1.1/account/verify_credentials.json";
-            var resource_query = "include_email=true";
-            var canonicalizedRequestBuilder = new StringBuilder();
-            canonicalizedRequestBuilder.Append(HttpMethod.Get.Method);
-            canonicalizedRequestBuilder.Append("&");
-            canonicalizedRequestBuilder.Append(UrlEncoder.Encode(resource_url));
-            canonicalizedRequestBuilder.Append("&");
-            canonicalizedRequestBuilder.Append(UrlEncoder.Encode(resource_query));
-            canonicalizedRequestBuilder.Append("%26");
-            canonicalizedRequestBuilder.Append(UrlEncoder.Encode(parameterString));
-
-            var signature = ComputeSignature(Options.ConsumerSecret, accessToken.TokenSecret, canonicalizedRequestBuilder.ToString());
-            authorizationParts.Add("oauth_signature", signature);
-
-            var authorizationHeaderBuilder = new StringBuilder();
-            authorizationHeaderBuilder.Append("OAuth ");
-            foreach (var authorizationPart in authorizationParts)
-            {
-                authorizationHeaderBuilder.AppendFormat(
-                    "{0}=\"{1}\", ", authorizationPart.Key, UrlEncoder.Encode(authorizationPart.Value));
-            }
-            authorizationHeaderBuilder.Length = authorizationHeaderBuilder.Length - 2;
-
-            var request = new HttpRequestMessage(HttpMethod.Get, resource_url + "?include_email=true");
-            request.Headers.Add("Authorization", authorizationHeaderBuilder.ToString());
-
-            var response = await Backchannel.SendAsync(request, Context.RequestAborted);
             if (!response.IsSuccessStatusCode)
             {
                 Logger.LogError("Email request failed with a status code of " + response.StatusCode);
@@ -361,8 +305,8 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
                 algorithm.Key = Encoding.ASCII.GetBytes(
                     string.Format(CultureInfo.InvariantCulture,
                         "{0}&{1}",
-                        UrlEncoder.Encode(consumerSecret),
-                        string.IsNullOrEmpty(tokenSecret) ? string.Empty : UrlEncoder.Encode(tokenSecret)));
+                        Uri.EscapeDataString(consumerSecret),
+                        string.IsNullOrEmpty(tokenSecret) ? string.Empty : Uri.EscapeDataString(tokenSecret)));
                 var hash = algorithm.ComputeHash(Encoding.ASCII.GetBytes(signatureData));
                 return Convert.ToBase64String(hash);
             }

--- a/src/Microsoft.AspNetCore.Authentication/HandleRequestResult.cs
+++ b/src/Microsoft.AspNetCore.Authentication/HandleRequestResult.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Authentication
             {
                 throw new ArgumentNullException(nameof(ticket));
             }
-            return new HandleRequestResult() { Ticket = ticket };
+            return new HandleRequestResult() { Ticket = ticket, Properties = ticket.Properties };
         }
 
         /// <summary>


### PR DESCRIPTION
Fix for https://github.com/aspnet/Security/issues/1788

CookieCanBeUpdatedByValidatorDuringRefresh is the new regression test that fails for the identity scenario.

@Tratcher @ajcvickers @blowdart 