### PR TITLE
Eliminate allocations in AuthorizationPolicy.CombineAsync with no policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ project.lock.json
 /.vs/
 .vscode/
 global.json
+BenchmarkDotNet.Artifacts/

--- a/Security.sln
+++ b/Security.sln
@@ -79,6 +79,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Authen
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WsFedSample", "samples\WsFedSample\WsFedSample.csproj", "{5EC2E398-E46A-430D-8E4B-E91C8FC3E800}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmarks", "benchmarks", "{55052FE3-F8C2-4E6C-97B0-C02ED1DBEA62}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Security.Performance", "benchmarks\Microsoft.AspNetCore.Security.Performance\Microsoft.AspNetCore.Security.Performance.csproj", "{556C4FAA-F4B1-4EA9-8921-CB1DF7D94C2A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -517,6 +521,22 @@ Global
 		{5EC2E398-E46A-430D-8E4B-E91C8FC3E800}.Release|x64.Build.0 = Release|Any CPU
 		{5EC2E398-E46A-430D-8E4B-E91C8FC3E800}.Release|x86.ActiveCfg = Release|Any CPU
 		{5EC2E398-E46A-430D-8E4B-E91C8FC3E800}.Release|x86.Build.0 = Release|Any CPU
+		{556C4FAA-F4B1-4EA9-8921-CB1DF7D94C2A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{556C4FAA-F4B1-4EA9-8921-CB1DF7D94C2A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{556C4FAA-F4B1-4EA9-8921-CB1DF7D94C2A}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{556C4FAA-F4B1-4EA9-8921-CB1DF7D94C2A}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{556C4FAA-F4B1-4EA9-8921-CB1DF7D94C2A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{556C4FAA-F4B1-4EA9-8921-CB1DF7D94C2A}.Debug|x64.Build.0 = Debug|Any CPU
+		{556C4FAA-F4B1-4EA9-8921-CB1DF7D94C2A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{556C4FAA-F4B1-4EA9-8921-CB1DF7D94C2A}.Debug|x86.Build.0 = Debug|Any CPU
+		{556C4FAA-F4B1-4EA9-8921-CB1DF7D94C2A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{556C4FAA-F4B1-4EA9-8921-CB1DF7D94C2A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{556C4FAA-F4B1-4EA9-8921-CB1DF7D94C2A}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{556C4FAA-F4B1-4EA9-8921-CB1DF7D94C2A}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{556C4FAA-F4B1-4EA9-8921-CB1DF7D94C2A}.Release|x64.ActiveCfg = Release|Any CPU
+		{556C4FAA-F4B1-4EA9-8921-CB1DF7D94C2A}.Release|x64.Build.0 = Release|Any CPU
+		{556C4FAA-F4B1-4EA9-8921-CB1DF7D94C2A}.Release|x86.ActiveCfg = Release|Any CPU
+		{556C4FAA-F4B1-4EA9-8921-CB1DF7D94C2A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -549,6 +569,7 @@ Global
 		{24A28F5D-E5A9-4CA8-B0D2-924A1F8BE14E} = {F8C0AA27-F3FB-4286-8E4C-47EF86B539FF}
 		{B1FC6AAF-9BF2-4CDA-84A2-AA8BF7603F29} = {4D2B6A51-2F9F-44F5-8131-EA5CAC053652}
 		{5EC2E398-E46A-430D-8E4B-E91C8FC3E800} = {F8C0AA27-F3FB-4286-8E4C-47EF86B539FF}
+		{556C4FAA-F4B1-4EA9-8921-CB1DF7D94C2A} = {55052FE3-F8C2-4E6C-97B0-C02ED1DBEA62}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {ABF8089E-43D0-4010-84A7-7A9DCFE49357}

--- a/benchmarks/Microsoft.AspNetCore.Security.Performance/AuthorizationMiddlewareBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.Security.Performance/AuthorizationMiddlewareBenchmark.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Security
+{
+    public class AuthorizationMiddlewareBenchmark
+    {
+        private AuthorizationMiddleware _authorizationMiddleware;
+        private DefaultHttpContext _httpContextNoEndpoint;
+        private DefaultHttpContext _httpContextHasEndpoint;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var policyProvider = new DefaultAuthorizationPolicyProvider(Options.Create(new AuthorizationOptions()));
+            _authorizationMiddleware = new AuthorizationMiddleware((context) => Task.CompletedTask, policyProvider);
+
+            _httpContextNoEndpoint = new DefaultHttpContext();
+
+            var feature = new EndpointFeature
+            {
+                Endpoint = new Endpoint((context) => Task.CompletedTask, EndpointMetadataCollection.Empty, "Test endpoint")
+            };
+            _httpContextHasEndpoint = new DefaultHttpContext();
+            _httpContextHasEndpoint.Features.Set<IEndpointFeature>(feature);
+        }
+
+        [Benchmark]
+        public Task Invoke_NoEndpoint_NoAuthorization()
+        {
+            return _authorizationMiddleware.Invoke(_httpContextNoEndpoint);
+        }
+
+        [Benchmark]
+        public Task Invoke_HasEndpoint_NoAuthorization()
+        {
+            return _authorizationMiddleware.Invoke(_httpContextHasEndpoint);
+        }
+
+        private class EndpointFeature : IEndpointFeature
+        {
+            public Endpoint Endpoint { get; set; }
+        }
+    }
+}

--- a/benchmarks/Microsoft.AspNetCore.Security.Performance/AuthorizationPolicyBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.Security.Performance/AuthorizationPolicyBenchmark.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Security
+{
+    public class AuthorizationPolicyBenchmark
+    {
+        private DefaultAuthorizationPolicyProvider _policyProvider;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _policyProvider = new DefaultAuthorizationPolicyProvider(Options.Create(new AuthorizationOptions()));
+        }
+
+        [Benchmark]
+        public Task CombineAsync()
+        {
+            return AuthorizationPolicy.CombineAsync(_policyProvider, Array.Empty<IAuthorizeData>());
+        }
+    }
+}

--- a/benchmarks/Microsoft.AspNetCore.Security.Performance/Microsoft.AspNetCore.Security.Performance.csproj
+++ b/benchmarks/Microsoft.AspNetCore.Security.Performance/Microsoft.AspNetCore.Security.Performance.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Microsoft.AspNetCore.Security</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Authorization.Policy\Microsoft.AspNetCore.Authorization.Policy.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.BenchmarkRunner.Sources" PrivateAssets="All" Version="$(MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="$(MicrosoftAspNetCoreHttpPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingPackageVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/Microsoft.AspNetCore.Security.Performance/Properties/AssemblyInfo.cs
+++ b/benchmarks/Microsoft.AspNetCore.Security.Performance/Properties/AssemblyInfo.cs
@@ -1,0 +1,1 @@
+﻿[assembly: BenchmarkDotNet.Attributes.AspNetCoreBenchmark]

--- a/benchmarks/Microsoft.AspNetCore.Security.Performance/readme.md
+++ b/benchmarks/Microsoft.AspNetCore.Security.Performance/readme.md
@@ -1,0 +1,16 @@
+Compile the solution in Release mode (so binaries are available in release)
+
+To run a specific benchmark add it as parameter.
+```
+dotnet run -c Release --framework <tfm> <benchmark_name>
+```
+
+To run all benchmarks use '*' as the name.
+```
+dotnet run -c Release --framework <tfm> *
+```
+
+If you run without any parameters, you'll be offered the list of all benchmarks and get to choose.
+```
+dotnet run -c Release --framework <tfm> 
+```

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,9 +3,11 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
+    <BenchmarkDotNetPackageVersion>0.10.13</BenchmarkDotNetPackageVersion>
     <InternalAspNetCoreSdkPackageVersion>3.0.0-alpha1-20181004.7</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftAspNetCoreAuthenticationAbstractionsPackageVersion>3.0.0-alpha1-10670</MicrosoftAspNetCoreAuthenticationAbstractionsPackageVersion>
     <MicrosoftAspNetCoreAuthenticationCorePackageVersion>3.0.0-alpha1-10670</MicrosoftAspNetCoreAuthenticationCorePackageVersion>
+    <MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>3.0.0-alpha1-10657</MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>
     <MicrosoftAspNetCoreDataProtectionExtensionsPackageVersion>3.0.0-alpha1-10670</MicrosoftAspNetCoreDataProtectionExtensionsPackageVersion>
     <MicrosoftAspNetCoreDataProtectionPackageVersion>3.0.0-alpha1-10670</MicrosoftAspNetCoreDataProtectionPackageVersion>
     <MicrosoftAspNetCoreDiagnosticsPackageVersion>3.0.0-alpha1-10670</MicrosoftAspNetCoreDiagnosticsPackageVersion>

--- a/src/Microsoft.AspNetCore.Authorization/AuthorizationPolicy.cs
+++ b/src/Microsoft.AspNetCore.Authorization/AuthorizationPolicy.cs
@@ -120,52 +120,74 @@ namespace Microsoft.AspNetCore.Authorization
                 throw new ArgumentNullException(nameof(authorizeData));
             }
 
-            var policyBuilder = new AuthorizationPolicyBuilder();
-            var any = false;
-            foreach (var authorizeDatum in authorizeData)
+            // Avoid allocating enumerator if the data is known to be empty
+            var skipEnumeratingData = false;
+            if (authorizeData is IList<IAuthorizeData> dataList)
             {
-                any = true;
-                var useDefaultPolicy = true;
-                if (!string.IsNullOrWhiteSpace(authorizeDatum.Policy))
+                skipEnumeratingData = dataList.Count == 0;
+            }
+
+            AuthorizationPolicyBuilder policyBuilder = null;
+            if (!skipEnumeratingData)
+            {
+                foreach (var authorizeDatum in authorizeData)
                 {
-                    var policy = await policyProvider.GetPolicyAsync(authorizeDatum.Policy);
-                    if (policy == null)
+                    if (policyBuilder == null)
                     {
-                        throw new InvalidOperationException(Resources.FormatException_AuthorizationPolicyNotFound(authorizeDatum.Policy));
+                        policyBuilder = new AuthorizationPolicyBuilder();
                     }
-                    policyBuilder.Combine(policy);
-                    useDefaultPolicy = false;
-                }
-                var rolesSplit = authorizeDatum.Roles?.Split(',');
-                if (rolesSplit != null && rolesSplit.Any())
-                {
-                    var trimmedRolesSplit = rolesSplit.Where(r => !string.IsNullOrWhiteSpace(r)).Select(r => r.Trim());
-                    policyBuilder.RequireRole(trimmedRolesSplit);
-                    useDefaultPolicy = false;
-                }
-                var authTypesSplit = authorizeDatum.AuthenticationSchemes?.Split(',');
-                if (authTypesSplit != null && authTypesSplit.Any())
-                {
-                    foreach (var authType in authTypesSplit)
+
+                    var useDefaultPolicy = true;
+                    if (!string.IsNullOrWhiteSpace(authorizeDatum.Policy))
                     {
-                        if (!string.IsNullOrWhiteSpace(authType))
+                        var policy = await policyProvider.GetPolicyAsync(authorizeDatum.Policy);
+                        if (policy == null)
                         {
-                            policyBuilder.AuthenticationSchemes.Add(authType.Trim());
+                            throw new InvalidOperationException(Resources.FormatException_AuthorizationPolicyNotFound(authorizeDatum.Policy));
+                        }
+                        policyBuilder.Combine(policy);
+                        useDefaultPolicy = false;
+                    }
+
+                    var rolesSplit = authorizeDatum.Roles?.Split(',');
+                    if (rolesSplit != null && rolesSplit.Any())
+                    {
+                        var trimmedRolesSplit = rolesSplit.Where(r => !string.IsNullOrWhiteSpace(r)).Select(r => r.Trim());
+                        policyBuilder.RequireRole(trimmedRolesSplit);
+                        useDefaultPolicy = false;
+                    }
+
+                    var authTypesSplit = authorizeDatum.AuthenticationSchemes?.Split(',');
+                    if (authTypesSplit != null && authTypesSplit.Any())
+                    {
+                        foreach (var authType in authTypesSplit)
+                        {
+                            if (!string.IsNullOrWhiteSpace(authType))
+                            {
+                                policyBuilder.AuthenticationSchemes.Add(authType.Trim());
+                            }
                         }
                     }
-                }
-                if (useDefaultPolicy)
-                {
-                    policyBuilder.Combine(await policyProvider.GetDefaultPolicyAsync());
+
+                    if (useDefaultPolicy)
+                    {
+                        policyBuilder.Combine(await policyProvider.GetDefaultPolicyAsync());
+                    }
                 }
             }
+
             var requiredPolicy = await policyProvider.GetRequiredPolicyAsync();
             if (requiredPolicy != null)
             {
-                any = true;
+                if (policyBuilder == null)
+                {
+                    policyBuilder = new AuthorizationPolicyBuilder();
+                }
+
                 policyBuilder.Combine(requiredPolicy);
             }
-            return any ? policyBuilder.Build() : null;
+
+            return policyBuilder?.Build();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Authorization/DefaultAuthorizationPolicyProvider.cs
+++ b/src/Microsoft.AspNetCore.Authorization/DefaultAuthorizationPolicyProvider.cs
@@ -14,6 +14,8 @@ namespace Microsoft.AspNetCore.Authorization
     public class DefaultAuthorizationPolicyProvider : IAuthorizationPolicyProvider
     {
         private readonly AuthorizationOptions _options;
+        private Task<AuthorizationPolicy> _cachedDefaultPolicy;
+        private Task<AuthorizationPolicy> _cachedRequiredPolicy;
 
         /// <summary>
         /// Creates a new instance of <see cref="DefaultAuthorizationPolicyProvider"/>.
@@ -35,7 +37,7 @@ namespace Microsoft.AspNetCore.Authorization
         /// <returns>The default authorization policy.</returns>
         public Task<AuthorizationPolicy> GetDefaultPolicyAsync()
         {
-            return Task.FromResult(_options.DefaultPolicy);
+            return GetCachedPolicy(ref _cachedDefaultPolicy, _options.DefaultPolicy);
         }
 
         /// <summary>
@@ -44,7 +46,17 @@ namespace Microsoft.AspNetCore.Authorization
         /// <returns>The required authorization policy.</returns>
         public Task<AuthorizationPolicy> GetRequiredPolicyAsync()
         {
-            return Task.FromResult(_options.RequiredPolicy);
+            return GetCachedPolicy(ref _cachedRequiredPolicy, _options.RequiredPolicy);
+        }
+
+        private Task<AuthorizationPolicy> GetCachedPolicy(ref Task<AuthorizationPolicy> cachedPolicy, AuthorizationPolicy currentPolicy)
+        {
+            var local = cachedPolicy;
+            if (local == null || local.Result != currentPolicy)
+            {
+                cachedPolicy = local = Task.FromResult(currentPolicy);
+            }
+            return local;
         }
 
         /// <summary>


### PR DESCRIPTION
Used by AuthorizationMiddleware. Want to avoid allocations when there is no policy to evaluate.

Hide whitespace for best reviewing experience.

On https://github.com/aspnet/Security/pull/1894