### PR TITLE
Change description of role in RequireRole method

### DIFF
--- a/src/Microsoft.AspNetCore.Authorization/AuthorizationPolicyBuilder.cs
+++ b/src/Microsoft.AspNetCore.Authorization/AuthorizationPolicyBuilder.cs
@@ -147,7 +147,7 @@ namespace Microsoft.AspNetCore.Authorization
         /// Adds a <see cref="RolesAuthorizationRequirement"/>
         /// to the current instance.
         /// </summary>
-        /// <param name="roles">The roles required.</param>
+        /// <param name="roles">The allowed roles.</param>
         /// <returns>A reference to this instance after the operation has completed.</returns>
         public AuthorizationPolicyBuilder RequireRole(params string[] roles)
         {
@@ -163,7 +163,7 @@ namespace Microsoft.AspNetCore.Authorization
         /// Adds a <see cref="RolesAuthorizationRequirement"/>
         /// to the current instance.
         /// </summary>
-        /// <param name="roles">The roles required.</param>
+        /// <param name="roles">The allowed roles.</param>
         /// <returns>A reference to this instance after the operation has completed.</returns>
         public AuthorizationPolicyBuilder RequireRole(IEnumerable<string> roles)
         {


### PR DESCRIPTION
The description of the pram roles feels ambiguous. Make it clear that the user should belong to one of the roles and not all of them.
As documented: https://docs.microsoft.com/en-us/aspnet/core/security/authorization/roles?view=aspnetcore-2.1