### PR TITLE
Update Facebook to v3.1 endpoints

### DIFF
--- a/samples/SocialSample/Startup.cs
+++ b/samples/SocialSample/Startup.cs
@@ -59,6 +59,7 @@ namespace SocialSample
                 .AddCookie(o => o.LoginPath = new PathString("/login"))
                 // You must first create an app with Facebook and add its ID and Secret to your user-secrets.
                 // https://developers.facebook.com/apps/
+                // https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow#login
                 .AddFacebook(o =>
             {
                 o.AppId = Configuration["facebook:appid"];
@@ -74,6 +75,8 @@ namespace SocialSample
             })
                 // You must first create an app with Google and add its ID and Secret to your user-secrets.
                 // https://console.developers.google.com/project
+                // https://developers.google.com/identity/protocols/OAuth2WebServer
+                // https://developers.google.com/+/web/people/
                 .AddOAuth("Google-AccessToken", "Google AccessToken only", o =>
             {
                 o.ClientId = Configuration["google:clientid"];
@@ -92,6 +95,8 @@ namespace SocialSample
             })
                 // You must first create an app with Google and add its ID and Secret to your user-secrets.
                 // https://console.developers.google.com/project
+                // https://developers.google.com/identity/protocols/OAuth2WebServer
+                // https://developers.google.com/+/web/people/
                 .AddGoogle(o =>
             {
                 o.ClientId = Configuration["google:clientid"];
@@ -108,6 +113,7 @@ namespace SocialSample
             })
                 // You must first create an app with Twitter and add its key and Secret to your user-secrets.
                 // https://apps.twitter.com/
+                // https://developer.twitter.com/en/docs/basics/authentication/api-reference/access_token
                 .AddTwitter(o =>
             {
                 o.ConsumerKey = Configuration["twitter:consumerkey"];

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookDefaults.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookDefaults.cs
@@ -9,10 +9,11 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
 
         public static readonly string DisplayName = "Facebook";
 
-        public static readonly string AuthorizationEndpoint = "https://www.facebook.com/v2.12/dialog/oauth";
+        // https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow#login
+        public static readonly string AuthorizationEndpoint = "https://www.facebook.com/v3.1/dialog/oauth";
 
-        public static readonly string TokenEndpoint = "https://graph.facebook.com/v2.12/oauth/access_token";
+        public static readonly string TokenEndpoint = "https://graph.facebook.com/v3.1/oauth/access_token";
 
-        public static readonly string UserInformationEndpoint = "https://graph.facebook.com/v2.12/me";
+        public static readonly string UserInformationEndpoint = "https://graph.facebook.com/v3.1/me";
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookOptions.cs
@@ -26,7 +26,6 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             AuthorizationEndpoint = FacebookDefaults.AuthorizationEndpoint;
             TokenEndpoint = FacebookDefaults.TokenEndpoint;
             UserInformationEndpoint = FacebookDefaults.UserInformationEndpoint;
-            Scope.Add("public_profile");
             Scope.Add("email");
             Fields.Add("name");
             Fields.Add("email");

--- a/src/Microsoft.AspNetCore.Authentication.Google/GoogleDefaults.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Google/GoogleDefaults.cs
@@ -12,10 +12,12 @@ namespace Microsoft.AspNetCore.Authentication.Google
 
         public static readonly string DisplayName = "Google";
 
+        // https://developers.google.com/identity/protocols/OAuth2WebServer
         public static readonly string AuthorizationEndpoint = "https://accounts.google.com/o/oauth2/v2/auth";
 
         public static readonly string TokenEndpoint = "https://www.googleapis.com/oauth2/v4/token";
 
+        // https://developers.google.com/+/web/people/
         public static readonly string UserInformationEndpoint = "https://www.googleapis.com/plus/v1/people/me";
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountDefaults.cs
+++ b/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount/MicrosoftAccountDefaults.cs
@@ -9,6 +9,7 @@ namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
 
         public static readonly string DisplayName = "Microsoft";
 
+        // https://developer.microsoft.com/en-us/graph/docs/concepts/auth_v2_user
         public static readonly string AuthorizationEndpoint = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize";
 
         public static readonly string TokenEndpoint = "https://login.microsoftonline.com/common/oauth2/v2.0/token";

--- a/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterDefaults.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterDefaults.cs
@@ -8,5 +8,14 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
         public const string AuthenticationScheme = "Twitter";
 
         public static readonly string DisplayName = "Twitter";
+
+        // https://developer.twitter.com/en/docs/basics/authentication/api-reference/request_token
+        internal const string RequestTokenEndpoint = "https://api.twitter.com/oauth/request_token";
+
+        // https://developer.twitter.com/en/docs/basics/authentication/api-reference/authenticate
+        internal const string AuthenticationEndpoint = "https://api.twitter.com/oauth/authenticate?oauth_token=";
+
+        // https://developer.twitter.com/en/docs/basics/authentication/api-reference/access_token
+        internal const string AccessTokenEndpoint = "https://api.twitter.com/oauth/access_token";
     }
 }

--- a/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterHandler.cs
+++ b/src/Microsoft.AspNetCore.Authentication.Twitter/TwitterHandler.cs
@@ -22,9 +22,6 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
     public class TwitterHandler : RemoteAuthenticationHandler<TwitterOptions>
     {
         private static readonly DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-        private const string RequestTokenEndpoint = "https://api.twitter.com/oauth/request_token";
-        private const string AuthenticationEndpoint = "https://api.twitter.com/oauth/authenticate?oauth_token=";
-        private const string AccessTokenEndpoint = "https://api.twitter.com/oauth/access_token";
 
         private HttpClient Backchannel => Options.Backchannel;
 
@@ -138,7 +135,7 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
 
             // If CallbackConfirmed is false, this will throw
             var requestToken = await ObtainRequestTokenAsync(BuildRedirectUri(Options.CallbackPath), properties);
-            var twitterAuthenticationEndpoint = AuthenticationEndpoint + requestToken.Token;
+            var twitterAuthenticationEndpoint = TwitterDefaults.AuthenticationEndpoint + requestToken.Token;
 
             var cookieOptions = Options.StateCookie.Build(Context, Clock.UtcNow);
 
@@ -233,7 +230,7 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
         {
             Logger.ObtainRequestToken();
 
-            var response = await ExecuteRequestAsync(RequestTokenEndpoint, HttpMethod.Post, extraOAuthPairs: new Dictionary<string, string>() { { "oauth_callback", callBackUri } });
+            var response = await ExecuteRequestAsync(TwitterDefaults.RequestTokenEndpoint, HttpMethod.Post, extraOAuthPairs: new Dictionary<string, string>() { { "oauth_callback", callBackUri } });
             response.EnsureSuccessStatusCode();
             var responseText = await response.Content.ReadAsStringAsync();
 
@@ -253,7 +250,7 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
             Logger.ObtainAccessToken();
 
             var formPost = new Dictionary<string, string> { { "oauth_verifier", verifier } };
-            var response = await ExecuteRequestAsync(AccessTokenEndpoint, HttpMethod.Post, token, formData: formPost);
+            var response = await ExecuteRequestAsync(TwitterDefaults.AccessTokenEndpoint, HttpMethod.Post, token, formData: formPost);
 
             if (!response.IsSuccessStatusCode)
             {

--- a/test/Microsoft.AspNetCore.Authentication.Test/FacebookTests.cs
+++ b/test/Microsoft.AspNetCore.Authentication.Test/FacebookTests.cs
@@ -673,7 +673,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             var transaction = await server.SendAsync("http://example.com/base/login");
             Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var location = transaction.Response.Headers.Location.AbsoluteUri;
-            Assert.Contains("https://www.facebook.com/v2.12/dialog/oauth", location);
+            Assert.Contains("https://www.facebook.com/v3.1/dialog/oauth", location);
             Assert.Contains("response_type=code", location);
             Assert.Contains("client_id=", location);
             Assert.Contains("redirect_uri=" + UrlEncoder.Default.Encode("http://example.com/base/signin-facebook"), location);
@@ -705,7 +705,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             var transaction = await server.SendAsync("http://example.com/login");
             Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var location = transaction.Response.Headers.Location.AbsoluteUri;
-            Assert.Contains("https://www.facebook.com/v2.12/dialog/oauth", location);
+            Assert.Contains("https://www.facebook.com/v3.1/dialog/oauth", location);
             Assert.Contains("response_type=code", location);
             Assert.Contains("client_id=", location);
             Assert.Contains("redirect_uri=" + UrlEncoder.Default.Encode("http://example.com/signin-facebook"), location);
@@ -739,7 +739,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             var transaction = await server.SendAsync("http://example.com/challenge");
             Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var location = transaction.Response.Headers.Location.AbsoluteUri;
-            Assert.Contains("https://www.facebook.com/v2.12/dialog/oauth", location);
+            Assert.Contains("https://www.facebook.com/v3.1/dialog/oauth", location);
             Assert.Contains("response_type=code", location);
             Assert.Contains("client_id=", location);
             Assert.Contains("redirect_uri=", location);


### PR DESCRIPTION
#92 Facebook has changed its API version from v2.12 to v3.1. It has also removed the public_profile scope, this permission is available by default. See https://developers.facebook.com/docs/graph-api/changelog/version3.0#login

None of the other providers have made any relevant API changes. I did add some doc links for next time.